### PR TITLE
feat(activities): add ActivityTypes module with entity, service, controller, DTOs, policy, and tests

### DIFF
--- a/backend/src/activities-type/activity-type.entity.ts
+++ b/backend/src/activities-type/activity-type.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToMany,
+  JoinTable,
+  Check,
+} from 'typeorm';
+import { Role } from '../roles/role.entity';
+
+@Entity({ name: 'activity_type' })
+@Check(`name <> ''`)
+@Check(`description <> ''`)
+export class ActivityType {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index({ unique: true })
+  @Column({ type: 'text', nullable: false })
+  name!: string;
+
+  @Column({ type: 'text', nullable: false })
+  description!: string;
+
+  @ManyToMany(() => Role, { eager: true })
+  @JoinTable({
+    name: 'activity_type_role',
+    joinColumn: { name: 'activity_type_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'role_id', referencedColumnName: 'id' },
+  })
+  allowed_roles!: Role[];
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  created_at!: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updated_at!: Date;
+}

--- a/backend/src/activities-type/activity-types.controller.ts
+++ b/backend/src/activities-type/activity-types.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { ActivityTypesService } from './activity-types.service';
+import { CreateActivityTypeDto } from './dto/create-activity-type.dto';
+import { UpdateActivityTypeDto } from './dto/update-activity-type.dto';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+
+@Controller('activity-types')
+export class ActivityTypesController {
+  constructor(private readonly service: ActivityTypesService) {}
+
+  @Get()
+  async list() {
+    return this.service.findAll();
+  }
+
+  @Get(':id')
+  async getOne(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.service.findOne(id);
+  }
+
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  @Post()
+  async create(@Body() dto: CreateActivityTypeDto) {
+    return this.service.create(dto);
+  }
+
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  @Put(':id')
+  async update(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: UpdateActivityTypeDto) {
+    return this.service.update(id, dto);
+  }
+
+  @UseGuards(RolesGuard)
+  @Roles('admin')
+  @Delete(':id')
+  async remove(@Param('id', new ParseUUIDPipe()) id: string) {
+    await this.service.remove(id);
+    return { message: 'Activity type deleted.' };
+  }
+}

--- a/backend/src/activities-type/activity-types.module.ts
+++ b/backend/src/activities-type/activity-types.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ActivityType } from './activity-type.entity';
+import { ActivityTypesService } from './activity-types.service';
+import { ActivityTypesController } from './activity-types.controller';
+import { Role } from '../roles/role.entity';
+import { ACTIVITY_TYPE_USAGE_POLICY } from './usage/activity-type-usage.policy';
+import type { ActivityTypeUsagePolicy } from './usage/activity-type-usage.policy';
+import { NullActivityTypeUsagePolicy } from './usage/null-activity-type-usage.policy';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ActivityType, Role])],
+  controllers: [ActivityTypesController],
+  providers: [
+    ActivityTypesService,
+    { provide: ACTIVITY_TYPE_USAGE_POLICY, useClass: NullActivityTypeUsagePolicy },
+  ],
+  exports: [ActivityTypesService],
+})
+export class ActivityTypesModule {}

--- a/backend/src/activities-type/activity-types.service.ts
+++ b/backend/src/activities-type/activity-types.service.ts
@@ -1,0 +1,97 @@
+import { BadRequestException, Injectable, NotFoundException, Inject } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { ActivityType } from './activity-type.entity';
+import { CreateActivityTypeDto } from './dto/create-activity-type.dto';
+import { UpdateActivityTypeDto } from './dto/update-activity-type.dto';
+import { Role } from '../roles/role.entity';
+import {
+  ACTIVITY_TYPE_USAGE_POLICY,
+  ActivityTypeUsagePolicy,
+} from './usage/activity-type-usage.policy';
+
+@Injectable()
+export class ActivityTypesService {
+  constructor(
+    @InjectRepository(ActivityType) private readonly repo: Repository<ActivityType>,
+    @InjectRepository(Role) private readonly rolesRepo: Repository<Role>,
+    @Inject(ACTIVITY_TYPE_USAGE_POLICY) private readonly usagePolicy: ActivityTypeUsagePolicy,
+  ) {}
+
+  private async ensureNameUnique(name: string, ignoreId?: string) {
+    const existing = await this.repo.findOne({ where: { name } });
+    if (existing && existing.id !== ignoreId) {
+      throw new BadRequestException('Activity type name must be unique.');
+    }
+  }
+
+  private async loadRolesOrThrow(roleIds: string[]): Promise<Role[]> {
+    const roles = await this.rolesRepo.find({ where: { id: In(roleIds) } });
+    if (roles.length !== roleIds.length) {
+      throw new BadRequestException('One or more provided role_ids do not exist.');
+    }
+    return roles;
+  }
+
+  async create(dto: CreateActivityTypeDto): Promise<ActivityType> {
+    const name = dto.name.trim();
+    const description = dto.description.trim();
+
+    await this.ensureNameUnique(name);
+
+    const roles = await this.loadRolesOrThrow(dto.role_ids);
+
+    const entity = this.repo.create({
+      name,
+      description,
+      allowed_roles: roles,
+    });
+
+    return this.repo.save(entity);
+  }
+
+  async findAll(): Promise<ActivityType[]> {
+    return this.repo.find();
+  }
+
+  async findOne(id: string): Promise<ActivityType> {
+    const found = await this.repo.findOne({ where: { id } });
+    if (!found) throw new NotFoundException('Activity type not found.');
+    return found;
+  }
+
+  async update(id: string, dto: UpdateActivityTypeDto): Promise<ActivityType> {
+    const entity = await this.findOne(id);
+
+    if (dto.name !== undefined) {
+      const name = dto.name.trim();
+      await this.ensureNameUnique(name, id);
+      entity.name = name;
+    }
+
+    if (dto.description !== undefined) {
+      const description = dto.description.trim();
+      if (!description) throw new BadRequestException('Description cannot be empty.');
+      entity.description = description;
+    }
+
+    if (dto.role_ids !== undefined) {
+      const roles = await this.loadRolesOrThrow(dto.role_ids);
+      entity.allowed_roles = roles;
+    }
+
+    return this.repo.save(entity);
+  }
+
+  async remove(id: string): Promise<void> {
+    const inUse = await this.usagePolicy.isInUse(id);
+    if (inUse) {
+      throw new BadRequestException(
+        'Cannot delete this activity type because it is currently in use by existing activities.',
+      );
+    }
+
+    const entity = await this.findOne(id);
+    await this.repo.remove(entity);
+  }
+}

--- a/backend/src/activities-type/dto/create-activity-type.dto.ts
+++ b/backend/src/activities-type/dto/create-activity-type.dto.ts
@@ -1,0 +1,16 @@
+import { IsArray, ArrayNotEmpty, IsString, IsUUID, IsNotEmpty } from 'class-validator';
+
+export class CreateActivityTypeDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  description!: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsUUID('4', { each: true })
+  role_ids!: string[];
+}

--- a/backend/src/activities-type/dto/update-activity-type.dto.ts
+++ b/backend/src/activities-type/dto/update-activity-type.dto.ts
@@ -1,0 +1,18 @@
+import { IsArray, IsOptional, IsString, IsUUID, IsNotEmpty } from 'class-validator';
+
+export class UpdateActivityTypeDto {
+  @IsString()
+  @IsOptional()
+  @IsNotEmpty()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  @IsNotEmpty()
+  description?: string;
+
+  @IsArray()
+  @IsOptional()
+  @IsUUID('4', { each: true })
+  role_ids?: string[];
+}

--- a/backend/src/activities-type/usage/activity-type-usage.policy.ts
+++ b/backend/src/activities-type/usage/activity-type-usage.policy.ts
@@ -1,0 +1,5 @@
+export const ACTIVITY_TYPE_USAGE_POLICY = Symbol('ACTIVITY_TYPE_USAGE_POLICY');
+
+export interface ActivityTypeUsagePolicy {
+  isInUse(activityTypeId: string): Promise<boolean>;
+}

--- a/backend/src/activities-type/usage/null-activity-type-usage.policy.ts
+++ b/backend/src/activities-type/usage/null-activity-type-usage.policy.ts
@@ -1,0 +1,7 @@
+import { ActivityTypeUsagePolicy } from './activity-type-usage.policy';
+
+export class NullActivityTypeUsagePolicy implements ActivityTypeUsagePolicy {
+  async isInUse(_activityTypeId: string): Promise<boolean> {
+    return false;
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { AdminModule } from './admin/admin.module';
 import { RolesModule } from './roles/roles.module';
 import authConfig from './config/auth.config';
 import { UsersModule } from './users/users.module';
+import { ActivityTypesModule } from './activities-type/activity-types.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { UsersModule } from './users/users.module';
     AdminModule,
     RolesModule,
     UsersModule,
+    ActivityTypesModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/entities/tests/activity-types.controller.spec.ts
+++ b/backend/src/entities/tests/activity-types.controller.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ActivityTypesController } from '../../activities-type/activity-types.controller';
+import { ActivityTypesService } from '../../activities-type/activity-types.service';
+import { RolesGuard } from '../../auth/roles.guard';
+
+const serviceMock = {
+  findAll: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  remove: jest.fn(),
+};
+
+class AllowAllRolesGuard {
+  canActivate() {
+    return true;
+  }
+}
+
+describe('ActivityTypesController', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ActivityTypesController],
+      providers: [
+        { provide: ActivityTypesService, useValue: serviceMock },
+        { provide: RolesGuard, useClass: AllowAllRolesGuard },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('GET /activity-types calls service.findAll', async () => {
+    serviceMock.findAll.mockResolvedValueOnce(['x']);
+    const controller = app.get(ActivityTypesController);
+    const result = await controller.list();
+    expect(serviceMock.findAll).toHaveBeenCalled();
+    expect(result).toEqual(['x']);
+  });
+
+  it('GET /activity-types/:id calls service.findOne', async () => {
+    serviceMock.findOne.mockResolvedValueOnce({ id: 'id-1' });
+    const controller = app.get(ActivityTypesController);
+    const result = await controller.getOne('id-1');
+    expect(serviceMock.findOne).toHaveBeenCalledWith('id-1');
+    expect(result).toEqual({ id: 'id-1' });
+  });
+
+  it('POST /activity-types (admin) calls service.create', async () => {
+    const dto = {
+      name: 'Bible Study',
+      description: 'Group Bible study',
+      role_ids: ['11111111-1111-1111-1111-111111111111'],
+    };
+    serviceMock.create.mockResolvedValueOnce({ id: 'new-id', ...dto });
+
+    const controller = app.get(ActivityTypesController);
+    const result = await controller.create(dto as any);
+
+    expect(serviceMock.create).toHaveBeenCalledWith(dto);
+    expect(result).toEqual({ id: 'new-id', ...dto });
+  });
+
+  it('PUT /activity-types/:id (admin) calls service.update', async () => {
+    const dto = { name: 'New Name' };
+    serviceMock.update.mockResolvedValueOnce({ id: 'id-1', ...dto });
+
+    const controller = app.get(ActivityTypesController);
+    const result = await controller.update('id-1', dto as any);
+
+    expect(serviceMock.update).toHaveBeenCalledWith('id-1', dto);
+    expect(result).toEqual({ id: 'id-1', ...dto });
+  });
+
+  it('DELETE /activity-types/:id (admin) calls service.remove', async () => {
+    serviceMock.remove.mockResolvedValueOnce(undefined);
+
+    const controller = app.get(ActivityTypesController);
+    const result = await controller.remove('id-1');
+
+    expect(serviceMock.remove).toHaveBeenCalledWith('id-1');
+    expect(result).toEqual({ message: 'Activity type deleted.' });
+  });
+});

--- a/backend/src/entities/tests/activity-types.service.spec.ts
+++ b/backend/src/entities/tests/activity-types.service.spec.ts
@@ -1,0 +1,206 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Repository, In, ObjectLiteral } from 'typeorm';
+
+import { ActivityTypesService } from '../../activities-type/activity-types.service';
+import { ActivityType } from '../../activities-type/activity-type.entity';
+import { Role } from '../../roles/role.entity';
+
+class UsagePolicyStub {
+  isInUse = jest.fn<Promise<boolean>, [string]>();
+}
+
+function createMockRepo<T extends ObjectLiteral>() {
+  return {
+    find: jest.fn<Promise<T[]>, any>(),
+    findOne: jest.fn<Promise<T | null>, any>(),
+    findBy: jest.fn<Promise<T[]>, any>(),
+    save: jest.fn<Promise<T>, any>(),
+    create: jest.fn<T, any>(),
+    remove: jest.fn<Promise<T>, any>(),
+    count: jest.fn<Promise<number>, any>(),
+  } as unknown as jest.Mocked<Repository<T>>;
+}
+
+describe('ActivityTypesService', () => {
+  let service: ActivityTypesService;
+  let activityTypeRepo: jest.Mocked<Repository<ActivityType>>;
+  let roleRepo: jest.Mocked<Repository<Role>>;
+  let usagePolicy: UsagePolicyStub;
+
+  const roleMissionary: Role = {
+    id: '11111111-1111-1111-1111-111111111111',
+    name: 'missionary',
+    description: 'Missionary role',
+    users: [],
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+
+  const rolePastor: Role = {
+    id: '22222222-2222-2222-2222-222222222222',
+    name: 'pastor',
+    description: 'Pastor role',
+    users: [],
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+
+  const atype: ActivityType = {
+    id: 'aaaaaaa0-0000-0000-0000-000000000000',
+    name: 'Bible Study',
+    description: 'Group Bible study',
+    allowed_roles: [roleMissionary],
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+
+  beforeEach(async () => {
+    activityTypeRepo = createMockRepo<ActivityType>();
+    roleRepo = createMockRepo<Role>();
+    usagePolicy = new UsagePolicyStub();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ActivityTypesService,
+        { provide: getRepositoryToken(ActivityType), useValue: activityTypeRepo },
+        { provide: getRepositoryToken(Role), useValue: roleRepo },
+        { provide: 'ACTIVITY_TYPE_USAGE_POLICY' as any, useValue: usagePolicy },
+      ],
+    })
+
+      .compile();
+
+    service = module.get(ActivityTypesService);
+
+    usagePolicy.isInUse.mockResolvedValue(false);
+  });
+
+  describe('create', () => {
+    it('creates an activity type when name is unique and roles exist', async () => {
+      activityTypeRepo.findOne.mockResolvedValue(null);
+      roleRepo.find.mockResolvedValue([roleMissionary, rolePastor]);
+
+      const createdObj = { ...atype, id: 'new-id', allowed_roles: [roleMissionary, rolePastor] };
+      activityTypeRepo.create.mockReturnValue(createdObj as any);
+      activityTypeRepo.save.mockResolvedValue(createdObj as any);
+
+      const dto = {
+        name: 'Bible Study',
+        description: 'Group Bible study',
+        role_ids: [roleMissionary.id, rolePastor.id],
+      };
+
+      const result = await service.create(dto as any);
+      expect(activityTypeRepo.findOne).toHaveBeenCalledWith({ where: { name: dto.name } });
+      expect(roleRepo.find).toHaveBeenCalledWith({ where: { id: In(dto.role_ids) } });
+      expect(activityTypeRepo.create).toHaveBeenCalledWith({
+        name: dto.name,
+        description: dto.description,
+        allowed_roles: [roleMissionary, rolePastor],
+      });
+      expect(activityTypeRepo.save).toHaveBeenCalledWith(createdObj);
+      expect(result).toEqual(createdObj);
+    });
+
+    it('throws if name already exists', async () => {
+      activityTypeRepo.findOne.mockResolvedValue(atype);
+      const dto = {
+        name: atype.name,
+        description: 'anything',
+        role_ids: [roleMissionary.id],
+      };
+      await expect(service.create(dto as any)).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws if one or more role_ids do not exist', async () => {
+      activityTypeRepo.findOne.mockResolvedValue(null);
+      roleRepo.find.mockResolvedValue([roleMissionary]);
+      const dto = {
+        name: 'New Type',
+        description: 'Desc',
+        role_ids: [roleMissionary.id, rolePastor.id],
+      };
+      await expect(service.create(dto as any)).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('returns all activity types', async () => {
+      activityTypeRepo.find.mockResolvedValue([atype]);
+      const result = await service.findAll();
+      expect(activityTypeRepo.find).toHaveBeenCalled();
+      expect(result).toEqual([atype]);
+    });
+  });
+
+  describe('findOne', () => {
+    it('returns the item if it exists', async () => {
+      activityTypeRepo.findOne.mockResolvedValue(atype);
+      const result = await service.findOne(atype.id);
+      expect(result).toBe(atype);
+    });
+
+    it('throws NotFound if it does not exist', async () => {
+      activityTypeRepo.findOne.mockResolvedValue(null);
+      await expect(service.findOne('missing-id')).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('updates name/description/roles when valid', async () => {
+      const existing = { ...atype };
+      activityTypeRepo.findOne.mockResolvedValueOnce(existing);
+      activityTypeRepo.findOne.mockResolvedValueOnce(null);
+      roleRepo.find.mockResolvedValue([rolePastor]);
+
+      const dto = {
+        name: 'New Name',
+        description: 'New Desc',
+        role_ids: [rolePastor.id],
+      };
+
+      const saved = { ...existing, ...dto, allowed_roles: [rolePastor] };
+      activityTypeRepo.save.mockResolvedValue(saved as any);
+
+      const result = await service.update(existing.id, dto as any);
+
+      expect(roleRepo.find).toHaveBeenCalledWith({ where: { id: In(dto.role_ids) } });
+      expect(activityTypeRepo.save).toHaveBeenCalled();
+      expect(result).toEqual(saved);
+    });
+
+    it('throws BadRequest if new name collides with another record', async () => {
+      activityTypeRepo.findOne.mockResolvedValueOnce({ ...atype });
+      activityTypeRepo.findOne.mockResolvedValueOnce({ ...atype, id: 'other-id' });
+
+      await expect(service.update(atype.id, { name: 'Bible Study' } as any)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('throws BadRequest if description becomes empty', async () => {
+      activityTypeRepo.findOne.mockResolvedValue({ ...atype });
+      await expect(service.update(atype.id, { description: '  ' } as any)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('throws BadRequest if usagePolicy reports "in use"', async () => {
+      usagePolicy.isInUse.mockResolvedValue(true);
+      await expect(service.remove(atype.id)).rejects.toBeInstanceOf(BadRequestException);
+      expect(usagePolicy.isInUse).toHaveBeenCalledWith(atype.id);
+    });
+
+    it('removes the entity when not in use', async () => {
+      usagePolicy.isInUse.mockResolvedValue(false);
+      activityTypeRepo.findOne.mockResolvedValue({ ...atype });
+
+      await service.remove(atype.id);
+      expect(activityTypeRepo.remove).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces the ActivityTypes module to manage activity type definitions in the system.
It includes entity modeling, role-based restrictions, usage policies, and full CRUD support with validation and tests.

Changes Included
**Entity**

- Added ActivityType entity with:
- id, name, description, timestamps.
- Non-empty checks for name and description.
- Unique name constraint.
- Many-to-many relation with Role (allowed_roles).

**DTOs**

- CreateActivityTypeDto: validates name, description, and role_ids (non-empty array of UUIDs).
- UpdateActivityTypeDto: supports optional updates for name, description, and role_ids.

**Service** 

- Uniqueness checks for name.
- Validation and loading of roles (role_ids).
- Update logic for all fields.
- Delete prevention when usage policy reports type is in use.

**Controller**

- Endpoints: list all, get one by ID, create, update, delete.
- Secured create/update/delete with RolesGuard and @Roles('admin').
- UUID validation for route params.

**Module**

- Registered ActivityTypesModule with TypeORM integration for ActivityType and Role.
- Provided default NullActivityTypeUsagePolicy implementation.

**Policies**

- Defined ActivityTypeUsagePolicy interface and DI token.
- Added NullActivityTypeUsagePolicy as default (always returns false).

**Tests**

- Unit tests for ActivityTypesController CRUD endpoints with mocked service.
- Unit tests for ActivityTypesService covering create, update, find, delete, and validation scenarios.
