### PR TITLE
feat: add activity lifecycle status field and locked indicator

### DIFF
--- a/backend/src/activity/activities.controller.ts
+++ b/backend/src/activity/activities.controller.ts
@@ -20,12 +20,14 @@ import { UpdateActivityDto } from './dto/update-activity.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { IdentityResolutionService } from '../auth/identity-resolution.service';
 import { ActivityResponseDto } from './dto/activity-response.dto';
+import { ReportingPeriodsService } from '../reporting-periods/reporting-periods.service';
 import { Request } from 'express';
 import { Repository, In } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../users/user.entity';
 import { ActivityType } from '../activities-type/activity-type.entity';
 import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
+import { Activity } from './activity.entity';
 
 @UseGuards(JwtAuthGuard)
 @Controller('activities')
@@ -33,6 +35,7 @@ export class ActivitiesController {
   constructor(
     private readonly activities: ActivitiesService,
     private readonly identity: IdentityResolutionService,
+    private readonly reportingPeriods: ReportingPeriodsService,
     @InjectRepository(User) private readonly usersRepo: Repository<User>,
     @InjectRepository(ActivityType) private readonly typesRepo: Repository<ActivityType>,
     @InjectRepository(ReportingPeriod)
@@ -42,6 +45,28 @@ export class ActivitiesController {
   private async getReportingPeriodForActivity(activity: any): Promise<ReportingPeriod | null> {
     if (!activity.reportingPeriodId) return null;
     return this.reportingPeriodsRepo.findOne({ where: { id: activity.reportingPeriodId } });
+  }
+
+  private async calculateLockedStatus(
+    activity: Activity,
+    userId: string,
+    reportingPeriod: ReportingPeriod | null,
+  ): Promise<boolean> {
+    if (!reportingPeriod || !reportingPeriod.isLocked) {
+      return false;
+    }
+
+    if (!activity.reportingPeriodId) {
+      return false;
+    }
+
+    const hasException = await this.reportingPeriods.hasUserExceptionForDate(
+      userId,
+      activity.reportingPeriodId,
+      activity.activityDate,
+    );
+
+    return !hasException;
   }
 
   @Post()
@@ -57,11 +82,14 @@ export class ActivitiesController {
       this.getReportingPeriodForActivity(created),
     ]);
 
+    const locked = await this.calculateLockedStatus(created, user.id, reportingPeriod);
+
     return ActivityResponseDto.fromEntity(
       created,
       owner.username,
       (type as any).name,
       reportingPeriod,
+      locked,
     );
   }
 
@@ -92,18 +120,25 @@ export class ActivitiesController {
       })(),
     ]);
 
+    const itemsWithLocked = await Promise.all(
+      items.map(async (a) => {
+        const reportingPeriod = reportingPeriodsMap.get(a.reportingPeriodId || '') ?? null;
+        const locked = await this.calculateLockedStatus(a, user.id, reportingPeriod);
+        return ActivityResponseDto.fromEntity(
+          a,
+          owner.username,
+          typesMap.get(a.activityTypeId) ?? '',
+          reportingPeriod,
+          locked,
+        );
+      }),
+    );
+
     return {
       page,
       limit,
       total,
-      items: items.map((a) =>
-        ActivityResponseDto.fromEntity(
-          a,
-          owner.username,
-          typesMap.get(a.activityTypeId) ?? '',
-          reportingPeriodsMap.get(a.reportingPeriodId || '') ?? null,
-        ),
-      ),
+      items: itemsWithLocked,
     };
   }
 
@@ -118,7 +153,10 @@ export class ActivitiesController {
       this.typesRepo.findOneByOrFail({ id: a.activityTypeId }),
       this.getReportingPeriodForActivity(a),
     ]);
-    return ActivityResponseDto.fromEntity(a, owner.username, (type as any).name, reportingPeriod);
+
+    const locked = await this.calculateLockedStatus(a, user.id, reportingPeriod);
+
+    return ActivityResponseDto.fromEntity(a, owner.username, (type as any).name, reportingPeriod, locked);
   }
 
   @Patch(':id')
@@ -136,11 +174,15 @@ export class ActivitiesController {
       this.typesRepo.findOneByOrFail({ id: updated.activityTypeId }),
       this.getReportingPeriodForActivity(updated),
     ]);
+
+    const locked = await this.calculateLockedStatus(updated, user.id, reportingPeriod);
+
     return ActivityResponseDto.fromEntity(
       updated,
       owner.username,
       (type as any).name,
       reportingPeriod,
+      locked,
     );
   }
 

--- a/backend/src/activity/activities.module.ts
+++ b/backend/src/activity/activities.module.ts
@@ -9,6 +9,7 @@ import { User } from '../users/user.entity';
 import { ActivityType } from '../activities-type/activity-type.entity';
 import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
 import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
+import { ReportingPeriodsModule } from '../reporting-periods/reporting-periods.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
       ReportingPeriod,
       UserRoleAssignment,
     ]),
+    ReportingPeriodsModule,
   ],
   controllers: [ActivitiesController],
   providers: [ActivitiesService, IdentityResolutionService],

--- a/backend/src/activity/dto/activity-response.dto.ts
+++ b/backend/src/activity/dto/activity-response.dto.ts
@@ -23,7 +23,8 @@ export class ActivityResponseDto {
     a: Activity,
     ownerUsername: string,
     activityTypeName: string,
-    reportingPeriod?: ReportingPeriod | null,
+    reportingPeriod: ReportingPeriod | null,
+    locked: boolean,
   ): ActivityResponseDto {
     const dto = new ActivityResponseDto();
     dto.id = a.id;
@@ -34,7 +35,7 @@ export class ActivityResponseDto {
     dto.hasExpense = a.hasExpense;
     dto.expenseAmount = a.expenseAmount ?? null;
     dto.status = a.status;
-    dto.locked = reportingPeriod?.isLocked ?? false;
+    dto.locked = locked;
     dto.reportingPeriodId = a.reportingPeriodId ?? null;
     dto.reportingPeriodName = reportingPeriod?.name ?? null;
     dto.createdAt = a.createdAt;

--- a/backend/src/activity/tests/activity-locked-indicator.spec.ts
+++ b/backend/src/activity/tests/activity-locked-indicator.spec.ts
@@ -1,0 +1,391 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ActivitiesController } from '../activities.controller';
+import { ActivitiesService } from '../activities.service';
+import { IdentityResolutionService } from '../../auth/identity-resolution.service';
+import { ReportingPeriodsService } from '../../reporting-periods/reporting-periods.service';
+import { Activity } from '../activity.entity';
+import { ActivityType } from '../../activities-type/activity-type.entity';
+import { ReportingPeriod } from '../../reporting-periods/reporting-period.entity';
+import { User } from '../../users/user.entity';
+import { ActivityStatus } from '../activity-status.enum';
+import { ReportingPeriodStatus } from '../../reporting-periods/reporting-period-status.enum';
+
+describe('ActivitiesController - Locked Indicator', () => {
+  let controller: ActivitiesController;
+  let activitiesService: jest.Mocked<ActivitiesService>;
+  let reportingPeriodsService: jest.Mocked<ReportingPeriodsService>;
+  let identityService: jest.Mocked<IdentityResolutionService>;
+  let usersRepo: jest.Mocked<Repository<User>>;
+  let typesRepo: jest.Mocked<Repository<ActivityType>>;
+  let periodsRepo: jest.Mocked<Repository<ReportingPeriod>>;
+
+  const mockUser = {
+    id: 'user-id',
+    username: 'testuser',
+    email: 'test@example.com',
+  };
+
+  const mockActivity: Activity = {
+    id: 'activity-id',
+    activityTypeId: 'type-id',
+    activityDate: '2024-01-10',
+    description: 'Test activity',
+    hasExpense: false,
+    expenseAmount: null,
+    userId: 'user-id',
+    reportingPeriodId: 'period-id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: 'user-id',
+    updatedBy: 'user-id',
+    status: ActivityStatus.ACTIVE,
+    archivedAt: null,
+    archivedBy: null,
+  } as Activity;
+
+  const mockActivityType: ActivityType = {
+    id: 'type-id',
+    name: 'Test Type',
+    description: 'Test activity type',
+  } as ActivityType;
+
+  const mockActivePeriod: ReportingPeriod = {
+    id: 'period-id',
+    entityId: 'entity-id',
+    entity: {} as any,
+    termId: 'term-id',
+    term: {} as any,
+    name: 'January 2024',
+    description: 'Active period',
+    startDate: '2024-01-01',
+    endDate: '2024-01-14',
+    status: ReportingPeriodStatus.ACTIVE,
+    isLocked: false,
+    containsDate: jest.fn(),
+    activities: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: 'admin-id',
+    updatedBy: 'admin-id',
+  } as ReportingPeriod;
+
+  const mockLockedPeriod: ReportingPeriod = {
+    ...mockActivePeriod,
+    status: ReportingPeriodStatus.LOCKED,
+    isLocked: true,
+  } as ReportingPeriod;
+
+  beforeEach(async () => {
+    const mockActivitiesService = {
+      create: jest.fn(),
+      findMine: jest.fn(),
+      findOneMine: jest.fn(),
+      updateMine: jest.fn(),
+    };
+
+    const mockReportingPeriodsService = {
+      hasUserExceptionForDate: jest.fn(),
+    };
+
+    const mockIdentityService = {
+      resolveUserBySubAndIssuer: jest.fn(),
+    };
+
+    const mockUsersRepo = {
+      findOneByOrFail: jest.fn(),
+    };
+
+    const mockTypesRepo = {
+      findOneByOrFail: jest.fn(),
+      find: jest.fn(),
+    };
+
+    const mockPeriodsRepo = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ActivitiesController],
+      providers: [
+        {
+          provide: ActivitiesService,
+          useValue: mockActivitiesService,
+        },
+        {
+          provide: ReportingPeriodsService,
+          useValue: mockReportingPeriodsService,
+        },
+        {
+          provide: IdentityResolutionService,
+          useValue: mockIdentityService,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUsersRepo,
+        },
+        {
+          provide: getRepositoryToken(ActivityType),
+          useValue: mockTypesRepo,
+        },
+        {
+          provide: getRepositoryToken(ReportingPeriod),
+          useValue: mockPeriodsRepo,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ActivitiesController>(ActivitiesController);
+    activitiesService = module.get(ActivitiesService);
+    reportingPeriodsService = module.get(ReportingPeriodsService);
+    identityService = module.get(IdentityResolutionService);
+    usersRepo = module.get(getRepositoryToken(User));
+    typesRepo = module.get(getRepositoryToken(ActivityType));
+    periodsRepo = module.get(getRepositoryToken(ReportingPeriod));
+  });
+
+  describe('create - locked indicator', () => {
+    it('should return locked: false when period is active', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      const createDto = {
+        activityTypeId: 'type-id',
+        activityDate: '2024-01-10',
+        hasExpense: false,
+      };
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.create.mockResolvedValue(mockActivity);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.findOneByOrFail.mockResolvedValue(mockActivityType);
+      periodsRepo.findOne.mockResolvedValue(mockActivePeriod);
+
+      const result = await controller.create(mockRequest, createDto as any);
+
+      expect(result.locked).toBe(false);
+      expect(reportingPeriodsService.hasUserExceptionForDate).not.toHaveBeenCalled();
+    });
+
+    it('should return locked: true when period is locked and user has no exception', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      const createDto = {
+        activityTypeId: 'type-id',
+        activityDate: '2024-01-10',
+        hasExpense: false,
+      };
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.create.mockResolvedValue(mockActivity);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.findOneByOrFail.mockResolvedValue(mockActivityType);
+      periodsRepo.findOne.mockResolvedValue(mockLockedPeriod);
+      reportingPeriodsService.hasUserExceptionForDate.mockResolvedValue(false);
+
+      const result = await controller.create(mockRequest, createDto as any);
+
+      expect(result.locked).toBe(true);
+      expect(reportingPeriodsService.hasUserExceptionForDate).toHaveBeenCalledWith(
+        'user-id',
+        'period-id',
+        '2024-01-10',
+      );
+    });
+
+    it('should return locked: false when period is locked but user has exception for the date', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      const createDto = {
+        activityTypeId: 'type-id',
+        activityDate: '2024-01-10',
+        hasExpense: false,
+      };
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.create.mockResolvedValue(mockActivity);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.findOneByOrFail.mockResolvedValue(mockActivityType);
+      periodsRepo.findOne.mockResolvedValue(mockLockedPeriod);
+      reportingPeriodsService.hasUserExceptionForDate.mockResolvedValue(true);
+
+      const result = await controller.create(mockRequest, createDto as any);
+
+      expect(result.locked).toBe(false);
+      expect(reportingPeriodsService.hasUserExceptionForDate).toHaveBeenCalledWith(
+        'user-id',
+        'period-id',
+        '2024-01-10',
+      );
+    });
+
+    it('should return locked: false when activity has no reporting period', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      const createDto = {
+        activityTypeId: 'type-id',
+        activityDate: '2024-01-10',
+        hasExpense: false,
+      };
+
+      const activityWithoutPeriod = { ...mockActivity, reportingPeriodId: null };
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.create.mockResolvedValue(activityWithoutPeriod);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.findOneByOrFail.mockResolvedValue(mockActivityType);
+      periodsRepo.findOne.mockResolvedValue(null);
+
+      const result = await controller.create(mockRequest, createDto as any);
+
+      expect(result.locked).toBe(false);
+      expect(reportingPeriodsService.hasUserExceptionForDate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getOne - locked indicator', () => {
+    it('should return locked: false when period is active', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.findOneMine.mockResolvedValue(mockActivity);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.findOneByOrFail.mockResolvedValue(mockActivityType);
+      periodsRepo.findOne.mockResolvedValue(mockActivePeriod);
+
+      const result = await controller.getOne(mockRequest, 'activity-id');
+
+      expect(result.locked).toBe(false);
+    });
+
+    it('should return locked: true when period is locked and user has no exception', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.findOneMine.mockResolvedValue(mockActivity);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.findOneByOrFail.mockResolvedValue(mockActivityType);
+      periodsRepo.findOne.mockResolvedValue(mockLockedPeriod);
+      reportingPeriodsService.hasUserExceptionForDate.mockResolvedValue(false);
+
+      const result = await controller.getOne(mockRequest, 'activity-id');
+
+      expect(result.locked).toBe(true);
+    });
+
+    it('should return locked: false when user has exception covering the activity date', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.findOneMine.mockResolvedValue(mockActivity);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.findOneByOrFail.mockResolvedValue(mockActivityType);
+      periodsRepo.findOne.mockResolvedValue(mockLockedPeriod);
+      reportingPeriodsService.hasUserExceptionForDate.mockResolvedValue(true);
+
+      const result = await controller.getOne(mockRequest, 'activity-id');
+
+      expect(result.locked).toBe(false);
+    });
+  });
+
+  describe('findMine - locked indicator', () => {
+    it('should calculate locked status for each activity individually', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      const activity1 = { ...mockActivity, id: 'act-1', activityDate: '2024-01-05' };
+      const activity2 = { ...mockActivity, id: 'act-2', activityDate: '2024-01-10' };
+      const activity3 = { ...mockActivity, id: 'act-3', activityDate: '2024-01-15' };
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.findMine.mockResolvedValue([[activity1, activity2, activity3], 3]);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.find.mockResolvedValue([mockActivityType]);
+      periodsRepo.find.mockResolvedValue([mockLockedPeriod]);
+
+      // User has exception for Jan 5-10, but not Jan 15
+      reportingPeriodsService.hasUserExceptionForDate.mockImplementation(
+        async (userId, periodId, date) => {
+          if (date === '2024-01-05' || date === '2024-01-10') return true;
+          if (date === '2024-01-15') return false;
+          return false;
+        },
+      );
+
+      const result = await controller.findMine(mockRequest, 1, 20);
+
+      expect(result.items).toHaveLength(3);
+      expect(result.items[0].locked).toBe(false); // Jan 5 - has exception
+      expect(result.items[1].locked).toBe(false); // Jan 10 - has exception
+      expect(result.items[2].locked).toBe(true); // Jan 15 - no exception
+      expect(reportingPeriodsService.hasUserExceptionForDate).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return all locked: false when period is active', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      const activity1 = { ...mockActivity, id: 'act-1' };
+      const activity2 = { ...mockActivity, id: 'act-2' };
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.findMine.mockResolvedValue([[activity1, activity2], 2]);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.find.mockResolvedValue([mockActivityType]);
+      periodsRepo.find.mockResolvedValue([mockActivePeriod]);
+
+      const result = await controller.findMine(mockRequest, 1, 20);
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].locked).toBe(false);
+      expect(result.items[1].locked).toBe(false);
+      expect(reportingPeriodsService.hasUserExceptionForDate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update - locked indicator', () => {
+    it('should return correct locked status after update', async () => {
+      const mockRequest = {
+        user: { sub: 'auth0|123', iss: 'https://test.auth0.com/' },
+      } as any;
+
+      const updateDto = {
+        description: 'Updated description',
+      };
+
+      identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
+      activitiesService.updateMine.mockResolvedValue(mockActivity);
+      usersRepo.findOneByOrFail.mockResolvedValue(mockUser as any);
+      typesRepo.findOneByOrFail.mockResolvedValue(mockActivityType);
+      periodsRepo.findOne.mockResolvedValue(mockLockedPeriod);
+      reportingPeriodsService.hasUserExceptionForDate.mockResolvedValue(true);
+
+      const result = await controller.update(mockRequest, 'activity-id', updateDto);
+
+      expect(result.locked).toBe(false);
+      expect(reportingPeriodsService.hasUserExceptionForDate).toHaveBeenCalledWith(
+        'user-id',
+        'period-id',
+        '2024-01-10',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

  Updates the activity locked indicator to consider per-user date-range exceptions when calculating locked status.
  Activities in locked reporting periods now return `locked: false` if the user has an active exception covering the
  activity date.

  ## Changes

  - Modified `ActivityResponseDto.fromEntity()` to accept `locked` as a parameter instead of calculating it
  internally
  - Added `calculateLockedStatus()` helper method in `ActivitiesController` that checks both reporting period status
  and user exceptions
  - Integrated `ReportingPeriodsService` into `ActivitiesModule` to access exception checking
  - Updated all activity endpoints (`create`, `getOne`, `findMine`, `update`) to calculate per-user locked status
  - Added 10 comprehensive unit tests covering various lock/exception scenarios

  ## Behavior

  The locked indicator now follows this logic:
  - `locked: false` - Period is active OR user has exception covering the activity date
  - `locked: true` - Period is locked AND user has no exception for that date
  - `locked: false` - Activity has no reporting period

  ## Test Coverage

  All 206 tests passing, including new tests for:
  - Active vs locked periods
  - User exceptions covering activity dates
  - Multiple activities with different exception coverage
  - All CRUD endpoints

  Closes #75