### PR TITLE
feat(frontend): add reusable form validation utilities

### DIFF
--- a/frontend/lib/core/validators.dart
+++ b/frontend/lib/core/validators.dart
@@ -1,0 +1,62 @@
+class Validators {
+  static String? required(String? value, {String fieldName = 'Este campo'}) {
+    if (value == null || value.trim().isEmpty) {
+      return '$fieldName es requerido';
+    }
+    return null;
+  }
+
+  static String? minLength(String? value, int min) {
+    if (value == null || value.trim().isEmpty) return null;
+    if (value.trim().length < min) {
+      return 'Debe tener al menos $min caracteres';
+    }
+    return null;
+  }
+
+  static String? maxLength(String? value, int max) {
+    if (value == null || value.trim().isEmpty) return null;
+    if (value.trim().length > max) {
+      return 'No debe exceder $max caracteres';
+    }
+    return null;
+  }
+
+  static String? positiveNumber(String? value) {
+    if (value == null || value.trim().isEmpty) return null;
+    final number = double.tryParse(value.trim());
+    if (number == null) {
+      return 'Debe ser un número válido';
+    }
+    if (number <= 0) {
+      return 'Debe ser un número positivo';
+    }
+    return null;
+  }
+
+  static String? dateNotInFuture(DateTime? value) {
+    if (value == null) return null;
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final selected = DateTime(value.year, value.month, value.day);
+    if (selected.isAfter(today)) {
+      return 'La fecha no puede ser futura';
+    }
+    return null;
+  }
+
+  static String? requiredField<T>(T? value, {String fieldName = 'Este campo'}) {
+    if (value == null) {
+      return '$fieldName es requerido';
+    }
+    return null;
+  }
+
+  static String? combine(List<String? Function()> validators) {
+    for (final validator in validators) {
+      final error = validator();
+      if (error != null) return error;
+    }
+    return null;
+  }
+}

--- a/frontend/lib/widgets/dialogs/create_activity_dialog.dart
+++ b/frontend/lib/widgets/dialogs/create_activity_dialog.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import '../dialogs/calendar_dialog.dart';
 import '../../models/activity_type.dart';
 import '../../services/activity_type.dart';
+import '../../core/validators.dart';
 
 class CreateActivityDialog extends StatefulWidget {
   final String baseUrl;
@@ -306,8 +307,10 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                           onChanged: _submitting
                               ? null
                               : (v) => setState(() => _selectedType = v),
-                          validator: (v) =>
-                              v == null ? 'Selecciona un tipo' : null,
+                          validator: (v) => Validators.requiredField(
+                            v,
+                            fieldName: 'El tipo de actividad',
+                          ),
                           decoration: const InputDecoration(
                             border: OutlineInputBorder(),
                             hintText: 'Selecciona un tipo',
@@ -336,9 +339,10 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                           icon: const Icon(Icons.calendar_today),
                         ),
                       ),
-                      validator: (v) => (v == null || v.trim().isEmpty)
-                          ? 'Selecciona una fecha'
-                          : null,
+                      validator: (v) => Validators.required(
+                        v,
+                        fieldName: 'La fecha',
+                      ),
                     ),
                     const SizedBox(height: 16),
                     Align(
@@ -374,12 +378,15 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                           hintText: 'Monto del gasto',
                           border: OutlineInputBorder(),
                         ),
-                        validator: (v) {
-                          if (_hasExpense && (v == null || v.trim().isEmpty)) {
-                            return 'Ingresa el monto del gasto';
-                          }
-                          return null;
-                        },
+                        validator: (v) => Validators.combine([
+                          () => _hasExpense
+                              ? Validators.required(
+                                  v,
+                                  fieldName: 'El monto del gasto',
+                                )
+                              : null,
+                          () => Validators.positiveNumber(v),
+                        ]),
                       ),
                       const SizedBox(height: 16),
                     ],


### PR DESCRIPTION
## Description

Created a centralized validation system with reusable utilities to replace scattered inline validation logic across forms.

### Changes
- Created `lib/core/validators.dart` with common validation methods
- Implemented validators: `required`, `minLength`, `maxLength`, `positiveNumber`, `dateNotInFuture`, `requiredField`, and `combine`
- All error messages in Spanish for consistency
- Applied validators to `CreateActivityDialog` form fields