### PR TITLE
refactor(frontend): remove duplicate field names in activity payloads

### DIFF
--- a/frontend/lib/services/activity.dart
+++ b/frontend/lib/services/activity.dart
@@ -31,18 +31,12 @@ class ActivityService {
     final iso = date.toUtc().toIso8601String();
 
     final payload = <String, dynamic>{
-      'activity_type_id': typeId,
-      'type_id': typeId,
-      'activity_date': iso,
-      'date': iso,
+      'activityTypeId': typeId,
+      'activityDate': iso,
       if (description != null && description.trim().isNotEmpty)
         'description': description.trim(),
       'hasExpense': hasExpense,
-      'has_expense': hasExpense,
-      if (hasExpense) ...{
-        'expenseAmount': (expenseAmount ?? '0').trim(),
-        'expense_amount': (expenseAmount ?? '0').trim(),
-      },
+      if (hasExpense) 'expenseAmount': (expenseAmount ?? '0').trim(),
     };
 
     final resp = await http.post(

--- a/frontend/lib/widgets/dialogs/create_activity_dialog.dart
+++ b/frontend/lib/widgets/dialogs/create_activity_dialog.dart
@@ -105,20 +105,11 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
       final amount = (hasExp ? _amountCtrl.text.trim() : null);
 
       final payload = <String, dynamic>{
-        'activity_type_id': typeId,
-        'type_id': typeId,
         'activityTypeId': typeId,
-        'typeId': typeId,
-        'activity_date': iso,
-        'date': iso,
         'activityDate': iso,
         if (desc.isNotEmpty) 'description': desc,
         'hasExpense': hasExp,
-        'has_expense': hasExp,
-        if (hasExp) ...{
-          'expenseAmount': amount,
-          'expense_amount': amount,
-        },
+        if (hasExp) 'expenseAmount': amount,
       };
 
       final resp = await http.post(


### PR DESCRIPTION
## Description

Cleaned up duplicate field names being sent to the backend API in activity creation requests.

### Changes
- Removed duplicate fields from `lib/services/activity.dart`
- Removed duplicate fields from `lib/widgets/dialogs/create_activity_dialog.dart`
- Now using only camelCase field names: `activityTypeId`, `activityDate`, `hasExpense`, `expenseAmount`

