### PR TITLE
feat: rename activity types endpoint and add comprehensive tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ Secretary is a monorepo containing both backend (NestJS/TypeScript) and frontend
 - Issue #80: Historical tracking for role assignments with start/end dates
 - Issue #76: Admin endpoint to view all activities with role context
 - Issue #75: Activity locked indicator in response DTOs (PARTIALLY IMPLEMENTED)
-- Issue #74: Role-based validation on activity updates (IMPLEMENTED but issue open)
-- Issue #72: Activity type endpoint naming (implemented as /my-activity-types instead of /my-authorized)
+- Issue #72: Activity type endpoint renamed to /authorized
 
 ### Milestone 4: Data Retrieval for Reporting (PLANNED)
 - Aggregated activity views by user, role, organization, time

--- a/backend/src/activities-type/activity-types.controller.spec.ts
+++ b/backend/src/activities-type/activity-types.controller.spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ActivityTypesController } from './activity-types.controller';
+import { ActivityTypesService } from './activity-types.service';
+import { IdentityResolutionService } from '../auth/identity-resolution.service';
+import { JwtValidatedUser } from '../auth/jwt.strategy';
+import { Request } from 'express';
+import { ActivityType } from './activity-type.entity';
+
+describe('ActivityTypesController', () => {
+  let controller: ActivityTypesController;
+  let service: jest.Mocked<ActivityTypesService>;
+  let identityService: jest.Mocked<IdentityResolutionService>;
+
+  const mockActivityTypes: Partial<ActivityType>[] = [
+    {
+      id: 'type-1',
+      name: 'Baptism',
+      description: 'Baptism ceremony',
+    },
+    {
+      id: 'type-2',
+      name: 'Wedding',
+      description: 'Wedding ceremony',
+    },
+  ];
+
+  const mockUser = {
+    id: 'user-123',
+    username: 'john.doe',
+    email: 'john.doe@example.com',
+    role_id: 'role-missionary',
+  };
+
+  beforeEach(async () => {
+    const mockService = {
+      findAll: jest.fn(),
+      findAllByUserRole: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    };
+
+    const mockIdentityService = {
+      resolveUserBySubAndIssuer: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ActivityTypesController],
+      providers: [
+        {
+          provide: ActivityTypesService,
+          useValue: mockService,
+        },
+        {
+          provide: IdentityResolutionService,
+          useValue: mockIdentityService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ActivityTypesController>(ActivityTypesController);
+    service = module.get(ActivityTypesService);
+    identityService = module.get(IdentityResolutionService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('list', () => {
+    it('should return all activity types', async () => {
+      service.findAll.mockResolvedValue(mockActivityTypes as ActivityType[]);
+
+      const result = await controller.list();
+
+      expect(service.findAll).toHaveBeenCalled();
+      expect(service.findAllByUserRole).not.toHaveBeenCalled();
+      expect(result).toEqual(mockActivityTypes);
+    });
+  });
+
+  describe('getAuthorized', () => {
+    it('should return only authorized activity types for the current user', async () => {
+      const mockJwtUser: JwtValidatedUser = {
+        sub: 'auth0|123456',
+        iss: 'https://test.auth0.com/',
+        roles: ['missionary'],
+        permissions: [],
+      };
+
+      const mockRequest = {
+        user: mockJwtUser,
+      } as Request & { user: JwtValidatedUser };
+
+      const authorizedTypes = [mockActivityTypes[0]];
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      service.findAllByUserRole.mockResolvedValue(authorizedTypes as ActivityType[]);
+
+      const result = await controller.getAuthorized(mockRequest);
+
+      expect(identityService.resolveUserBySubAndIssuer).toHaveBeenCalledWith(
+        'auth0|123456',
+        'https://test.auth0.com/',
+      );
+      expect(service.findAllByUserRole).toHaveBeenCalledWith('role-missionary');
+      expect(result).toEqual(authorizedTypes);
+    });
+
+    it('should handle user with no authorized activity types', async () => {
+      const mockJwtUser: JwtValidatedUser = {
+        sub: 'auth0|123456',
+        iss: 'https://test.auth0.com/',
+        roles: ['guest'],
+        permissions: [],
+      };
+
+      const mockRequest = {
+        user: mockJwtUser,
+      } as Request & { user: JwtValidatedUser };
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      service.findAllByUserRole.mockResolvedValue([]);
+
+      const result = await controller.getAuthorized(mockRequest);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw error when user is not authenticated', async () => {
+      const mockRequest = {
+        user: undefined,
+      } as Request;
+
+      await expect(controller.getAuthorized(mockRequest)).rejects.toThrow();
+    });
+  });
+
+  describe('getOne', () => {
+    it('should return a single activity type by id', async () => {
+      service.findOne.mockResolvedValue(mockActivityTypes[0] as ActivityType);
+
+      const result = await controller.getOne('type-1');
+
+      expect(service.findOne).toHaveBeenCalledWith('type-1');
+      expect(result).toEqual(mockActivityTypes[0]);
+    });
+  });
+});

--- a/backend/src/activities-type/activity-types.controller.ts
+++ b/backend/src/activities-type/activity-types.controller.ts
@@ -33,8 +33,8 @@ export class ActivityTypesController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Get('my-activity-types')
-  async getMyActivityTypes(@Req() req: Request) {
+  @Get('authorized')
+  async getAuthorized(@Req() req: Request) {
     const { sub, iss } = (req.user as JwtValidatedUser) ?? {};
     const user = await this.identityService.resolveUserBySubAndIssuer(sub, iss);
     return this.service.findAllByUserRole(user.role_id);

--- a/frontend/lib/services/activity_type.dart
+++ b/frontend/lib/services/activity_type.dart
@@ -30,7 +30,7 @@ class ActivityTypeService {
   ActivityTypeService({
     required this.baseUrl,
     required this.getAccessToken,
-    this.path = '/activity-types/my-activity-types',
+    this.path = '/activity-types/authorized',
     http.Client? client,
   }) : _client = client ?? http.Client();
 

--- a/frontend/lib/widgets/dialogs/create_activity_dialog.dart
+++ b/frontend/lib/widgets/dialogs/create_activity_dialog.dart
@@ -19,7 +19,7 @@ class CreateActivityDialog extends StatefulWidget {
     required this.baseUrl,
     required this.getAccessToken,
     this.onRequireLogin,
-    this.typesPath = '/activity-types/my-activity-types',
+    this.typesPath = '/activity-types/authorized',
   });
 
   @override


### PR DESCRIPTION
  - Rename GET /activity-types/my-activity-types to GET /activity-types/authorized
  - Add unit tests for list(), getAuthorized(), and getOne() methods
  - Update frontend services to use new /authorized endpoint
  - Update README documentation with new endpoint path

  The dedicated /authorized sub-resource provides clearer separation between
  public (all types) and authenticated (user-specific filtered types) endpoints
  while maintaining straightforward authentication requirements.

  Closes #72