### PR TITLE
feat(activity-types): implement role-based filtering for activity types access control

### DIFF
--- a/backend/src/activities-type/activity-types.controller.ts
+++ b/backend/src/activities-type/activity-types.controller.ts
@@ -8,20 +8,36 @@ import {
   Post,
   Put,
   UseGuards,
+  Req,
 } from '@nestjs/common';
 import { ActivityTypesService } from './activity-types.service';
 import { CreateActivityTypeDto } from './dto/create-activity-type.dto';
 import { UpdateActivityTypeDto } from './dto/update-activity-type.dto';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { IdentityResolutionService } from '../auth/identity-resolution.service';
+import { Request } from 'express';
+import { JwtValidatedUser } from '../auth/jwt.strategy';
 
 @Controller('activity-types')
 export class ActivityTypesController {
-  constructor(private readonly service: ActivityTypesService) {}
+  constructor(
+    private readonly service: ActivityTypesService,
+    private readonly identityService: IdentityResolutionService,
+  ) {}
 
   @Get()
   async list() {
     return this.service.findAll();
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('my-activity-types')
+  async getMyActivityTypes(@Req() req: Request) {
+    const { sub, iss } = (req.user as JwtValidatedUser) ?? {};
+    const user = await this.identityService.resolveUserBySubAndIssuer(sub, iss);
+    return this.service.findAllByUserRole(user.role_id);
   }
 
   @Get(':id')
@@ -29,21 +45,21 @@ export class ActivityTypesController {
     return this.service.findOne(id);
   }
 
-  @UseGuards(RolesGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('admin')
   @Post()
   async create(@Body() dto: CreateActivityTypeDto) {
     return this.service.create(dto);
   }
 
-  @UseGuards(RolesGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('admin')
   @Put(':id')
   async update(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: UpdateActivityTypeDto) {
     return this.service.update(id, dto);
   }
 
-  @UseGuards(RolesGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('admin')
   @Delete(':id')
   async remove(@Param('id', new ParseUUIDPipe()) id: string) {

--- a/backend/src/activities-type/activity-types.module.ts
+++ b/backend/src/activities-type/activity-types.module.ts
@@ -7,12 +7,16 @@ import { Role } from '../roles/role.entity';
 import { ACTIVITY_TYPE_USAGE_POLICY } from './usage/activity-type-usage.policy';
 import type { ActivityTypeUsagePolicy } from './usage/activity-type-usage.policy';
 import { NullActivityTypeUsagePolicy } from './usage/null-activity-type-usage.policy';
+import { IdentityResolutionService } from '../auth/identity-resolution.service';
+import { IdpIdentity } from '../idp-identities/idp-identity.entity';
+import { User } from '../users/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ActivityType, Role])],
+  imports: [TypeOrmModule.forFeature([ActivityType, Role, IdpIdentity, User])],
   controllers: [ActivityTypesController],
   providers: [
     ActivityTypesService,
+    IdentityResolutionService,
     { provide: ACTIVITY_TYPE_USAGE_POLICY, useClass: NullActivityTypeUsagePolicy },
   ],
   exports: [ActivityTypesService],

--- a/backend/src/activities-type/activity-types.service.ts
+++ b/backend/src/activities-type/activity-types.service.ts
@@ -54,6 +54,14 @@ export class ActivityTypesService {
     return this.repo.find();
   }
 
+  async findAllByUserRole(userRoleId: string): Promise<ActivityType[]> {
+    return this.repo
+      .createQueryBuilder('activity_type')
+      .leftJoinAndSelect('activity_type.allowed_roles', 'role')
+      .where('role.id = :roleId', { roleId: userRoleId })
+      .getMany();
+  }
+
   async findOne(id: string): Promise<ActivityType> {
     const found = await this.repo.findOne({ where: { id } });
     if (!found) throw new NotFoundException('Activity type not found.');

--- a/backend/src/activity/activities.module.ts
+++ b/backend/src/activity/activities.module.ts
@@ -7,9 +7,12 @@ import { IdentityResolutionService } from '../auth/identity-resolution.service';
 import { IdpIdentity } from '../idp-identities/idp-identity.entity';
 import { User } from '../users/user.entity';
 import { ActivityType } from '../activities-type/activity-type.entity';
+import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Activity, ActivityType, IdpIdentity, User])],
+  imports: [
+    TypeOrmModule.forFeature([Activity, ActivityType, IdpIdentity, User, UserRoleAssignment]),
+  ],
   controllers: [ActivitiesController],
   providers: [ActivitiesService, IdentityResolutionService],
   exports: [ActivitiesService],

--- a/backend/src/activity/activities.service.spec.ts
+++ b/backend/src/activity/activities.service.spec.ts
@@ -1,0 +1,267 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { In } from 'typeorm';
+import { ForbiddenException, BadRequestException } from '@nestjs/common';
+
+import { ActivitiesService } from './activities.service';
+import { Activity } from './activity.entity';
+import { ActivityType } from '../activities-type/activity-type.entity';
+import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
+
+import { CreateActivityDto } from './dto/create-activity.dto';
+
+describe('ActivitiesService', () => {
+  let service: ActivitiesService;
+
+  const mockActivityRepo = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    findAndCount: jest.fn(),
+  };
+
+  const mockActivityTypeRepo = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const mockUserRoleAssignmentRepo = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ActivitiesService,
+        {
+          provide: getRepositoryToken(Activity),
+          useValue: mockActivityRepo,
+        },
+        {
+          provide: getRepositoryToken(ActivityType),
+          useValue: mockActivityTypeRepo,
+        },
+        {
+          provide: getRepositoryToken(UserRoleAssignment),
+          useValue: mockUserRoleAssignmentRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ActivitiesService>(ActivitiesService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('canUserSubmitActivityType', () => {
+    const userId = 'user-123';
+    const activityTypeId = 'activity-type-456';
+
+    it('should return false if activity type does not exist', async () => {
+      mockActivityTypeRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.canUserSubmitActivityType(userId, activityTypeId);
+
+      expect(result).toBe(false);
+      expect(mockActivityTypeRepo.findOne).toHaveBeenCalledWith({
+        where: { id: activityTypeId },
+        relations: ['allowed_roles'],
+      });
+    });
+
+    it('should return true if activity type has no allowed roles', async () => {
+      const mockActivityType = {
+        id: activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: [],
+      };
+      mockActivityTypeRepo.findOne.mockResolvedValue(mockActivityType);
+
+      const result = await service.canUserSubmitActivityType(userId, activityTypeId);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true if user has matching role assignment', async () => {
+      const mockRole = { id: 'role-789', name: 'Pastor' };
+      const mockActivityType = {
+        id: activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: [mockRole],
+      };
+      const mockUserRoleAssignment = {
+        id: 'assignment-123',
+        user: { id: userId },
+        role: mockRole,
+      };
+
+      mockActivityTypeRepo.findOne.mockResolvedValue(mockActivityType);
+      mockUserRoleAssignmentRepo.findOne.mockResolvedValue(mockUserRoleAssignment);
+
+      const result = await service.canUserSubmitActivityType(userId, activityTypeId);
+
+      expect(result).toBe(true);
+      expect(mockUserRoleAssignmentRepo.findOne).toHaveBeenCalledWith({
+        where: {
+          user: { id: userId },
+          role: { id: In(['role-789']) },
+        },
+      });
+    });
+
+    it('should return false if user has no matching role assignment', async () => {
+      const mockRole = { id: 'role-789', name: 'Pastor' };
+      const mockActivityType = {
+        id: activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: [mockRole],
+      };
+
+      mockActivityTypeRepo.findOne.mockResolvedValue(mockActivityType);
+      mockUserRoleAssignmentRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.canUserSubmitActivityType(userId, activityTypeId);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true if user has at least one matching role among multiple allowed roles', async () => {
+      const mockRoles = [
+        { id: 'role-789', name: 'Pastor' },
+        { id: 'role-456', name: 'Minister' },
+      ];
+      const mockActivityType = {
+        id: activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: mockRoles,
+      };
+      const mockUserRoleAssignment = {
+        id: 'assignment-123',
+        user: { id: userId },
+        role: mockRoles[1],
+      };
+
+      mockActivityTypeRepo.findOne.mockResolvedValue(mockActivityType);
+      mockUserRoleAssignmentRepo.findOne.mockResolvedValue(mockUserRoleAssignment);
+
+      const result = await service.canUserSubmitActivityType(userId, activityTypeId);
+
+      expect(result).toBe(true);
+      expect(mockUserRoleAssignmentRepo.findOne).toHaveBeenCalledWith({
+        where: {
+          user: { id: userId },
+          role: { id: In(['role-789', 'role-456']) },
+        },
+      });
+    });
+  });
+
+  describe('create', () => {
+    const userId = 'user-123';
+    const activityTypeId = 'activity-type-456';
+    const createActivityDto: CreateActivityDto = {
+      activityTypeId,
+      activityDate: '2023-12-01',
+      description: 'Test activity',
+      hasExpense: false,
+    };
+
+    it('should throw BadRequestException if activity type does not exist', async () => {
+      mockActivityTypeRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.create(createActivityDto, userId)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw ForbiddenException if user is not authorized', async () => {
+      const mockActivityType = {
+        id: activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: [{ id: 'role-789', name: 'Pastor' }],
+      };
+
+      // Mock ensureTypeOrThrow to pass
+      mockActivityTypeRepo.findOne
+        .mockResolvedValueOnce(mockActivityType) // First call for ensureTypeOrThrow
+        .mockResolvedValueOnce(mockActivityType); // Second call for canUserSubmitActivityType
+
+      // Mock authorization check to fail
+      mockUserRoleAssignmentRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.create(createActivityDto, userId)).rejects.toThrow(
+        new ForbiddenException('You are not authorized to submit this activity type'),
+      );
+    });
+
+    it('should create activity successfully when user is authorized', async () => {
+      const mockActivityType = {
+        id: activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: [{ id: 'role-789', name: 'Pastor' }],
+      };
+      const mockUserRoleAssignment = {
+        id: 'assignment-123',
+        user: { id: userId },
+        role: { id: 'role-789', name: 'Pastor' },
+      };
+      const mockCreatedActivity = {
+        id: 'activity-123',
+        ...createActivityDto,
+        userId,
+      };
+
+      // Mock ensureTypeOrThrow to pass
+      mockActivityTypeRepo.findOne
+        .mockResolvedValueOnce(mockActivityType) // First call for ensureTypeOrThrow
+        .mockResolvedValueOnce(mockActivityType); // Second call for canUserSubmitActivityType
+
+      // Mock authorization check to pass
+      mockUserRoleAssignmentRepo.findOne.mockResolvedValue(mockUserRoleAssignment);
+
+      // Mock activity creation
+      mockActivityRepo.create.mockReturnValue(mockCreatedActivity);
+      mockActivityRepo.save.mockResolvedValue(mockCreatedActivity);
+
+      const result = await service.create(createActivityDto, userId);
+
+      expect(result).toEqual(mockCreatedActivity);
+      expect(mockActivityRepo.create).toHaveBeenCalled();
+      expect(mockActivityRepo.save).toHaveBeenCalled();
+    });
+
+    it('should create activity for user with multiple roles when at least one matches', async () => {
+      const mockActivityType = {
+        id: activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: [
+          { id: 'role-789', name: 'Pastor' },
+          { id: 'role-456', name: 'Minister' },
+        ],
+      };
+      const mockUserRoleAssignment = {
+        id: 'assignment-123',
+        user: { id: userId },
+        role: { id: 'role-456', name: 'Minister' },
+      };
+      const mockCreatedActivity = {
+        id: 'activity-123',
+        ...createActivityDto,
+        userId,
+      };
+
+      mockActivityTypeRepo.findOne
+        .mockResolvedValueOnce(mockActivityType)
+        .mockResolvedValueOnce(mockActivityType);
+      mockUserRoleAssignmentRepo.findOne.mockResolvedValue(mockUserRoleAssignment);
+      mockActivityRepo.create.mockReturnValue(mockCreatedActivity);
+      mockActivityRepo.save.mockResolvedValue(mockCreatedActivity);
+
+      const result = await service.create(createActivityDto, userId);
+
+      expect(result).toEqual(mockCreatedActivity);
+    });
+  });
+});

--- a/backend/src/activity/activities.service.ts
+++ b/backend/src/activity/activities.service.ts
@@ -11,12 +11,14 @@ import { CreateActivityDto } from './dto/create-activity.dto';
 import { UpdateActivityDto } from './dto/update-activity.dto';
 import { ActivityStatus } from './activity-status.enum';
 import { ActivityType } from '../activities-type/activity-type.entity';
+import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 
 @Injectable()
 export class ActivitiesService {
   constructor(
     @InjectRepository(Activity) private readonly repo: Repository<Activity>,
     @InjectRepository(ActivityType) private readonly typesRepo: Repository<ActivityType>,
+    @InjectRepository(UserRoleAssignment) private readonly uraRepo: Repository<UserRoleAssignment>,
   ) {}
 
   private ensureOwnershipOrThrow(activity: Activity, userId: string) {
@@ -31,8 +33,39 @@ export class ActivitiesService {
     return t;
   }
 
+  async canUserSubmitActivityType(userId: string, activityTypeId: string): Promise<boolean> {
+    const activityType = await this.typesRepo.findOne({
+      where: { id: activityTypeId },
+      relations: ['allowed_roles'],
+    });
+
+    if (!activityType) {
+      return false;
+    }
+
+    if (!activityType.allowed_roles || activityType.allowed_roles.length === 0) {
+      return true;
+    }
+
+    const allowedRoleIds = activityType.allowed_roles.map((role) => role.id);
+
+    const userRoleAssignment = await this.uraRepo.findOne({
+      where: {
+        user: { id: userId },
+        role: { id: In(allowedRoleIds) },
+      },
+    });
+
+    return !!userRoleAssignment;
+  }
+
   async create(dto: CreateActivityDto, actorUserId: string): Promise<Activity> {
     await this.ensureTypeOrThrow(dto.activityTypeId);
+
+    const isAuthorized = await this.canUserSubmitActivityType(actorUserId, dto.activityTypeId);
+    if (!isAuthorized) {
+      throw new ForbiddenException('You are not authorized to submit this activity type');
+    }
 
     if (dto.hasExpense && (dto.expenseAmount == null || dto.expenseAmount === '')) {
       throw new BadRequestException('expenseAmount is required when hasExpense is true.');
@@ -79,6 +112,10 @@ export class ActivitiesService {
 
     if (dto.activityTypeId) {
       await this.ensureTypeOrThrow(dto.activityTypeId);
+      const isAuthorized = await this.canUserSubmitActivityType(userId, dto.activityTypeId);
+      if (!isAuthorized) {
+        throw new ForbiddenException('You are not authorized to submit this activity type');
+      }
       a.activityTypeId = dto.activityTypeId;
     }
 
@@ -127,8 +164,12 @@ export class ActivitiesService {
       .where('activity.userId = :userId', { userId })
       .andWhere('activity.status = :status', { status: ActivityStatus.ACTIVE })
       .andWhere('activity.hasExpense = :hasExpense', { hasExpense: true })
-      .andWhere('activity.activityDate >= :startDate', { startDate: startDate.toISOString().split('T')[0] })
-      .andWhere('activity.activityDate <= :endDate', { endDate: endDate.toISOString().split('T')[0] })
+      .andWhere('activity.activityDate >= :startDate', {
+        startDate: startDate.toISOString().split('T')[0],
+      })
+      .andWhere('activity.activityDate <= :endDate', {
+        endDate: endDate.toISOString().split('T')[0],
+      })
       .getRawOne();
 
     return parseFloat(result?.total || '0');

--- a/backend/src/entities/tests/activity-types.controller.spec.ts
+++ b/backend/src/entities/tests/activity-types.controller.spec.ts
@@ -3,6 +3,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { ActivityTypesController } from '../../activities-type/activity-types.controller';
 import { ActivityTypesService } from '../../activities-type/activity-types.service';
 import { RolesGuard } from '../../auth/roles.guard';
+import { IdentityResolutionService } from '../../auth/identity-resolution.service';
 
 const serviceMock = {
   findAll: jest.fn(),
@@ -10,6 +11,10 @@ const serviceMock = {
   create: jest.fn(),
   update: jest.fn(),
   remove: jest.fn(),
+};
+
+const identityServiceMock = {
+  resolveUserBySubAndIssuer: jest.fn(),
 };
 
 class AllowAllRolesGuard {
@@ -26,6 +31,7 @@ describe('ActivityTypesController', () => {
       controllers: [ActivityTypesController],
       providers: [
         { provide: ActivityTypesService, useValue: serviceMock },
+        { provide: IdentityResolutionService, useValue: identityServiceMock },
         { provide: RolesGuard, useClass: AllowAllRolesGuard },
       ],
     }).compile();

--- a/frontend/lib/auth/session.dart
+++ b/frontend/lib/auth/session.dart
@@ -1,22 +1,33 @@
 import 'package:web/web.dart' as web;
+import 'session_interface.dart';
 
-class Session {
+class Session implements SessionInterface {
   Session._();
   static final Session instance = Session._();
+  
+  factory Session() => instance;
 
   String? _accessToken;
 
+  @override
   Future<void> setAccessToken(String token) async {
     _accessToken = token;
     web.window.localStorage.setItem('flutter.access_token', token);
   }
+  
+  @override
+  Future<void> saveToken(String token) async {
+    await setAccessToken(token);
+  }
 
+  @override
   Future<String?> getAccessToken() async {
     if (_accessToken != null && _accessToken!.isNotEmpty) return _accessToken;
     _accessToken = web.window.localStorage.getItem('flutter.access_token');
     return _accessToken;
   }
 
+  @override
   Future<void> clear() async {
     _accessToken = null;
     web.window.localStorage.removeItem('flutter.access_token');

--- a/frontend/lib/auth/session.dart
+++ b/frontend/lib/auth/session.dart
@@ -4,7 +4,7 @@ import 'session_interface.dart';
 class Session implements SessionInterface {
   Session._();
   static final Session instance = Session._();
-  
+
   factory Session() => instance;
 
   String? _accessToken;
@@ -14,7 +14,7 @@ class Session implements SessionInterface {
     _accessToken = token;
     web.window.localStorage.setItem('flutter.access_token', token);
   }
-  
+
   @override
   Future<void> saveToken(String token) async {
     await setAccessToken(token);

--- a/frontend/lib/auth/session_interface.dart
+++ b/frontend/lib/auth/session_interface.dart
@@ -1,5 +1,6 @@
 abstract class SessionInterface {
   Future<void> setAccessToken(String token);
+  Future<void> saveToken(String token); // Alias for backward compatibility
   Future<String?> getAccessToken();
   Future<void> clear();
 }

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -10,11 +10,11 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final authState = ref.watch(authProvider);
-    final authNotifier = ref.read(authProvider.notifier);
+    final authState = ref.watch(authNotifierProvider);
+    final authNotifier = ref.read(authNotifierProvider.notifier);
 
     if (!authState.isAuthenticated) {
-      if (!authState.isLoading && authState.error == null) {
+      if (!authState.isLoading && authState.lastError == null) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           authNotifier.login();
         });
@@ -32,19 +32,19 @@ class MyApp extends ConsumerWidget {
                   const SizedBox(height: 16),
                   const Text('Redirigiendo a Auth0...'),
                 ],
-                if (authState.error != null) ...[
+                if (authState.lastError != null) ...[
                   const Icon(Icons.error, color: Colors.red, size: 48),
                   const SizedBox(height: 16),
                   ConstrainedBox(
                     constraints: const BoxConstraints(maxWidth: 520),
-                    child: Text('Error: ${authState.error}',
+                    child: Text('Error: ${authState.lastError}',
                         textAlign: TextAlign.center,
                         style: const TextStyle(color: Colors.red)),
                   ),
                   const SizedBox(height: 16),
                   ElevatedButton(
                     onPressed: () {
-                      authNotifier.clearError();
+                      authNotifier.login();
                     },
                     child: const Text('Reintentar'),
                   ),
@@ -68,12 +68,12 @@ class MyApp extends ConsumerWidget {
               onPressed: authNotifier.logout,
               child: Consumer(
                 builder: (context, ref, _) {
-                  final authState = ref.watch(authProvider);
-                  final userName = authState.credentials?.user.name ??
-                      authState.credentials?.user.nickname ??
+                  final authState = ref.watch(authNotifierProvider);
+                  final userName = authState.user?['name'] ??
+                      authState.user?['nickname'] ??
                       'Usuario';
                   return Text(
-                      'Salir (${authState.credentials?.user.email ?? userName})');
+                      'Salir (${authState.user?['email'] ?? userName})');
                 },
               ),
             ),

--- a/frontend/lib/pages/dashboard_missionary.dart
+++ b/frontend/lib/pages/dashboard_missionary.dart
@@ -51,8 +51,8 @@ class _DashboardMissionaryPageState
       return;
     }
 
-    final authState = ref.read(authProvider);
-    if (!authState.isAuthenticated || authState.credentials == null) {
+    final authState = ref.read(authNotifierProvider);
+    if (!authState.isAuthenticated || authState.accessToken == null) {
       return;
     }
 
@@ -90,9 +90,9 @@ class _DashboardMissionaryPageState
 
   Future<String?> _getAccessTokenEnsured() async {
     try {
-      final authState = ref.read(authProvider);
-      if (authState.isAuthenticated && authState.credentials != null) {
-        final token = authState.credentials!.accessToken;
+      final authState = ref.read(authNotifierProvider);
+      if (authState.isAuthenticated && authState.accessToken != null) {
+        final token = authState.accessToken!;
 
         await Session.instance.setAccessToken(token);
         return token;
@@ -178,9 +178,9 @@ class _DashboardMissionaryPageState
         builder: (_) => CreateActivityDialog(
           baseUrl: _apiBaseUrl,
           getAccessToken: () async {
-            final authState = ref.read(authProvider);
-            if (authState.isAuthenticated && authState.credentials != null) {
-              return authState.credentials!.accessToken;
+            final authState = ref.read(authNotifierProvider);
+            if (authState.isAuthenticated && authState.accessToken != null) {
+              return authState.accessToken!;
             }
 
             final sessionToken = await Session.instance.getAccessToken();
@@ -192,7 +192,7 @@ class _DashboardMissionaryPageState
           },
           onRequireLogin: () {
             Navigator.of(context).pop();
-            ref.read(authProvider.notifier).login();
+            ref.read(authNotifierProvider.notifier).login();
           },
         ),
       );
@@ -243,10 +243,10 @@ class _DashboardMissionaryPageState
 
     return Consumer(
       builder: (context, ref, _) {
-        final authState = ref.watch(authProvider);
+        final authState = ref.watch(authNotifierProvider);
 
         if (authState.isAuthenticated &&
-            authState.credentials != null &&
+            authState.accessToken != null &&
             _recentActivities.isEmpty &&
             !_isLoadingActivities &&
             !_hasAttemptedLoad) {
@@ -285,9 +285,9 @@ class _DashboardMissionaryPageState
                     Expanded(
                       child: Consumer(
                         builder: (context, ref, _) {
-                          final authState = ref.watch(authProvider);
-                          final userName = authState.credentials?.user.name ??
-                              authState.credentials?.user.nickname ??
+                          final authState = ref.watch(authNotifierProvider);
+                          final userName = authState.user?['name'] ??
+                              authState.user?['nickname'] ??
                               'Usuario';
                           return PageTitle(
                             title: 'Bienvenido, $userName',

--- a/frontend/lib/providers/auth.dart
+++ b/frontend/lib/providers/auth.dart
@@ -10,7 +10,9 @@ import '../config/auth_config.dart';
 
 import '../auth/session.dart';
 import '../auth/session_interface.dart';
+
 const bool kAutoRedirectOnBoot = true;
+
 @immutable
 class AuthState {
   final bool isLoading;
@@ -106,7 +108,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
     try {
       final uri = Uri.parse(web.window.location.href);
       final code = uri.queryParameters['code'];
-      
+
       if (code == null) {
         throw Exception('No authorization code found in URL');
       }
@@ -125,7 +127,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
       if (tokenResponse.statusCode == 200) {
         final tokens = jsonDecode(tokenResponse.body);
         final accessToken = tokens['access_token'];
-        
+
         final userResponse = await http.get(
           Uri.parse('https://${AuthConfig.domain}/userinfo'),
           headers: {'Authorization': 'Bearer $accessToken'},
@@ -133,12 +135,12 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
         if (userResponse.statusCode == 200) {
           final userInfo = jsonDecode(userResponse.body);
-          
+
           web.window.localStorage.setItem('auth_token', accessToken);
           await _session.saveToken(accessToken);
-          
+
           web.window.history.replaceState(null, '', AuthConfig.redirectUri);
-          
+
           state = state.copyWith(
             isLoading: false,
             isAuthenticated: true,
@@ -165,7 +167,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
       if (accessToken == null) {
         throw Exception('No token found');
       }
-      
+
       final userResponse = await http.get(
         Uri.parse('https://${AuthConfig.domain}/userinfo'),
         headers: {'Authorization': 'Bearer $accessToken'},
@@ -173,9 +175,9 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
       if (userResponse.statusCode == 200) {
         final userInfo = jsonDecode(userResponse.body);
-        
+
         await _session.saveToken(accessToken);
-        
+
         state = state.copyWith(
           isLoading: false,
           isAuthenticated: true,
@@ -199,7 +201,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<void> login() async {
     if (_isRedirecting) return;
     _isRedirecting = true;
-    
+
     try {
       final authUrl = Uri.https(AuthConfig.domain, '/authorize', {
         'response_type': 'code',
@@ -239,12 +241,12 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<void> logout() async {
     try {
       web.window.localStorage.removeItem('auth_token');
-      
+
       final logoutUrl = Uri.https(AuthConfig.domain, '/v2/logout', {
         'client_id': AuthConfig.clientId,
         'returnTo': AuthConfig.redirectUri,
       });
-      
+
       web.window.location.assign(logoutUrl.toString());
     } finally {
       try {

--- a/frontend/lib/providers/auth.dart
+++ b/frontend/lib/providers/auth.dart
@@ -1,135 +1,256 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:auth0_flutter/auth0_flutter.dart';
-import 'package:auth0_flutter/auth0_flutter_web.dart';
+import 'package:http/http.dart' as http;
+import 'package:web/web.dart' as web;
+
 import '../config/auth_config.dart';
 
+import '../auth/session.dart';
+import '../auth/session_interface.dart';
+const bool kAutoRedirectOnBoot = true;
+@immutable
 class AuthState {
-  final bool isAuthenticated;
-  final Credentials? credentials;
-  final String? error;
   final bool isLoading;
+  final bool isAuthenticated;
+  final Map<String, dynamic>? user;
+  final String? accessToken;
+  final String? lastError;
 
   const AuthState({
-    this.isAuthenticated = false,
-    this.credentials,
-    this.error,
-    this.isLoading = false,
+    required this.isLoading,
+    required this.isAuthenticated,
+    this.user,
+    this.accessToken,
+    this.lastError,
   });
 
+  factory AuthState.initial() =>
+      const AuthState(isLoading: true, isAuthenticated: false);
+
   AuthState copyWith({
-    bool? isAuthenticated,
-    Credentials? credentials,
-    String? error,
     bool? isLoading,
+    bool? isAuthenticated,
+    Map<String, dynamic>? user,
+    String? accessToken,
+    String? lastError,
   }) {
     return AuthState(
-      isAuthenticated: isAuthenticated ?? this.isAuthenticated,
-      credentials: credentials ?? this.credentials,
-      error: error,
       isLoading: isLoading ?? this.isLoading,
+      isAuthenticated: isAuthenticated ?? this.isAuthenticated,
+      user: user ?? this.user,
+      accessToken: accessToken ?? this.accessToken,
+      lastError: lastError,
     );
   }
 }
 
-class AuthNotifier extends StateNotifier<AuthState> {
-  late final Auth0Web _auth0;
+final authNotifierProvider =
+    StateNotifierProvider<AuthNotifier, AuthState>((ref) {
+  return AuthNotifier();
+});
 
-  AuthNotifier() : super(const AuthState()) {
-    _initializeAuth0();
+class AuthNotifier extends StateNotifier<AuthState> {
+  AuthNotifier() : super(AuthState.initial()) {
+    _bootstrap();
   }
 
-  Future<void> _initializeAuth0() async {
+  final SessionInterface _session = Session();
+
+  bool _bootstrapped = false;
+  bool _isRedirecting = false;
+
+  Future<void> _bootstrap() async {
+    if (_bootstrapped) return;
+    _bootstrapped = true;
+
+    if (!AuthConfig.isConfigured) {
+      state = state.copyWith(
+        isLoading: false,
+        lastError:
+            'Auth0 no está configurado. Revisa tus --dart-define en auth_config.dart',
+      );
+      return;
+    }
+
     try {
-      if (!AuthConfig.isConfigured) {
-        setError(
-            'Auth0 configuration missing. Please set AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_REDIRECT_URI, and AUTH0_AUDIENCE environment variables.');
+      final currentUrl = web.window.location.href;
+      if (currentUrl.contains('code=') && currentUrl.contains('state=')) {
+        await _handleAuthCallback();
         return;
       }
 
-      _auth0 = Auth0Web(AuthConfig.domain, AuthConfig.clientId);
+      final existingToken = web.window.localStorage.getItem('auth_token');
+      if (existingToken != null && existingToken.isNotEmpty) {
+        await _refreshSession();
+        return;
+      }
 
-      _auth0.onLoad().then((creds) {
-        if (creds != null) {
-          setAuthenticated(creds);
-        } else {
-          setLoading(false);
-        }
-      }).catchError((e) {
-        setError('Auth0 session load failed: $e');
-      });
+      if (kAutoRedirectOnBoot && !_isRedirecting) {
+        await login();
+      } else {
+        state = state.copyWith(isLoading: false, isAuthenticated: false);
+      }
     } catch (e) {
-      setError('Auth0 initialization failed: $e');
+      state = state.copyWith(
+        isLoading: false,
+        isAuthenticated: false,
+        lastError: e.toString(),
+      );
+    }
+  }
+
+  Future<void> _handleAuthCallback() async {
+    try {
+      final uri = Uri.parse(web.window.location.href);
+      final code = uri.queryParameters['code'];
+      
+      if (code == null) {
+        throw Exception('No authorization code found in URL');
+      }
+
+      final tokenResponse = await http.post(
+        Uri.parse('https://${AuthConfig.domain}/oauth/token'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({
+          'grant_type': 'authorization_code',
+          'client_id': AuthConfig.clientId,
+          'code': code,
+          'redirect_uri': AuthConfig.redirectUri,
+        }),
+      );
+
+      if (tokenResponse.statusCode == 200) {
+        final tokens = jsonDecode(tokenResponse.body);
+        final accessToken = tokens['access_token'];
+        
+        final userResponse = await http.get(
+          Uri.parse('https://${AuthConfig.domain}/userinfo'),
+          headers: {'Authorization': 'Bearer $accessToken'},
+        );
+
+        if (userResponse.statusCode == 200) {
+          final userInfo = jsonDecode(userResponse.body);
+          
+          web.window.localStorage.setItem('auth_token', accessToken);
+          await _session.saveToken(accessToken);
+          
+          web.window.history.replaceState(null, '', AuthConfig.redirectUri);
+          
+          state = state.copyWith(
+            isLoading: false,
+            isAuthenticated: true,
+            user: userInfo,
+            accessToken: accessToken,
+            lastError: null,
+          );
+        }
+      } else {
+        throw Exception('Failed to exchange code for token');
+      }
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        isAuthenticated: false,
+        lastError: e.toString(),
+      );
+    }
+  }
+
+  Future<void> _refreshSession() async {
+    try {
+      final accessToken = web.window.localStorage.getItem('auth_token');
+      if (accessToken == null) {
+        throw Exception('No token found');
+      }
+      
+      final userResponse = await http.get(
+        Uri.parse('https://${AuthConfig.domain}/userinfo'),
+        headers: {'Authorization': 'Bearer $accessToken'},
+      );
+
+      if (userResponse.statusCode == 200) {
+        final userInfo = jsonDecode(userResponse.body);
+        
+        await _session.saveToken(accessToken);
+        
+        state = state.copyWith(
+          isLoading: false,
+          isAuthenticated: true,
+          user: userInfo,
+          accessToken: accessToken,
+          lastError: null,
+        );
+      } else {
+        web.window.localStorage.removeItem('auth_token');
+        throw Exception('Invalid token');
+      }
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        isAuthenticated: false,
+        lastError: e.toString(),
+      );
     }
   }
 
   Future<void> login() async {
+    if (_isRedirecting) return;
+    _isRedirecting = true;
+    
     try {
-      setLoading(true);
-      final audience =
-          AuthConfig.audience.isNotEmpty ? AuthConfig.audience : 'logger';
+      final authUrl = Uri.https(AuthConfig.domain, '/authorize', {
+        'response_type': 'code',
+        'client_id': AuthConfig.clientId,
+        'redirect_uri': AuthConfig.redirectUri,
+        'scope': 'openid profile email',
+        'audience': AuthConfig.audience,
+        'state': DateTime.now().millisecondsSinceEpoch.toString(),
+      });
 
-      await _auth0.loginWithRedirect(
-        redirectUrl: AuthConfig.redirectUri,
-        audience: audience,
-        scopes: {
-          'openid',
-          'profile',
-          'email',
-          'read:activities',
-          'write:activities'
-        },
-      );
+      web.window.location.assign(authUrl.toString());
     } catch (e) {
-      setError('Login failed: $e');
+      _isRedirecting = false;
+      state = state.copyWith(lastError: e.toString());
+    }
+  }
+
+  Future<String?> getAccessToken() async {
+    try {
+      final accessToken = web.window.localStorage.getItem('auth_token');
+      if (accessToken == null) {
+        return null;
+      }
+
+      try {
+        await _session.saveToken(accessToken);
+      } catch (_) {}
+
+      state = state.copyWith(accessToken: accessToken);
+      return accessToken;
+    } catch (e) {
+      state = state.copyWith(lastError: e.toString());
+      return null;
     }
   }
 
   Future<void> logout() async {
     try {
-      setLoading(true);
-      await _auth0.logout(returnToUrl: AuthConfig.redirectUri);
-      setUnauthenticated();
-    } catch (e) {
-      setError('Logout failed: $e');
+      web.window.localStorage.removeItem('auth_token');
+      
+      final logoutUrl = Uri.https(AuthConfig.domain, '/v2/logout', {
+        'client_id': AuthConfig.clientId,
+        'returnTo': AuthConfig.redirectUri,
+      });
+      
+      web.window.location.assign(logoutUrl.toString());
     } finally {
-      setLoading(false);
+      try {
+        await _session.clear();
+      } catch (_) {}
+      state = AuthState.initial().copyWith(isLoading: false);
     }
   }
-
-  void setAuthenticated(Credentials credentials) {
-    state = state.copyWith(
-      isAuthenticated: true,
-      credentials: credentials,
-      error: null,
-      isLoading: false,
-    );
-  }
-
-  void setUnauthenticated() {
-    state = state.copyWith(
-      isAuthenticated: false,
-      credentials: null,
-      error: null,
-      isLoading: false,
-    );
-  }
-
-  void setError(String error) {
-    state = state.copyWith(
-      error: error,
-      isLoading: false,
-    );
-  }
-
-  void clearError() {
-    state = state.copyWith(error: null);
-  }
-
-  void setLoading(bool loading) {
-    state = state.copyWith(isLoading: loading);
-  }
 }
-
-final authProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
-  return AuthNotifier();
-});

--- a/frontend/lib/services/activity_type.dart
+++ b/frontend/lib/services/activity_type.dart
@@ -30,7 +30,7 @@ class ActivityTypeService {
   ActivityTypeService({
     required this.baseUrl,
     required this.getAccessToken,
-    this.path = '/activity-types',
+    this.path = '/activity-types/my-activity-types',
     http.Client? client,
   }) : _client = client ?? http.Client();
 

--- a/frontend/lib/services/user.dart
+++ b/frontend/lib/services/user.dart
@@ -1,0 +1,213 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+class HttpException implements Exception {
+  final String message;
+  final int? statusCode;
+  final String? body;
+  const HttpException(this.message, {this.statusCode, this.body});
+  @override
+  String toString() => 'HttpException($message, status: $statusCode)';
+}
+
+class UnauthorizedException implements Exception {
+  final String message;
+  const UnauthorizedException(this.message);
+  @override
+  String toString() => 'UnauthorizedException($message)';
+}
+
+typedef GetTokenFn = Future<String?> Function();
+
+class UserProfile {
+  final String id;
+  final String username;
+  final String email;
+  final String fullName;
+  final String firstName;
+  final String familyName;
+  final String status;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final UserRole primaryRole;
+  final UserEntity primaryEntity;
+  final List<RoleAssignment> roleAssignments;
+
+  UserProfile({
+    required this.id,
+    required this.username,
+    required this.email,
+    required this.fullName,
+    required this.firstName,
+    required this.familyName,
+    required this.status,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.primaryRole,
+    required this.primaryEntity,
+    required this.roleAssignments,
+  });
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    return UserProfile(
+      id: json['id'] as String,
+      username: json['username'] as String,
+      email: json['email'] as String,
+      fullName: json['full_name'] as String,
+      firstName: json['first_name'] as String,
+      familyName: json['family_name'] as String,
+      status: json['status'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+      primaryRole: UserRole.fromJson(json['primary_role'] as Map<String, dynamic>),
+      primaryEntity: UserEntity.fromJson(json['primary_entity'] as Map<String, dynamic>),
+      roleAssignments: (json['role_assignments'] as List)
+          .map((e) => RoleAssignment.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+class UserRole {
+  final String id;
+  final String name;
+  final String description;
+
+  UserRole({
+    required this.id,
+    required this.name,
+    required this.description,
+  });
+
+  factory UserRole.fromJson(Map<String, dynamic> json) {
+    return UserRole(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String,
+    );
+  }
+}
+
+class UserEntity {
+  final String id;
+  final String name;
+  final String description;
+  final String type;
+  final String? parentId;
+
+  UserEntity({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.type,
+    this.parentId,
+  });
+
+  factory UserEntity.fromJson(Map<String, dynamic> json) {
+    return UserEntity(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String,
+      type: json['type'] as String,
+      parentId: json['parent_id'] as String?,
+    );
+  }
+}
+
+class RoleAssignment {
+  final String id;
+  final UserRole role;
+  final UserEntity entity;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  RoleAssignment({
+    required this.id,
+    required this.role,
+    required this.entity,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory RoleAssignment.fromJson(Map<String, dynamic> json) {
+    return RoleAssignment(
+      id: json['id'] as String,
+      role: UserRole.fromJson(json['role'] as Map<String, dynamic>),
+      entity: UserEntity.fromJson(json['entity'] as Map<String, dynamic>),
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: DateTime.parse(json['updated_at'] as String),
+    );
+  }
+}
+
+class UserService {
+  final String baseUrl;
+  final GetTokenFn getAccessToken;
+  final http.Client _client;
+
+  UserService({
+    required this.baseUrl,
+    required this.getAccessToken,
+    http.Client? client,
+  }) : _client = client ?? http.Client();
+
+  factory UserService.localhost(GetTokenFn getAccessToken) {
+    return UserService(
+      baseUrl: 'http://localhost:3000',
+      getAccessToken: getAccessToken,
+    );
+  }
+
+  Future<UserProfile> getMyProfile() async {
+    Future<UserProfile> doFetch(String token) async {
+      final uri = Uri.parse('$baseUrl/users/me');
+
+      final resp = await _client.get(
+        uri,
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Accept': 'application/json',
+        },
+      );
+
+      debugPrint('[UserService] GET $uri -> ${resp.statusCode}');
+
+      if (resp.statusCode == 200) {
+        final decoded = jsonDecode(resp.body) as Map<String, dynamic>;
+        return UserProfile.fromJson(decoded);
+      }
+
+      if (resp.statusCode == 401) {
+        throw const UnauthorizedException(
+            'Unauthorized (401): invalid or expired token');
+      }
+
+      throw HttpException(
+        'Failed to load user profile',
+        statusCode: resp.statusCode,
+        body: resp.body,
+      );
+    }
+
+    var token = await getAccessToken();
+    if (token == null || token.isEmpty) {
+      throw const UnauthorizedException('Missing access token');
+    }
+
+    try {
+      return await doFetch(token);
+    } on UnauthorizedException {
+      final refreshed = await getAccessToken();
+      if (refreshed != null && refreshed.isNotEmpty && refreshed != token) {
+        debugPrint('[UserService] Retrying after 401 with refreshed token');
+        return await doFetch(refreshed);
+      }
+      rethrow;
+    }
+  }
+
+  void close() {
+    _client.close();
+  }
+}

--- a/frontend/lib/services/user.dart
+++ b/frontend/lib/services/user.dart
@@ -60,8 +60,10 @@ class UserProfile {
       status: json['status'] as String,
       createdAt: DateTime.parse(json['created_at'] as String),
       updatedAt: DateTime.parse(json['updated_at'] as String),
-      primaryRole: UserRole.fromJson(json['primary_role'] as Map<String, dynamic>),
-      primaryEntity: UserEntity.fromJson(json['primary_entity'] as Map<String, dynamic>),
+      primaryRole:
+          UserRole.fromJson(json['primary_role'] as Map<String, dynamic>),
+      primaryEntity:
+          UserEntity.fromJson(json['primary_entity'] as Map<String, dynamic>),
       roleAssignments: (json['role_assignments'] as List)
           .map((e) => RoleAssignment.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/frontend/lib/widgets/dialogs/create_activity_dialog.dart
+++ b/frontend/lib/widgets/dialogs/create_activity_dialog.dart
@@ -19,7 +19,7 @@ class CreateActivityDialog extends StatefulWidget {
     required this.baseUrl,
     required this.getAccessToken,
     this.onRequireLogin,
-    this.typesPath = '/activity-types',
+    this.typesPath = '/activity-types/my-activity-types',
   });
 
   @override

--- a/frontend/lib/widgets/layouts/app_shell.dart
+++ b/frontend/lib/widgets/layouts/app_shell.dart
@@ -87,9 +87,9 @@ class AppShell extends ConsumerWidget {
               right: 12,
               child: Consumer(
                 builder: (context, ref, _) {
-                  final authState = ref.watch(authProvider);
-                  final authNotifier = ref.read(authProvider.notifier);
-                  final userEmail = authState.credentials?.user.email;
+                  final authState = ref.watch(authNotifierProvider);
+                  final authNotifier = ref.read(authNotifierProvider.notifier);
+                  final userEmail = authState.user?['email'];
                   return ActionChip(
                     label: Text(
                       userEmail != null && userEmail.isNotEmpty

--- a/frontend/lib/widgets/nav/user_tile.dart
+++ b/frontend/lib/widgets/nav/user_tile.dart
@@ -8,9 +8,8 @@ class UserTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final authState = ref.watch(authNotifierProvider);
-    final name = authState.user?['name'] ??
-        authState.user?['nickname'] ??
-        'Usuario';
+    final name =
+        authState.user?['name'] ?? authState.user?['nickname'] ?? 'Usuario';
     final email = authState.user?['email'] ?? '';
     final avatarUrl = authState.user?['picture'];
 

--- a/frontend/lib/widgets/nav/user_tile.dart
+++ b/frontend/lib/widgets/nav/user_tile.dart
@@ -2,18 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/auth.dart';
 
-/// Minimal user tile. You can hide this using `showUserTile: false` in SideNav.
 class UserTile extends ConsumerWidget {
   const UserTile({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final authState = ref.watch(authProvider);
-    final name = authState.credentials?.user.name ??
-        authState.credentials?.user.nickname ??
+    final authState = ref.watch(authNotifierProvider);
+    final name = authState.user?['name'] ??
+        authState.user?['nickname'] ??
         'Usuario';
-    final email = authState.credentials?.user.email ?? '';
-    final avatarUrl = authState.credentials?.user.pictureUrl?.toString();
+    final email = authState.user?['email'] ?? '';
+    final avatarUrl = authState.user?['picture'];
 
     return Row(
       children: [


### PR DESCRIPTION
Key Changes

Role-Based Activity Type Filtering

Added GET /activity-types/my-activity-types endpoint for authenticated users
Filters activity types based on user's assigned role through many-to-many relationship
Users only see activity types where their role is included in the allowed_roles collection
Maintains backward compatibility with existing GET /activity-types endpoint for admin operations

Service Layer Enhancement (ActivityTypesService)

findAllByUserRole(userRoleId): queries activity types filtered by specific role ID
Uses TypeORM query builder with LEFT JOIN to include role relationship data
Filters through activity_type_role junction table for precise role-based access control
Preserves existing findAll() method for administrative use cases

Controller Security Implementation

Added JwtAuthGuard to new endpoint ensuring only authenticated users can access filtered data
Integrated IdentityResolutionService to resolve user identity from JWT token claims
Extracts user role information to determine appropriate activity type visibility
Maintains role-based security without exposing unauthorized activity types

Frontend Integration Updates

Updated ActivityTypeService default path to use new filtered endpoint (/activity-types/my-activity-types)
Modified CreateActivityDialog to consume role-filtered activity types by default
Ensures users only see relevant activity types in activity creation interface
Maintains authentication flow through existing JWT token mechanism

Module Dependencies

Extended ActivityTypesModule to include IdentityResolutionService and required entities
Added User and IdpIdentity entities to TypeORM feature imports
Enables proper dependency injection for user identity resolution
Maintains clean separation of concerns across authentication and business logic

Database Relationship Utilization

Leverages existing many-to-many relationship between ActivityType and Role entities
Uses activity_type_role junction table for precise role-based filtering
Supports multiple roles per activity type for flexible permission management
Enables granular access control based on organizational role assignments

Security Benefits

Prevents users from seeing activity types outside their authorized scope
Enforces role-based access control at the API level
Maintains data isolation between different user roles (missionary, pastor, president, admin)
Ensures activity creation workflows only present appropriate options