### PR TITLE
feat: Add Reports Analytics Module with 7 Endpoints

### DIFF
--- a/backend/scripts/add-role-capability-fields.ts
+++ b/backend/scripts/add-role-capability-fields.ts
@@ -52,7 +52,8 @@ async function addRoleCapabilityFields() {
 
     console.log('Setting System Admin flag...');
     await dataSource.query(`UPDATE roles SET is_system_admin = TRUE WHERE name = $1`, [
-      [SYSTEM_ADMIN_ROLE],);
+      SYSTEM_ADMIN_ROLE,
+    ]);
 
     console.log('Setting can_manage_own_activities for Missionary roles...');
     for (const roleName of MISSIONARY_ROLES) {

--- a/backend/src/activity/activities.controller.ts
+++ b/backend/src/activity/activities.controller.ts
@@ -156,7 +156,13 @@ export class ActivitiesController {
 
     const locked = await this.calculateLockedStatus(a, user.id, reportingPeriod);
 
-    return ActivityResponseDto.fromEntity(a, owner.username, (type as any).name, reportingPeriod, locked);
+    return ActivityResponseDto.fromEntity(
+      a,
+      owner.username,
+      (type as any).name,
+      reportingPeriod,
+      locked,
+    );
   }
 
   @Patch(':id')

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { IdpIdentitiesModule } from './idp-identities/idp-identities.module';
 import { ActivitiesModule } from './activity/activities.module';
 import { ReportingPeriodsModule } from './reporting-periods/reporting-periods.module';
 import { CaslModule } from './casl/casl.module';
+import { ReportsModule } from './reports/reports.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { CaslModule } from './casl/casl.module';
     IdpIdentitiesModule,
     ActivitiesModule,
     ReportingPeriodsModule,
+    ReportsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -124,12 +124,23 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         assignments.filter((a) => isDateInRange(today, a.start_date, a.end_date)),
       );
 
+    const roles: string[] = [];
+    if (user.role?.name) {
+      roles.push(user.role.name);
+    }
+    roleAssignments.forEach((assignment) => {
+      if (assignment.role?.name && !roles.includes(assignment.role.name)) {
+        roles.push(assignment.role.name);
+      }
+    });
+
     return {
       ...user,
       sub,
       iss,
       aud: payload?.aud,
       roleAssignments,
+      roles,
     };
   }
 }

--- a/backend/src/casl/casl-ability.factory.spec.ts
+++ b/backend/src/casl/casl-ability.factory.spec.ts
@@ -708,8 +708,12 @@ describe('CaslAbilityFactory', () => {
 
         const ability = await factory.createForUser(user);
 
-        const periodInScope = { entityId: 'field-1' } as Partial<ReportingPeriod> as ReportingPeriod;
-        const periodOutOfScope = { entityId: 'field-2' } as Partial<ReportingPeriod> as ReportingPeriod;
+        const periodInScope = {
+          entityId: 'field-1',
+        } as Partial<ReportingPeriod> as ReportingPeriod;
+        const periodOutOfScope = {
+          entityId: 'field-2',
+        } as Partial<ReportingPeriod> as ReportingPeriod;
 
         expect(ability.can(Action.Read, periodInScope)).toBe(true);
         expect(ability.cannot(Action.Read, periodOutOfScope)).toBe(true);
@@ -761,7 +765,10 @@ describe('CaslAbilityFactory', () => {
         const field2Activity = { entityId: 'field-2' } as Partial<Activity> as Activity;
         expect(ability.can(Action.Update, field2Activity)).toBe(true);
 
-        const unrelatedActivity = { userId: 'user-2', entityId: 'field-3' } as Partial<Activity> as Activity;
+        const unrelatedActivity = {
+          userId: 'user-2',
+          entityId: 'field-3',
+        } as Partial<Activity> as Activity;
         expect(ability.cannot(Action.Update, unrelatedActivity)).toBe(true);
       });
     });

--- a/backend/src/casl/casl.module.ts
+++ b/backend/src/casl/casl.module.ts
@@ -10,9 +10,7 @@ import { Entity } from '../entities/entity.entity';
  * Provides authorization services using CASL abilities
  */
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([UserRoleAssignment, Entity]),
-  ],
+  imports: [TypeOrmModule.forFeature([UserRoleAssignment, Entity])],
   providers: [CaslAbilityFactory, PoliciesGuard],
   exports: [CaslAbilityFactory, PoliciesGuard],
 })

--- a/backend/src/casl/check-policies.decorator.ts
+++ b/backend/src/casl/check-policies.decorator.ts
@@ -8,18 +8,18 @@ export const CHECK_POLICIES_KEY = 'check_policies';
 
 /**
  * Decorator to define authorization policies for a route
- * 
+ *
  * @example
  * // Simple check
  * @CheckPolicies((ability) => ability.can(Action.Read, 'Activity'))
- * 
+ *
  * @example
  * // Multiple checks
  * @CheckPolicies(
  *   (ability) => ability.can(Action.Create, 'Activity'),
  *   (ability) => ability.can(Action.Read, 'Entity')
  * )
- * 
+ *
  * @example
  * // Class-based handler
  * class ReadActivityPolicy implements IPolicyHandler {

--- a/backend/src/entities/tests/entities.controller.spec.ts
+++ b/backend/src/entities/tests/entities.controller.spec.ts
@@ -148,7 +148,9 @@ describe('EntitiesController', () => {
       service.findOne.mockResolvedValue(mockEntity);
       service.remove.mockResolvedValue({ affected: 1 } as never);
       const mockReq = { ability: { can: jest.fn().mockReturnValue(true) } } as any;
-      await expect(controller.remove(mockReq, '11111111-1111-1111-1111-111111111111')).resolves.toEqual({
+      await expect(
+        controller.remove(mockReq, '11111111-1111-1111-1111-111111111111'),
+      ).resolves.toEqual({
         affected: 1,
       });
     });

--- a/backend/src/reporting-periods/tests/reporting-period-exceptions.spec.ts
+++ b/backend/src/reporting-periods/tests/reporting-period-exceptions.spec.ts
@@ -156,9 +156,9 @@ describe('ReportingPeriodsService - Exceptions', () => {
 
       periodRepo.findOne.mockResolvedValue(mockPeriod);
 
-      await expect(
-        service.createOrUpdateException('period-id', dto, 'admin-id'),
-      ).rejects.toThrow(new BadRequestException('Start date must be before end date'));
+      await expect(service.createOrUpdateException('period-id', dto, 'admin-id')).rejects.toThrow(
+        new BadRequestException('Start date must be before end date'),
+      );
     });
 
     it('should throw BadRequestException when dates are outside period boundaries', async () => {
@@ -171,9 +171,7 @@ describe('ReportingPeriodsService - Exceptions', () => {
 
       periodRepo.findOne.mockResolvedValue(mockPeriod);
 
-      await expect(
-        service.createOrUpdateException('period-id', dto, 'admin-id'),
-      ).rejects.toThrow(
+      await expect(service.createOrUpdateException('period-id', dto, 'admin-id')).rejects.toThrow(
         new BadRequestException(
           'Exception dates must be within period boundaries (2024-01-01 - 2024-01-14)',
         ),
@@ -190,9 +188,7 @@ describe('ReportingPeriodsService - Exceptions', () => {
 
       periodRepo.findOne.mockResolvedValue(mockPeriod);
 
-      await expect(
-        service.createOrUpdateException('period-id', dto, 'admin-id'),
-      ).rejects.toThrow(
+      await expect(service.createOrUpdateException('period-id', dto, 'admin-id')).rejects.toThrow(
         new BadRequestException(
           'Exception dates must be within period boundaries (2024-01-01 - 2024-01-14)',
         ),
@@ -257,10 +253,7 @@ describe('ReportingPeriodsService - Exceptions', () => {
 
   describe('findExceptionsByPeriod', () => {
     it('should return all exceptions for a period', async () => {
-      const exceptions = [
-        mockException,
-        { ...mockException, id: 'exception-2', userId: 'user-2' },
-      ];
+      const exceptions = [mockException, { ...mockException, id: 'exception-2', userId: 'user-2' }];
 
       exceptionRepo.find.mockResolvedValue(exceptions as ReportingPeriodException[]);
 
@@ -288,11 +281,7 @@ describe('ReportingPeriodsService - Exceptions', () => {
     it('should return true when user has exception covering the date', async () => {
       exceptionRepo.findOne.mockResolvedValue(mockException);
 
-      const result = await service.hasUserExceptionForDate(
-        'user-id',
-        'period-id',
-        '2024-01-03',
-      );
+      const result = await service.hasUserExceptionForDate('user-id', 'period-id', '2024-01-03');
 
       expect(exceptionRepo.findOne).toHaveBeenCalledWith({
         where: { userId: 'user-id', reportingPeriodId: 'period-id' },
@@ -303,11 +292,7 @@ describe('ReportingPeriodsService - Exceptions', () => {
     it('should return true when date is at start boundary', async () => {
       exceptionRepo.findOne.mockResolvedValue(mockException);
 
-      const result = await service.hasUserExceptionForDate(
-        'user-id',
-        'period-id',
-        '2024-01-01',
-      );
+      const result = await service.hasUserExceptionForDate('user-id', 'period-id', '2024-01-01');
 
       expect(result).toBe(true);
     });
@@ -315,11 +300,7 @@ describe('ReportingPeriodsService - Exceptions', () => {
     it('should return true when date is at end boundary', async () => {
       exceptionRepo.findOne.mockResolvedValue(mockException);
 
-      const result = await service.hasUserExceptionForDate(
-        'user-id',
-        'period-id',
-        '2024-01-05',
-      );
+      const result = await service.hasUserExceptionForDate('user-id', 'period-id', '2024-01-05');
 
       expect(result).toBe(true);
     });
@@ -327,11 +308,7 @@ describe('ReportingPeriodsService - Exceptions', () => {
     it('should return false when date is before exception start', async () => {
       exceptionRepo.findOne.mockResolvedValue(mockException);
 
-      const result = await service.hasUserExceptionForDate(
-        'user-id',
-        'period-id',
-        '2023-12-31',
-      );
+      const result = await service.hasUserExceptionForDate('user-id', 'period-id', '2023-12-31');
 
       expect(result).toBe(false);
     });
@@ -339,11 +316,7 @@ describe('ReportingPeriodsService - Exceptions', () => {
     it('should return false when date is after exception end', async () => {
       exceptionRepo.findOne.mockResolvedValue(mockException);
 
-      const result = await service.hasUserExceptionForDate(
-        'user-id',
-        'period-id',
-        '2024-01-06',
-      );
+      const result = await service.hasUserExceptionForDate('user-id', 'period-id', '2024-01-06');
 
       expect(result).toBe(false);
     });
@@ -351,11 +324,7 @@ describe('ReportingPeriodsService - Exceptions', () => {
     it('should return false when user has no exception', async () => {
       exceptionRepo.findOne.mockResolvedValue(null);
 
-      const result = await service.hasUserExceptionForDate(
-        'user-id',
-        'period-id',
-        '2024-01-03',
-      );
+      const result = await service.hasUserExceptionForDate('user-id', 'period-id', '2024-01-03');
 
       expect(result).toBe(false);
     });

--- a/backend/src/reports/access/reports-access.service.ts
+++ b/backend/src/reports/access/reports-access.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Entity } from '../../entities/entity.entity';
+import { User } from '../../users/user.entity';
+
+@Injectable()
+export class ReportsAccessService {
+  constructor(
+    @InjectRepository(Entity)
+    private readonly entityRepo: Repository<Entity>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {}
+
+  async getEntityHierarchy(entityId: string): Promise<string[]> {
+    const entity = await this.entityRepo.findOne({
+      where: { id: entityId },
+      relations: ['children'],
+    });
+
+    if (!entity) {
+      throw new NotFoundException('Entity not found');
+    }
+
+    const entityIds = [entityId];
+    const queue = [entity];
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current) break;
+      const children = await this.entityRepo.find({
+        where: { parent_id: current.id },
+        relations: ['children'],
+      });
+
+      for (const child of children) {
+        entityIds.push(child.id);
+        queue.push(child);
+      }
+    }
+
+    return entityIds;
+  }
+
+  async validateEntityInUserScope(actorUserId: string, targetEntityId: string): Promise<boolean> {
+    const actor = await this.userRepo.findOne({
+      where: { id: actorUserId },
+      relations: ['entity'],
+    });
+
+    if (!actor) {
+      throw new NotFoundException('User not found');
+    }
+
+    const allowedEntityIds = await this.getEntityHierarchy(actor.entity_id);
+    return allowedEntityIds.includes(targetEntityId);
+  }
+
+  async validateUserInScope(actorUserId: string, targetUserId: string): Promise<boolean> {
+    const actor = await this.userRepo.findOne({
+      where: { id: actorUserId },
+      relations: ['entity'],
+    });
+    const target = await this.userRepo.findOne({
+      where: { id: targetUserId },
+      relations: ['entity'],
+    });
+
+    if (!actor || !target) {
+      throw new NotFoundException('User not found');
+    }
+
+    const allowedEntityIds = await this.getEntityHierarchy(actor.entity_id);
+    return allowedEntityIds.includes(target.entity_id);
+  }
+}

--- a/backend/src/reports/calculators/breakdowns.calculator.ts
+++ b/backend/src/reports/calculators/breakdowns.calculator.ts
@@ -1,0 +1,121 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Activity } from '../../activity/activity.entity';
+import { User } from '../../users/user.entity';
+import { UserStatus } from '../../users/user-status.enum';
+import { BreakdownsResponse } from '../dto/report-responses.dto';
+
+@Injectable()
+export class BreakdownsCalculator {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {}
+
+  async calculate(
+    activities: Activity[],
+    canViewReports: boolean,
+    isUserFiltered: boolean,
+  ): Promise<BreakdownsResponse> {
+    const typeMap = new Map<string, { name: string; count: number; expenses: number }>();
+    for (const activity of activities) {
+      const typeId = activity.activityTypeId;
+      const typeName = activity.activityType.name;
+      const existing = typeMap.get(typeId) || { name: typeName, count: 0, expenses: 0 };
+      existing.count++;
+      existing.expenses += activity.expenseAmount ? parseFloat(activity.expenseAmount) : 0;
+      typeMap.set(typeId, existing);
+    }
+
+    const byType = Array.from(typeMap.entries()).map(([typeId, data]) => ({
+      typeId,
+      name: data.name,
+      count: data.count,
+      expenses: Math.round(data.expenses * 100) / 100,
+    }));
+
+    const byEntity: Array<{
+      entityId: string;
+      name: string;
+      type: string;
+      count: number;
+      expenses: number;
+      compliance: { submitted: number; total: number };
+    }> = [];
+    if (canViewReports && !isUserFiltered) {
+      const entityMap = new Map<
+        string,
+        { name: string; type: string; count: number; expenses: number }
+      >();
+      for (const activity of activities) {
+        const entityId = activity.user.entity_id;
+        const entity = activity.user.entity;
+        const existing = entityMap.get(entityId) || {
+          name: entity.name,
+          type: entity.type,
+          count: 0,
+          expenses: 0,
+        };
+        existing.count++;
+        existing.expenses += activity.expenseAmount ? parseFloat(activity.expenseAmount) : 0;
+        entityMap.set(entityId, existing);
+      }
+
+      const entityIds = Array.from(entityMap.keys());
+      const allUsers = await this.userRepo.find({
+        where: { entity_id: In(entityIds), status: UserStatus.ACTIVE },
+      });
+
+      const usersByEntity = new Map<string, User[]>();
+      for (const user of allUsers) {
+        if (!usersByEntity.has(user.entity_id)) {
+          usersByEntity.set(user.entity_id, []);
+        }
+        const entityUsers = usersByEntity.get(user.entity_id);
+        if (entityUsers) {
+          entityUsers.push(user);
+        }
+      }
+
+      for (const [entityId, data] of entityMap.entries()) {
+        const usersInEntity = usersByEntity.get(entityId) || [];
+        const userIdsInEntity = usersInEntity.map((u) => u.id);
+        const usersSubmitted = new Set(
+          activities.filter((a) => userIdsInEntity.includes(a.userId)).map((a) => a.userId),
+        ).size;
+
+        byEntity.push({
+          entityId,
+          name: data.name,
+          type: data.type,
+          count: data.count,
+          expenses: Math.round(data.expenses * 100) / 100,
+          compliance: {
+            submitted: usersSubmitted,
+            total: usersInEntity.length,
+          },
+        });
+      }
+    }
+
+    const userMap = new Map<string, { name: string; count: number; expenses: number }>();
+    for (const activity of activities) {
+      const userId = activity.userId;
+      const userName = activity.user.full_name || activity.user.username;
+      const existing = userMap.get(userId) || { name: userName, count: 0, expenses: 0 };
+      existing.count++;
+      existing.expenses += activity.expenseAmount ? parseFloat(activity.expenseAmount) : 0;
+      userMap.set(userId, existing);
+    }
+
+    const byUser = Array.from(userMap.entries()).map(([userId, data]) => ({
+      userId,
+      name: data.name,
+      count: data.count,
+      expenses: Math.round(data.expenses * 100) / 100,
+    }));
+
+    return { byType, byEntity, byUser };
+  }
+}

--- a/backend/src/reports/calculators/comparison.calculator.ts
+++ b/backend/src/reports/calculators/comparison.calculator.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Activity } from '../../activity/activity.entity';
+import { User } from '../../users/user.entity';
+import { ReportingPeriod } from '../../reporting-periods/reporting-period.entity';
+import { UserStatus } from '../../users/user-status.enum';
+import { ComparisonResponse } from '../dto/report-responses.dto';
+
+@Injectable()
+export class ComparisonCalculator {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {}
+
+  async calculate(
+    currentPeriod: ReportingPeriod,
+    previousPeriod: ReportingPeriod,
+    currentActivities: Activity[],
+    previousActivities: Activity[],
+    entityIds: string[],
+    canViewReports: boolean,
+    isUserFiltered: boolean,
+  ): Promise<ComparisonResponse> {
+    let usersInScope: User[] = [];
+    if (canViewReports && !isUserFiltered) {
+      usersInScope = await this.userRepo.find({
+        where: { entity_id: In(entityIds), status: UserStatus.ACTIVE },
+      });
+    }
+
+    const formatDate = (date: string) => {
+      const d = new Date(date);
+      return d.toLocaleDateString('es-ES', { month: 'short', day: 'numeric' });
+    };
+
+    const getPeriodData = (period: ReportingPeriod, activities: Activity[]) => {
+      const totalExpenses = activities.reduce((sum, a) => {
+        return sum + (a.expenseAmount ? parseFloat(a.expenseAmount) : 0);
+      }, 0);
+
+      let usersExpected = 0;
+      let usersActive = 0;
+
+      if (canViewReports && !isUserFiltered) {
+        usersExpected = usersInScope.length;
+        usersActive = new Set(activities.map((a) => a.userId)).size;
+      } else {
+        usersExpected = 1;
+        usersActive = activities.length > 0 ? 1 : 0;
+      }
+
+      const complianceRate = usersExpected > 0 ? usersActive / usersExpected : 0;
+
+      return {
+        periodId: period.id,
+        dates: `${formatDate(period.startDate)}-${formatDate(period.endDate)}`,
+        activities: activities.length,
+        expenses: Math.round(totalExpenses * 100) / 100,
+        complianceRate: Math.round(complianceRate * 100) / 100,
+        usersActive,
+      };
+    };
+
+    const current = getPeriodData(currentPeriod, currentActivities);
+    const previous = getPeriodData(previousPeriod, previousActivities);
+
+    const calculateChange = (current: number, previous: number) => {
+      const value = current - previous;
+      const percent = previous !== 0 ? (value / previous) * 100 : 0;
+      return {
+        value: Math.round(value * 100) / 100,
+        percent: Math.round(percent * 100) / 100,
+      };
+    };
+
+    return {
+      current,
+      previous,
+      changes: {
+        activities: calculateChange(current.activities, previous.activities),
+        expenses: calculateChange(current.expenses, previous.expenses),
+        complianceRate: calculateChange(current.complianceRate, previous.complianceRate),
+        usersActive: calculateChange(current.usersActive, previous.usersActive),
+      },
+    };
+  }
+}

--- a/backend/src/reports/calculators/compliance.calculator.ts
+++ b/backend/src/reports/calculators/compliance.calculator.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Activity } from '../../activity/activity.entity';
+import { User } from '../../users/user.entity';
+import { UserStatus } from '../../users/user-status.enum';
+import { ComplianceResponse } from '../dto/report-responses.dto';
+
+@Injectable()
+export class ComplianceCalculator {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {}
+
+  async calculate(activities: Activity[], entityIds: string[]): Promise<ComplianceResponse> {
+    const usersInScope = await this.userRepo.find({
+      where: { entity_id: In(entityIds), status: UserStatus.ACTIVE },
+      relations: ['entity'],
+    });
+
+    const userIdsWithActivities = new Set(activities.map((a) => a.userId));
+
+    const submittedUsers = usersInScope
+      .filter((u) => userIdsWithActivities.has(u.id))
+      .map((u) => {
+        const userActivities = activities.filter((a) => a.userId === u.id);
+        const lastActivity = userActivities.reduce((latest, a) => {
+          return a.activityDate > latest ? a.activityDate : latest;
+        }, '');
+
+        return {
+          userId: u.id,
+          name: u.full_name || u.username,
+          count: userActivities.length,
+          lastActivity,
+        };
+      });
+
+    const notSubmittedUsersList = usersInScope.filter((u) => !userIdsWithActivities.has(u.id));
+
+    const roleAssignmentsMap = new Map<string, string[]>();
+    if (notSubmittedUsersList.length > 0) {
+      const userIds = notSubmittedUsersList.map((u) => u.id);
+      const allRoleAssignments = await this.userRepo.manager.query(
+        `SELECT ura.user_id, r.name FROM user_role_assignment ura
+         JOIN roles r ON ura.role_id = r.id
+         WHERE ura.user_id = ANY($1)`,
+        [userIds],
+      );
+
+      for (const assignment of allRoleAssignments) {
+        if (!roleAssignmentsMap.has(assignment.user_id)) {
+          roleAssignmentsMap.set(assignment.user_id, []);
+        }
+        const roles = roleAssignmentsMap.get(assignment.user_id);
+        if (roles) {
+          roles.push(assignment.name);
+        }
+      }
+    }
+
+    const notSubmittedUsers = notSubmittedUsersList.map((u) => ({
+      userId: u.id,
+      name: u.full_name || u.username,
+      roles: roleAssignmentsMap.get(u.id) || [],
+      entity: u.entity.name,
+    }));
+
+    return {
+      submitted: submittedUsers,
+      notSubmitted: notSubmittedUsers,
+    };
+  }
+}

--- a/backend/src/reports/calculators/expenses.calculator.ts
+++ b/backend/src/reports/calculators/expenses.calculator.ts
@@ -1,0 +1,97 @@
+import { Injectable } from '@nestjs/common';
+import { Activity } from '../../activity/activity.entity';
+import { ExpensesResponse } from '../dto/report-responses.dto';
+
+@Injectable()
+export class ExpensesCalculator {
+  async calculate(
+    activities: Activity[],
+    canViewReports: boolean,
+    isUserFiltered: boolean,
+  ): Promise<ExpensesResponse> {
+    const totalExpenses = activities.reduce((sum, a) => {
+      return sum + (a.expenseAmount ? parseFloat(a.expenseAmount) : 0);
+    }, 0);
+
+    const typeMap = new Map<string, { name: string; total: number; count: number }>();
+    for (const activity of activities) {
+      if (activity.expenseAmount) {
+        const typeId = activity.activityTypeId;
+        const typeName = activity.activityType.name;
+        const existing = typeMap.get(typeId) || { name: typeName, total: 0, count: 0 };
+        existing.total += parseFloat(activity.expenseAmount);
+        existing.count++;
+        typeMap.set(typeId, existing);
+      }
+    }
+
+    const byType = Array.from(typeMap.entries()).map(([typeId, data]) => ({
+      typeId,
+      name: data.name,
+      total: Math.round(data.total * 100) / 100,
+      percent: totalExpenses > 0 ? Math.round((data.total / totalExpenses) * 10000) / 100 : 0,
+      avgPerActivity: data.count > 0 ? Math.round((data.total / data.count) * 100) / 100 : 0,
+    }));
+
+    const byEntity: Array<{
+      entityId: string;
+      name: string;
+      total: number;
+      percent: number;
+      perUser: number;
+    }> = [];
+    if (canViewReports && !isUserFiltered) {
+      const entityMap = new Map<string, { name: string; total: number; userIds: Set<string> }>();
+      for (const activity of activities) {
+        if (activity.expenseAmount) {
+          const entityId = activity.user.entity_id;
+          const entityName = activity.user.entity.name;
+          const existing = entityMap.get(entityId) || {
+            name: entityName,
+            total: 0,
+            userIds: new Set(),
+          };
+          existing.total += parseFloat(activity.expenseAmount);
+          existing.userIds.add(activity.userId);
+          entityMap.set(entityId, existing);
+        }
+      }
+
+      for (const [entityId, data] of entityMap.entries()) {
+        byEntity.push({
+          entityId,
+          name: data.name,
+          total: Math.round(data.total * 100) / 100,
+          percent: totalExpenses > 0 ? Math.round((data.total / totalExpenses) * 10000) / 100 : 0,
+          perUser:
+            data.userIds.size > 0 ? Math.round((data.total / data.userIds.size) * 100) / 100 : 0,
+        });
+      }
+    }
+
+    const userMap = new Map<string, { name: string; total: number }>();
+    for (const activity of activities) {
+      if (activity.expenseAmount) {
+        const userId = activity.userId;
+        const userName = activity.user.full_name || activity.user.username;
+        const existing = userMap.get(userId) || { name: userName, total: 0 };
+        existing.total += parseFloat(activity.expenseAmount);
+        userMap.set(userId, existing);
+      }
+    }
+
+    const byUser = Array.from(userMap.entries()).map(([userId, data]) => ({
+      userId,
+      name: data.name,
+      total: Math.round(data.total * 100) / 100,
+      percent: totalExpenses > 0 ? Math.round((data.total / totalExpenses) * 10000) / 100 : 0,
+    }));
+
+    return {
+      total: Math.round(totalExpenses * 100) / 100,
+      byType,
+      byEntity,
+      byUser,
+    };
+  }
+}

--- a/backend/src/reports/calculators/rankings.calculator.ts
+++ b/backend/src/reports/calculators/rankings.calculator.ts
@@ -1,0 +1,160 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Activity } from '../../activity/activity.entity';
+import { User } from '../../users/user.entity';
+import { Entity } from '../../entities/entity.entity';
+import { ReportingPeriod } from '../../reporting-periods/reporting-period.entity';
+import { UserStatus } from '../../users/user-status.enum';
+import { ActivityStatus } from '../../activity/activity-status.enum';
+import { RankingsResponse } from '../dto/report-responses.dto';
+
+@Injectable()
+export class RankingsCalculator {
+  constructor(
+    @InjectRepository(Activity)
+    private readonly activityRepo: Repository<Activity>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(Entity)
+    private readonly entityRepo: Repository<Entity>,
+  ) {}
+
+  async calculate(
+    activities: Activity[],
+    entityIds: string[],
+    recentPeriods: ReportingPeriod[],
+    limit: number,
+  ): Promise<RankingsResponse> {
+    const userPerformance = new Map<
+      string,
+      { name: string; entity: string; count: number; expenses: number }
+    >();
+    for (const activity of activities) {
+      const userId = activity.userId;
+      const existing = userPerformance.get(userId) || {
+        name: activity.user.full_name || activity.user.username,
+        entity: activity.user.entity.name,
+        count: 0,
+        expenses: 0,
+      };
+      existing.count++;
+      existing.expenses += activity.expenseAmount ? parseFloat(activity.expenseAmount) : 0;
+      userPerformance.set(userId, existing);
+    }
+
+    const topPerformers = Array.from(userPerformance.entries())
+      .sort((a, b) => b[1].count - a[1].count)
+      .slice(0, limit)
+      .map(([userId, data]) => ({
+        userId,
+        name: data.name,
+        entity: data.entity,
+        count: data.count,
+        expenses: Math.round(data.expenses * 100) / 100,
+      }));
+
+    const childEntities = await this.entityRepo.find({
+      where: { id: In(entityIds) },
+    });
+
+    const allUsers = await this.userRepo.find({
+      where: { entity_id: In(entityIds), status: UserStatus.ACTIVE },
+    });
+
+    const usersByEntity = new Map<string, User[]>();
+    for (const user of allUsers) {
+      if (!usersByEntity.has(user.entity_id)) {
+        usersByEntity.set(user.entity_id, []);
+      }
+      const entityUsers = usersByEntity.get(user.entity_id);
+      if (entityUsers) {
+        entityUsers.push(user);
+      }
+    }
+
+    const entityCompliance = childEntities.map((entity) => {
+      const usersInEntity = usersByEntity.get(entity.id) || [];
+      const userIdsInEntity = usersInEntity.map((u) => u.id);
+      const usersSubmitted = new Set(
+        activities.filter((a) => userIdsInEntity.includes(a.userId)).map((a) => a.userId),
+      ).size;
+
+      const rate = usersInEntity.length > 0 ? usersSubmitted / usersInEntity.length : 0;
+      const missing = usersInEntity.length - usersSubmitted;
+
+      return {
+        entityId: entity.id,
+        name: entity.name,
+        rate: Math.round(rate * 100) / 100,
+        missing,
+      };
+    });
+
+    const lowestCompliance = entityCompliance
+      .filter((e) => e.missing > 0)
+      .sort((a, b) => a.rate - b.rate)
+      .slice(0, limit);
+
+    const inactiveUsers: Array<{
+      userId: string;
+      name: string;
+      entity: string;
+      periodsInactive: number;
+    }> = [];
+    if (recentPeriods.length > 0) {
+      const usersInScope = await this.userRepo.find({
+        where: { entity_id: In(entityIds), status: UserStatus.ACTIVE },
+        relations: ['entity'],
+      });
+
+      const userIds = usersInScope.map((u) => u.id);
+      const periodIds = recentPeriods.map((p) => p.id);
+
+      const allActivities = await this.activityRepo.find({
+        where: {
+          userId: In(userIds),
+          reportingPeriodId: In(periodIds),
+          status: ActivityStatus.ACTIVE,
+        },
+        select: ['userId', 'reportingPeriodId'],
+      });
+
+      const activitySet = new Set<string>();
+      for (const activity of allActivities) {
+        activitySet.add(`${activity.userId}:${activity.reportingPeriodId}`);
+      }
+
+      for (const user of usersInScope) {
+        let periodsInactive = 0;
+        for (const period of recentPeriods) {
+          const hasActivity = activitySet.has(`${user.id}:${period.id}`);
+          if (!hasActivity) {
+            periodsInactive++;
+          } else {
+            break;
+          }
+        }
+
+        if (periodsInactive >= 2) {
+          inactiveUsers.push({
+            userId: user.id,
+            name: user.full_name || user.username,
+            entity: user.entity.name,
+            periodsInactive,
+          });
+        }
+      }
+    }
+
+    const sortedInactiveUsers = inactiveUsers
+      .sort((a, b) => b.periodsInactive - a.periodsInactive)
+      .slice(0, limit);
+
+    return {
+      topPerformers,
+      lowestCompliance,
+      inactiveUsers: sortedInactiveUsers,
+    };
+  }
+}

--- a/backend/src/reports/calculators/summary.calculator.ts
+++ b/backend/src/reports/calculators/summary.calculator.ts
@@ -1,0 +1,92 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Activity } from '../../activity/activity.entity';
+import { User } from '../../users/user.entity';
+import { Entity } from '../../entities/entity.entity';
+import { ReportingPeriod } from '../../reporting-periods/reporting-period.entity';
+import { UserStatus } from '../../users/user-status.enum';
+import { SummaryResponse } from '../dto/report-responses.dto';
+
+@Injectable()
+export class SummaryCalculator {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(Entity)
+    private readonly entityRepo: Repository<Entity>,
+  ) {}
+
+  async calculate(
+    activities: Activity[],
+    targetEntityId: string,
+    entityIds: string[],
+    canViewReports: boolean,
+    isUserFiltered: boolean,
+    timeScope: {
+      period?: ReportingPeriod;
+      dateFrom?: string;
+      dateTo?: string;
+    },
+  ): Promise<SummaryResponse> {
+    const scope: 'personal' | 'entity' = canViewReports ? 'entity' : 'personal';
+
+    const totalActivities = activities.length;
+    const totalExpenses = activities.reduce((sum, a) => {
+      return sum + (a.expenseAmount ? parseFloat(a.expenseAmount) : 0);
+    }, 0);
+
+    let usersExpected = 0;
+    let usersSubmitted = 0;
+    let complianceRate = 0;
+
+    if (canViewReports && !isUserFiltered) {
+      const usersInScope = await this.userRepo.find({
+        where: { entity_id: In(entityIds), status: UserStatus.ACTIVE },
+      });
+      usersExpected = usersInScope.length;
+
+      const userIdsWithActivities = new Set(activities.map((a) => a.userId));
+      usersSubmitted = userIdsWithActivities.size;
+      complianceRate = usersExpected > 0 ? usersSubmitted / usersExpected : 0;
+    } else {
+      usersExpected = 1;
+      usersSubmitted = totalActivities > 0 ? 1 : 0;
+      complianceRate = usersSubmitted;
+    }
+
+    const entity = await this.entityRepo.findOne({ where: { id: targetEntityId } });
+    if (!entity) {
+      throw new NotFoundException('Entity not found');
+    }
+
+    return {
+      period: timeScope.period
+        ? {
+            id: timeScope.period.id,
+            startDate: timeScope.period.startDate,
+            endDate: timeScope.period.endDate,
+            status: timeScope.period.status,
+          }
+        : {
+            id: '',
+            startDate: timeScope.dateFrom || '',
+            endDate: timeScope.dateTo || '',
+            status: 'custom',
+          },
+      scope,
+      entity: {
+        id: entity.id,
+        name: entity.name,
+        type: entity.type,
+      },
+      totals: {
+        activities: totalActivities,
+        expenses: Math.round(totalExpenses * 100) / 100,
+        usersExpected,
+        usersSubmitted,
+        complianceRate: Math.round(complianceRate * 100) / 100,
+      },
+    };
+  }
+}

--- a/backend/src/reports/calculators/trends.calculator.ts
+++ b/backend/src/reports/calculators/trends.calculator.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Activity } from '../../activity/activity.entity';
+import { User } from '../../users/user.entity';
+import { ReportingPeriod } from '../../reporting-periods/reporting-period.entity';
+import { UserStatus } from '../../users/user-status.enum';
+import { TrendsResponse } from '../dto/report-responses.dto';
+
+@Injectable()
+export class TrendsCalculator {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {}
+
+  async calculate(
+    periodsData: Array<{ period: ReportingPeriod; activities: Activity[] }>,
+    entityIds: string[],
+    canViewReports: boolean,
+    isUserFiltered: boolean,
+  ): Promise<TrendsResponse> {
+    let usersInScope: User[] = [];
+    if (canViewReports && !isUserFiltered) {
+      usersInScope = await this.userRepo.find({
+        where: { entity_id: In(entityIds), status: UserStatus.ACTIVE },
+      });
+    }
+
+    const trendsData = periodsData.map(({ period, activities }) => {
+      const totalExpenses = activities.reduce((sum, a) => {
+        return sum + (a.expenseAmount ? parseFloat(a.expenseAmount) : 0);
+      }, 0);
+
+      let usersExpected = 0;
+      let usersSubmitted = 0;
+
+      if (canViewReports && !isUserFiltered) {
+        usersExpected = usersInScope.length;
+        usersSubmitted = new Set(activities.map((a) => a.userId)).size;
+      } else {
+        usersExpected = 1;
+        usersSubmitted = activities.length > 0 ? 1 : 0;
+      }
+
+      const complianceRate = usersExpected > 0 ? usersSubmitted / usersExpected : 0;
+
+      return {
+        periodId: period.id,
+        startDate: period.startDate,
+        endDate: period.endDate,
+        activities: activities.length,
+        expenses: Math.round(totalExpenses * 100) / 100,
+        complianceRate: Math.round(complianceRate * 100) / 100,
+        usersSubmitted,
+        usersExpected,
+      };
+    });
+
+    return {
+      periods: trendsData.reverse(),
+    };
+  }
+}

--- a/backend/src/reports/dto/report-query.dto.ts
+++ b/backend/src/reports/dto/report-query.dto.ts
@@ -1,0 +1,40 @@
+import {
+  IsOptional,
+  IsUUID,
+  IsDateString,
+  IsInt,
+  Min,
+  Validate,
+  ValidateIf,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ReportQueryDto {
+  @IsOptional()
+  @IsUUID()
+  periodId?: string;
+
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @IsOptional()
+  @IsUUID()
+  entityId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  userId?: string;
+}
+
+export class RankingsQueryDto extends ReportQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 5;
+}

--- a/backend/src/reports/dto/report-responses.dto.ts
+++ b/backend/src/reports/dto/report-responses.dto.ts
@@ -1,0 +1,178 @@
+export interface PeriodInfo {
+  id: string;
+  startDate: string;
+  endDate: string;
+  status: string;
+}
+
+export interface EntityInfo {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface SummaryTotals {
+  activities: number;
+  expenses: number;
+  usersExpected: number;
+  usersSubmitted: number;
+  complianceRate: number;
+}
+
+export interface SummaryResponse {
+  period: PeriodInfo;
+  scope: 'personal' | 'entity';
+  entity: EntityInfo;
+  totals: SummaryTotals;
+}
+
+export interface TypeBreakdown {
+  typeId: string;
+  name: string;
+  count: number;
+  expenses: number;
+}
+
+export interface EntityBreakdown {
+  entityId: string;
+  name: string;
+  type: string;
+  count: number;
+  expenses: number;
+  compliance: {
+    submitted: number;
+    total: number;
+  };
+}
+
+export interface UserBreakdown {
+  userId: string;
+  name: string;
+  count: number;
+  expenses: number;
+}
+
+export interface BreakdownsResponse {
+  byType: TypeBreakdown[];
+  byEntity: EntityBreakdown[];
+  byUser: UserBreakdown[];
+}
+
+export interface SubmittedUser {
+  userId: string;
+  name: string;
+  count: number;
+  lastActivity: string;
+}
+
+export interface NotSubmittedUser {
+  userId: string;
+  name: string;
+  roles: string[];
+  entity: string;
+}
+
+export interface ComplianceResponse {
+  submitted: SubmittedUser[];
+  notSubmitted: NotSubmittedUser[];
+}
+
+export interface TrendPeriod {
+  periodId: string;
+  startDate: string;
+  endDate: string;
+  activities: number;
+  expenses: number;
+  complianceRate: number;
+  usersSubmitted: number;
+  usersExpected: number;
+}
+
+export interface TrendsResponse {
+  periods: TrendPeriod[];
+}
+
+export interface PeriodSummary {
+  periodId: string;
+  dates: string;
+  activities: number;
+  expenses: number;
+  complianceRate: number;
+  usersActive: number;
+}
+
+export interface Change {
+  value: number;
+  percent: number;
+}
+
+export interface ComparisonChanges {
+  activities: Change;
+  expenses: Change;
+  complianceRate: Change;
+  usersActive: Change;
+}
+
+export interface ComparisonResponse {
+  current: PeriodSummary;
+  previous: PeriodSummary;
+  changes: ComparisonChanges;
+}
+
+export interface TopPerformer {
+  userId: string;
+  name: string;
+  entity: string;
+  count: number;
+  expenses: number;
+}
+
+export interface LowCompliance {
+  entityId: string;
+  name: string;
+  rate: number;
+  missing: number;
+}
+
+export interface InactiveUser {
+  userId: string;
+  name: string;
+  entity: string;
+  periodsInactive: number;
+}
+
+export interface RankingsResponse {
+  topPerformers: TopPerformer[];
+  lowestCompliance: LowCompliance[];
+  inactiveUsers: InactiveUser[];
+}
+
+export interface ExpenseByType {
+  typeId: string;
+  name: string;
+  total: number;
+  percent: number;
+  avgPerActivity: number;
+}
+
+export interface ExpenseByEntity {
+  entityId: string;
+  name: string;
+  total: number;
+  percent: number;
+  perUser: number;
+}
+
+export interface ExpenseByUser {
+  userId: string;
+  name: string;
+  total: number;
+  percent: number;
+}
+
+export interface ExpensesResponse {
+  total: number;
+  byType: ExpenseByType[];
+  byEntity: ExpenseByEntity[];
+  byUser: ExpenseByUser[];
+}

--- a/backend/src/reports/query/reports-activity-query.factory.ts
+++ b/backend/src/reports/query/reports-activity-query.factory.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { Activity } from '../../activity/activity.entity';
+import { ActivityStatus } from '../../activity/activity-status.enum';
+
+@Injectable()
+export class ReportsActivityQueryFactory {
+  constructor(
+    @InjectRepository(Activity)
+    private readonly activityRepo: Repository<Activity>,
+  ) {}
+
+  buildActivityQuery(
+    actorUserId: string,
+    entityIds: string[],
+    timeScope: { periodIds?: string[]; dateFrom?: string; dateTo?: string },
+    filterUserId?: string,
+  ): SelectQueryBuilder<Activity> {
+    const qb = this.activityRepo
+      .createQueryBuilder('activity')
+      .leftJoinAndSelect('activity.user', 'user')
+      .leftJoinAndSelect('user.entity', 'entity')
+      .leftJoinAndSelect('activity.activityType', 'activityType')
+      .where('activity.status = :status', { status: ActivityStatus.ACTIVE });
+
+    if (filterUserId) {
+      qb.andWhere('activity.userId = :filterUserId', { filterUserId });
+    } else {
+      qb.andWhere('user.entity_id IN (:...entityIds)', { entityIds });
+    }
+
+    if (timeScope.periodIds) {
+      qb.andWhere('activity.reportingPeriodId IN (:...periodIds)', {
+        periodIds: timeScope.periodIds,
+      });
+    } else if (timeScope.dateFrom && timeScope.dateTo) {
+      qb.andWhere('activity.activityDate BETWEEN :dateFrom AND :dateTo', {
+        dateFrom: timeScope.dateFrom,
+        dateTo: timeScope.dateTo,
+      });
+    }
+
+    return qb;
+  }
+}

--- a/backend/src/reports/reports.controller.spec.ts
+++ b/backend/src/reports/reports.controller.spec.ts
@@ -1,0 +1,295 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReportsController } from './reports.controller';
+import { ReportsService } from './reports.service';
+import { IdentityResolutionService } from '../auth/identity-resolution.service';
+
+describe('ReportsController', () => {
+  let controller: ReportsController;
+  let reportsService: ReportsService;
+  let identityService: IdentityResolutionService;
+
+  const mockReportsService = {
+    getSummary: jest.fn(),
+    getBreakdowns: jest.fn(),
+    getCompliance: jest.fn(),
+    getTrends: jest.fn(),
+    getComparison: jest.fn(),
+    getRankings: jest.fn(),
+    getExpenses: jest.fn(),
+  };
+
+  const mockIdentityService = {
+    resolveUserBySubAndIssuer: jest.fn(),
+  };
+
+  const mockRequest = {
+    user: {
+      sub: 'auth0|123456',
+      iss: 'https://example.auth0.com/',
+    },
+  };
+
+  const mockUser = {
+    id: 'user-1',
+    email: 'user@example.com',
+    username: 'testuser',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReportsController],
+      providers: [
+        {
+          provide: ReportsService,
+          useValue: mockReportsService,
+        },
+        {
+          provide: IdentityResolutionService,
+          useValue: mockIdentityService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ReportsController>(ReportsController);
+    reportsService = module.get<ReportsService>(ReportsService);
+    identityService = module.get<IdentityResolutionService>(IdentityResolutionService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getSummary', () => {
+    it('should return summary data', async () => {
+      const mockSummary = {
+        period: {
+          id: 'period-1',
+          startDate: '2024-12-01',
+          endDate: '2024-12-14',
+          status: 'active',
+        },
+        scope: 'entity' as const,
+        entity: { id: 'entity-1', name: 'Campo Seattle', type: 'FIELD' },
+        totals: {
+          activities: 71,
+          expenses: 380.0,
+          usersExpected: 20,
+          usersSubmitted: 15,
+          complianceRate: 0.75,
+        },
+      };
+
+      mockIdentityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser);
+      mockReportsService.getSummary.mockResolvedValue(mockSummary);
+
+      const result = await controller.getSummary(mockRequest as any, {});
+
+      expect(identityService.resolveUserBySubAndIssuer).toHaveBeenCalledWith(
+        mockRequest.user.sub,
+        mockRequest.user.iss,
+      );
+      expect(reportsService.getSummary).toHaveBeenCalledWith('user-1', {});
+      expect(result).toEqual(mockSummary);
+    });
+
+    it('should pass query parameters to service', async () => {
+      mockIdentityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser);
+      mockReportsService.getSummary.mockResolvedValue({} as any);
+
+      const query = { periodId: 'period-1', entityId: 'entity-1' };
+      await controller.getSummary(mockRequest as any, query);
+
+      expect(reportsService.getSummary).toHaveBeenCalledWith('user-1', query);
+    });
+  });
+
+  describe('getBreakdowns', () => {
+    it('should return breakdowns data', async () => {
+      const mockBreakdowns = {
+        byType: [{ typeId: 'type-1', name: 'Visitas a Hogares', count: 45, expenses: 230.0 }],
+        byEntity: [
+          {
+            entityId: 'entity-1',
+            name: 'Campo Seattle',
+            type: 'FIELD',
+            count: 28,
+            expenses: 180.0,
+            compliance: { submitted: 5, total: 6 },
+          },
+        ],
+        byUser: [{ userId: 'user-1', name: 'María García', count: 12, expenses: 150.0 }],
+      };
+
+      mockIdentityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser);
+      mockReportsService.getBreakdowns.mockResolvedValue(mockBreakdowns);
+
+      const result = await controller.getBreakdowns(mockRequest as any, {});
+
+      expect(reportsService.getBreakdowns).toHaveBeenCalledWith('user-1', {});
+      expect(result).toEqual(mockBreakdowns);
+    });
+  });
+
+  describe('getCompliance', () => {
+    it('should return compliance data', async () => {
+      const mockCompliance = {
+        submitted: [
+          {
+            userId: 'user-1',
+            name: 'María García',
+            count: 12,
+            lastActivity: '2024-12-12',
+          },
+        ],
+        notSubmitted: [
+          {
+            userId: 'user-2',
+            name: 'Carlos Ruiz',
+            roles: ['Misionero'],
+            entity: 'Campo Seattle',
+          },
+        ],
+      };
+
+      mockIdentityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser);
+      mockReportsService.getCompliance.mockResolvedValue(mockCompliance);
+
+      const result = await controller.getCompliance(mockRequest as any, {});
+
+      expect(reportsService.getCompliance).toHaveBeenCalledWith('user-1', {});
+      expect(result).toEqual(mockCompliance);
+    });
+  });
+
+  describe('getTrends', () => {
+    it('should return trends data', async () => {
+      const mockTrends = {
+        periods: [
+          {
+            periodId: 'period-1',
+            startDate: '2024-12-01',
+            endDate: '2024-12-14',
+            activities: 71,
+            expenses: 380.0,
+            complianceRate: 0.75,
+            usersSubmitted: 15,
+            usersExpected: 20,
+          },
+        ],
+      };
+
+      mockIdentityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser);
+      mockReportsService.getTrends.mockResolvedValue(mockTrends);
+
+      const result = await controller.getTrends(mockRequest as any, {});
+
+      expect(reportsService.getTrends).toHaveBeenCalledWith('user-1', {});
+      expect(result).toEqual(mockTrends);
+    });
+  });
+
+  describe('getComparison', () => {
+    it('should return comparison data', async () => {
+      const mockComparison = {
+        current: {
+          periodId: 'period-1',
+          dates: 'Dic 1-14',
+          activities: 71,
+          expenses: 380.0,
+          complianceRate: 0.75,
+          usersActive: 15,
+        },
+        previous: {
+          periodId: 'period-2',
+          dates: 'Nov 17-30',
+          activities: 68,
+          expenses: 320.0,
+          complianceRate: 0.8,
+          usersActive: 16,
+        },
+        changes: {
+          activities: { value: 3, percent: 4.4 },
+          expenses: { value: 60.0, percent: 18.75 },
+          complianceRate: { value: -0.05, percent: -6.25 },
+          usersActive: { value: -1, percent: -6.25 },
+        },
+      };
+
+      mockIdentityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser);
+      mockReportsService.getComparison.mockResolvedValue(mockComparison);
+
+      const result = await controller.getComparison(mockRequest as any, {});
+
+      expect(reportsService.getComparison).toHaveBeenCalledWith('user-1', {});
+      expect(result).toEqual(mockComparison);
+    });
+  });
+
+  describe('getRankings', () => {
+    it('should return rankings data', async () => {
+      const mockRankings = {
+        topPerformers: [
+          {
+            userId: 'user-1',
+            name: 'María García',
+            entity: 'Seattle',
+            count: 12,
+            expenses: 150.0,
+          },
+        ],
+        lowestCompliance: [{ entityId: 'entity-2', name: 'Campo Tacoma', rate: 0.5, missing: 3 }],
+        inactiveUsers: [
+          {
+            userId: 'user-3',
+            name: 'Carlos Ruiz',
+            entity: 'Tacoma',
+            periodsInactive: 3,
+          },
+        ],
+      };
+
+      mockIdentityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser);
+      mockReportsService.getRankings.mockResolvedValue(mockRankings);
+
+      const result = await controller.getRankings(mockRequest as any, { limit: 5 });
+
+      expect(reportsService.getRankings).toHaveBeenCalledWith('user-1', { limit: 5 });
+      expect(result).toEqual(mockRankings);
+    });
+  });
+
+  describe('getExpenses', () => {
+    it('should return expenses data', async () => {
+      const mockExpenses = {
+        total: 380.0,
+        byType: [
+          {
+            typeId: 'type-1',
+            name: 'Visitas a Hogares',
+            total: 230.0,
+            percent: 60.5,
+            avgPerActivity: 5.11,
+          },
+        ],
+        byEntity: [
+          {
+            entityId: 'entity-1',
+            name: 'Campo Seattle',
+            total: 180.0,
+            percent: 47.4,
+            perUser: 30.0,
+          },
+        ],
+        byUser: [{ userId: 'user-1', name: 'María García', total: 150.0, percent: 39.5 }],
+      };
+
+      mockIdentityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser);
+      mockReportsService.getExpenses.mockResolvedValue(mockExpenses);
+
+      const result = await controller.getExpenses(mockRequest as any, {});
+
+      expect(reportsService.getExpenses).toHaveBeenCalledWith('user-1', {});
+      expect(result).toEqual(mockExpenses);
+    });
+  });
+});

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -1,0 +1,88 @@
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { ReportsService } from './reports.service';
+import { ReportQueryDto, RankingsQueryDto } from './dto/report-query.dto';
+import {
+  SummaryResponse,
+  BreakdownsResponse,
+  ComplianceResponse,
+  TrendsResponse,
+  ComparisonResponse,
+  RankingsResponse,
+  ExpensesResponse,
+} from './dto/report-responses.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { IdentityResolutionService } from '../auth/identity-resolution.service';
+import { Request } from 'express';
+import { JwtValidatedUser } from '../auth/jwt.strategy';
+
+@Controller('reports')
+@UseGuards(JwtAuthGuard)
+export class ReportsController {
+  constructor(
+    private readonly reportsService: ReportsService,
+    private readonly identityService: IdentityResolutionService,
+  ) {}
+
+  private async getUserIdFromRequest(req: Request): Promise<string> {
+    const { sub, iss } = (req.user as JwtValidatedUser) ?? {};
+    const user = await this.identityService.resolveUserBySubAndIssuer(sub, iss);
+    return user.id;
+  }
+
+  @Get('summary')
+  async getSummary(@Req() req: Request, @Query() query: ReportQueryDto): Promise<SummaryResponse> {
+    const userId = await this.getUserIdFromRequest(req);
+    return this.reportsService.getSummary(userId, query);
+  }
+
+  @Get('breakdowns')
+  async getBreakdowns(
+    @Req() req: Request,
+    @Query() query: ReportQueryDto,
+  ): Promise<BreakdownsResponse> {
+    const userId = await this.getUserIdFromRequest(req);
+    return this.reportsService.getBreakdowns(userId, query);
+  }
+
+  @Get('compliance')
+  async getCompliance(
+    @Req() req: Request,
+    @Query() query: ReportQueryDto,
+  ): Promise<ComplianceResponse> {
+    const userId = await this.getUserIdFromRequest(req);
+    return this.reportsService.getCompliance(userId, query);
+  }
+
+  @Get('trends')
+  async getTrends(@Req() req: Request, @Query() query: ReportQueryDto): Promise<TrendsResponse> {
+    const userId = await this.getUserIdFromRequest(req);
+    return this.reportsService.getTrends(userId, query);
+  }
+
+  @Get('comparison')
+  async getComparison(
+    @Req() req: Request,
+    @Query() query: ReportQueryDto,
+  ): Promise<ComparisonResponse> {
+    const userId = await this.getUserIdFromRequest(req);
+    return this.reportsService.getComparison(userId, query);
+  }
+
+  @Get('rankings')
+  async getRankings(
+    @Req() req: Request,
+    @Query() query: RankingsQueryDto,
+  ): Promise<RankingsResponse> {
+    const userId = await this.getUserIdFromRequest(req);
+    return this.reportsService.getRankings(userId, query);
+  }
+
+  @Get('expenses')
+  async getExpenses(
+    @Req() req: Request,
+    @Query() query: ReportQueryDto,
+  ): Promise<ExpensesResponse> {
+    const userId = await this.getUserIdFromRequest(req);
+    return this.reportsService.getExpenses(userId, query);
+  }
+}

--- a/backend/src/reports/reports.module.ts
+++ b/backend/src/reports/reports.module.ts
@@ -1,0 +1,43 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ReportsController } from './reports.controller';
+import { ReportsService } from './reports.service';
+import { Activity } from '../activity/activity.entity';
+import { User } from '../users/user.entity';
+import { Entity } from '../entities/entity.entity';
+import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
+import { ActivityType } from '../activities-type/activity-type.entity';
+import { AuthModule } from '../auth/auth.modules';
+import { ReportsAccessService } from './access/reports-access.service';
+import { ReportsTimeScopeService } from './time/reports-time-scope.service';
+import { ReportsActivityQueryFactory } from './query/reports-activity-query.factory';
+import { SummaryCalculator } from './calculators/summary.calculator';
+import { BreakdownsCalculator } from './calculators/breakdowns.calculator';
+import { ComplianceCalculator } from './calculators/compliance.calculator';
+import { TrendsCalculator } from './calculators/trends.calculator';
+import { ComparisonCalculator } from './calculators/comparison.calculator';
+import { RankingsCalculator } from './calculators/rankings.calculator';
+import { ExpensesCalculator } from './calculators/expenses.calculator';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Activity, User, Entity, ReportingPeriod, ActivityType]),
+    AuthModule,
+  ],
+  controllers: [ReportsController],
+  providers: [
+    ReportsService,
+    ReportsAccessService,
+    ReportsTimeScopeService,
+    ReportsActivityQueryFactory,
+    SummaryCalculator,
+    BreakdownsCalculator,
+    ComplianceCalculator,
+    TrendsCalculator,
+    ComparisonCalculator,
+    RankingsCalculator,
+    ExpensesCalculator,
+  ],
+  exports: [ReportsService],
+})
+export class ReportsModule {}

--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -1,0 +1,638 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ReportsService } from './reports.service';
+import { Activity } from '../activity/activity.entity';
+import { User } from '../users/user.entity';
+import { Entity } from '../entities/entity.entity';
+import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
+import { ActivityType } from '../activities-type/activity-type.entity';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { ReportsAccessService } from './access/reports-access.service';
+import { ReportsTimeScopeService } from './time/reports-time-scope.service';
+import { ReportsActivityQueryFactory } from './query/reports-activity-query.factory';
+import { SummaryCalculator } from './calculators/summary.calculator';
+import { BreakdownsCalculator } from './calculators/breakdowns.calculator';
+import { ComplianceCalculator } from './calculators/compliance.calculator';
+import { TrendsCalculator } from './calculators/trends.calculator';
+import { ComparisonCalculator } from './calculators/comparison.calculator';
+import { RankingsCalculator } from './calculators/rankings.calculator';
+import { ExpensesCalculator } from './calculators/expenses.calculator';
+
+describe('ReportsService', () => {
+  let service: ReportsService;
+  let activityRepo: Repository<Activity>;
+  let userRepo: Repository<User>;
+  let entityRepo: Repository<Entity>;
+  let periodRepo: Repository<ReportingPeriod>;
+  let activityTypeRepo: Repository<ActivityType>;
+  let accessService: ReportsAccessService;
+  let timeScopeService: ReportsTimeScopeService;
+  let queryFactory: ReportsActivityQueryFactory;
+
+  const mockQueryBuilder = {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+    getOne: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportsService,
+        {
+          provide: ReportsAccessService,
+          useValue: {
+            getEntityHierarchy: jest.fn().mockResolvedValue(['entity-1']),
+            validateEntityInUserScope: jest.fn().mockResolvedValue(true),
+            validateUserInScope: jest.fn().mockResolvedValue(true),
+          },
+        },
+        {
+          provide: ReportsTimeScopeService,
+          useValue: {
+            getOrDetermineTimeScope: jest.fn(),
+          },
+        },
+        {
+          provide: ReportsActivityQueryFactory,
+          useValue: {
+            buildActivityQuery: jest.fn(() => mockQueryBuilder),
+          },
+        },
+        SummaryCalculator,
+        BreakdownsCalculator,
+        ComplianceCalculator,
+        TrendsCalculator,
+        ComparisonCalculator,
+        RankingsCalculator,
+        ExpensesCalculator,
+        {
+          provide: getRepositoryToken(Activity),
+          useValue: {
+            createQueryBuilder: jest.fn(() => mockQueryBuilder),
+            findOne: jest.fn().mockResolvedValue(null),
+            find: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            find: jest.fn().mockResolvedValue([]),
+            manager: {
+              query: jest.fn().mockResolvedValue([]),
+            },
+          },
+        },
+        {
+          provide: getRepositoryToken(Entity),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            find: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
+          provide: getRepositoryToken(ReportingPeriod),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            find: jest.fn().mockResolvedValue([]),
+            createQueryBuilder: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(ActivityType),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            find: jest.fn().mockResolvedValue([]),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ReportsService>(ReportsService);
+    activityRepo = module.get<Repository<Activity>>(getRepositoryToken(Activity));
+    userRepo = module.get<Repository<User>>(getRepositoryToken(User));
+    entityRepo = module.get<Repository<Entity>>(getRepositoryToken(Entity));
+    periodRepo = module.get<Repository<ReportingPeriod>>(getRepositoryToken(ReportingPeriod));
+    activityTypeRepo = module.get<Repository<ActivityType>>(getRepositoryToken(ActivityType));
+    accessService = module.get<ReportsAccessService>(ReportsAccessService);
+    timeScopeService = module.get<ReportsTimeScopeService>(ReportsTimeScopeService);
+    queryFactory = module.get<ReportsActivityQueryFactory>(ReportsActivityQueryFactory);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getSummary', () => {
+    it('should return personal summary for user without canViewReports permission', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: false },
+        entity: { id: 'entity-1', name: 'Campo Seattle', type: 'FIELD' },
+      };
+
+      const mockPeriod = {
+        id: 'period-1',
+        startDate: '2024-12-01',
+        endDate: '2024-12-14',
+        status: 'active',
+        entityId: 'entity-1',
+      };
+
+      const mockActivities = [
+        {
+          id: 'activity-1',
+          userId: 'user-1',
+          expenseAmount: '50.00',
+          activityTypeId: 'type-1',
+          user: mockUser,
+        },
+        {
+          id: 'activity-2',
+          userId: 'user-1',
+          expenseAmount: '30.00',
+          activityTypeId: 'type-1',
+          user: mockUser,
+        },
+      ];
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(entityRepo, 'findOne').mockResolvedValue(mockUser.entity as any);
+      jest.spyOn(timeScopeService, 'getOrDetermineTimeScope').mockResolvedValue({
+        periodIds: [mockPeriod.id],
+        period: mockPeriod as any,
+      });
+      mockQueryBuilder.getMany.mockResolvedValue(mockActivities);
+
+      const result = await service.getSummary('user-1', {});
+
+      expect(result.scope).toBe('personal');
+      expect(result.totals.activities).toBe(2);
+      expect(result.totals.expenses).toBe(80);
+      expect(result.totals.usersExpected).toBe(1);
+      expect(result.totals.usersSubmitted).toBe(1);
+      expect(result.totals.complianceRate).toBe(1);
+    });
+
+    it('should return entity summary for user with canViewReports permission', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: true },
+        entity: { id: 'entity-1', name: 'Campo Seattle', type: 'FIELD' },
+      };
+
+      const mockPeriod = {
+        id: 'period-1',
+        startDate: '2024-12-01',
+        endDate: '2024-12-14',
+        status: 'active',
+        entityId: 'entity-1',
+      };
+
+      const mockActivities = [
+        {
+          id: 'activity-1',
+          userId: 'user-1',
+          expenseAmount: '50.00',
+          activityTypeId: 'type-1',
+          user: { id: 'user-1', entity_id: 'entity-1' },
+        },
+        {
+          id: 'activity-2',
+          userId: 'user-2',
+          expenseAmount: '30.00',
+          activityTypeId: 'type-1',
+          user: { id: 'user-2', entity_id: 'entity-1' },
+        },
+      ];
+
+      const mockUsersInScope = [
+        { id: 'user-1', status: 'active' },
+        { id: 'user-2', status: 'active' },
+        { id: 'user-3', status: 'active' },
+      ];
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(entityRepo, 'findOne').mockResolvedValue(mockUser.entity as any);
+      jest.spyOn(timeScopeService, 'getOrDetermineTimeScope').mockResolvedValue({
+        periodIds: [mockPeriod.id],
+        period: mockPeriod as any,
+      });
+      jest.spyOn(userRepo, 'find').mockResolvedValue(mockUsersInScope as any);
+      mockQueryBuilder.getMany.mockResolvedValue(mockActivities);
+
+      const result = await service.getSummary('user-1', {});
+
+      expect(result.scope).toBe('entity');
+      expect(result.totals.activities).toBe(2);
+      expect(result.totals.expenses).toBe(80);
+      expect(result.totals.usersExpected).toBe(3);
+      expect(result.totals.usersSubmitted).toBe(2);
+      expect(result.totals.complianceRate).toBe(0.67);
+    });
+
+    it('should throw ForbiddenException when regular user tries to view entity report', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: false },
+        entity: { id: 'entity-1' },
+      };
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+
+      await expect(service.getSummary('user-1', { entityId: 'entity-2' })).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should throw ForbiddenException when user tries to view data outside their scope', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: true },
+        entity: { id: 'entity-1' },
+      };
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(accessService, 'validateEntityInUserScope').mockResolvedValue(false);
+
+      await expect(service.getSummary('user-1', { entityId: 'entity-2' })).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
+  describe('getBreakdowns', () => {
+    it('should return breakdowns by type, entity, and user', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: true },
+        entity: { id: 'entity-1' },
+      };
+
+      const mockPeriod = {
+        id: 'period-1',
+        startDate: '2024-12-01',
+        endDate: '2024-12-14',
+        status: 'active',
+        entityId: 'entity-1',
+      };
+
+      const mockActivities = [
+        {
+          id: 'activity-1',
+          userId: 'user-1',
+          activityTypeId: 'type-1',
+          expenseAmount: '50.00',
+          activityType: { name: 'Visitas' },
+          user: {
+            id: 'user-1',
+            entity_id: 'entity-1',
+            full_name: 'María García',
+            entity: { id: 'entity-1', name: 'Campo Seattle', type: 'FIELD' },
+          },
+        },
+        {
+          id: 'activity-2',
+          userId: 'user-2',
+          activityTypeId: 'type-1',
+          expenseAmount: '30.00',
+          activityType: { name: 'Visitas' },
+          user: {
+            id: 'user-2',
+            entity_id: 'entity-1',
+            full_name: 'Juan Pérez',
+            entity: { id: 'entity-1', name: 'Campo Seattle', type: 'FIELD' },
+          },
+        },
+      ];
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(periodRepo, 'findOne').mockResolvedValue(mockPeriod as any);
+      jest.spyOn(entityRepo, 'findOne').mockResolvedValue({ id: 'entity-1', children: [] } as any);
+      jest.spyOn(entityRepo, 'find').mockResolvedValue([]);
+      jest.spyOn(userRepo, 'find').mockResolvedValue([
+        { id: 'user-1', status: 'active' },
+        { id: 'user-2', status: 'active' },
+      ] as any);
+      mockQueryBuilder.getMany.mockResolvedValue(mockActivities);
+
+      const result = await service.getBreakdowns('user-1', {});
+
+      expect(result.byType).toHaveLength(1);
+      expect(result.byType[0].name).toBe('Visitas');
+      expect(result.byType[0].count).toBe(2);
+      expect(result.byType[0].expenses).toBe(80);
+
+      expect(result.byEntity).toHaveLength(1);
+      expect(result.byEntity[0].name).toBe('Campo Seattle');
+      expect(result.byEntity[0].count).toBe(2);
+
+      expect(result.byUser).toHaveLength(2);
+    });
+
+    it('should not include entity breakdown for regular users', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: false },
+        entity: { id: 'entity-1' },
+      };
+
+      const mockPeriod = {
+        id: 'period-1',
+        startDate: '2024-12-01',
+        endDate: '2024-12-14',
+        status: 'active',
+        entityId: 'entity-1',
+      };
+
+      const mockActivities = [
+        {
+          id: 'activity-1',
+          userId: 'user-1',
+          activityTypeId: 'type-1',
+          expenseAmount: '50.00',
+          activityType: { name: 'Visitas' },
+          user: {
+            id: 'user-1',
+            entity_id: 'entity-1',
+            full_name: 'María García',
+            entity: { id: 'entity-1', name: 'Campo Seattle', type: 'FIELD' },
+          },
+        },
+      ];
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(periodRepo, 'findOne').mockResolvedValue(mockPeriod as any);
+      mockQueryBuilder.getMany.mockResolvedValue(mockActivities);
+
+      const result = await service.getBreakdowns('user-1', {});
+
+      expect(result.byEntity).toHaveLength(0);
+      expect(result.byUser).toHaveLength(1);
+    });
+  });
+
+  describe('getCompliance', () => {
+    it('should throw ForbiddenException for users without canViewReports', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: false },
+      };
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+
+      await expect(service.getCompliance('user-1', {})).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return submitted and not submitted user lists', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: true },
+        entity: { id: 'entity-1' },
+      };
+
+      const mockPeriod = {
+        id: 'period-1',
+        startDate: '2024-12-01',
+        endDate: '2024-12-14',
+        status: 'active',
+        entityId: 'entity-1',
+      };
+
+      const mockActivities = [
+        {
+          id: 'activity-1',
+          userId: 'user-1',
+          activityDate: '2024-12-10',
+          user: { id: 'user-1' },
+        },
+      ];
+
+      const mockUsersInScope = [
+        {
+          id: 'user-1',
+          full_name: 'María García',
+          status: 'active',
+          entity: { name: 'Campo Seattle' },
+        },
+        {
+          id: 'user-2',
+          full_name: 'Juan Pérez',
+          status: 'active',
+          entity: { name: 'Campo Seattle' },
+        },
+      ];
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(entityRepo, 'findOne').mockResolvedValue({ id: 'entity-1', children: [] } as any);
+      jest.spyOn(timeScopeService, 'getOrDetermineTimeScope').mockResolvedValue({
+        periodIds: [mockPeriod.id],
+        period: mockPeriod as any,
+      });
+      jest.spyOn(userRepo, 'find').mockResolvedValue(mockUsersInScope as any);
+      jest.spyOn(userRepo.manager, 'query').mockResolvedValue([
+        { user_id: 'user-2', name: 'Misionero' },
+      ]);
+      mockQueryBuilder.getMany.mockResolvedValue(mockActivities);
+
+      const result = await service.getCompliance('user-1', {});
+
+      expect(result.submitted).toHaveLength(1);
+      expect(result.submitted[0].userId).toBe('user-1');
+      expect(result.submitted[0].count).toBe(1);
+
+      expect(result.notSubmitted).toHaveLength(1);
+      expect(result.notSubmitted[0].userId).toBe('user-2');
+      expect(result.notSubmitted[0].roles).toEqual(['Misionero']);
+    });
+  });
+
+  describe('getTrends', () => {
+    it('should return trends data for last 5 periods', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: true },
+        entity: { id: 'entity-1' },
+      };
+
+      const mockPeriods = [
+        {
+          id: 'period-1',
+          startDate: '2024-12-01',
+          endDate: '2024-12-14',
+          entityId: 'entity-1',
+        },
+        {
+          id: 'period-2',
+          startDate: '2024-11-17',
+          endDate: '2024-11-30',
+          entityId: 'entity-1',
+        },
+      ];
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(periodRepo, 'find').mockResolvedValue(mockPeriods as any);
+      jest.spyOn(entityRepo, 'findOne').mockResolvedValue({ id: 'entity-1', children: [] } as any);
+      jest.spyOn(entityRepo, 'find').mockResolvedValue([]);
+      jest.spyOn(userRepo, 'find').mockResolvedValue([{ id: 'user-1', status: 'active' }] as any);
+      mockQueryBuilder.getMany.mockResolvedValue([
+        { id: 'activity-1', userId: 'user-1', expenseAmount: '50.00' },
+      ]);
+
+      const result = await service.getTrends('user-1', {});
+
+      expect(result.periods).toHaveLength(2);
+      expect(result.periods[0].activities).toBe(1);
+      expect(result.periods[0].expenses).toBe(50);
+    });
+  });
+
+  describe('getRankings', () => {
+    it('should throw ForbiddenException for users without canViewReports', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: false },
+      };
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+
+      await expect(service.getRankings('user-1', {})).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return top performers, lowest compliance, and inactive users', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: true },
+        entity: { id: 'entity-1' },
+      };
+
+      const mockPeriod = {
+        id: 'period-1',
+        startDate: '2024-12-01',
+        endDate: '2024-12-14',
+        status: 'active',
+        entityId: 'entity-1',
+      };
+
+      const mockActivities = [
+        {
+          id: 'activity-1',
+          userId: 'user-1',
+          expenseAmount: '50.00',
+          user: {
+            id: 'user-1',
+            full_name: 'María García',
+            entity: { name: 'Campo Seattle', id: 'entity-1' },
+            entity_id: 'entity-1',
+          },
+        },
+      ];
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(periodRepo, 'findOne').mockResolvedValue(mockPeriod as any);
+      jest.spyOn(periodRepo, 'find').mockResolvedValue([mockPeriod, mockPeriod, mockPeriod] as any);
+      jest.spyOn(entityRepo, 'findOne').mockResolvedValue({ id: 'entity-1', children: [] } as any);
+      jest
+        .spyOn(entityRepo, 'find')
+        .mockResolvedValue([{ id: 'entity-1', name: 'Campo Seattle' }] as any);
+      jest.spyOn(userRepo, 'find').mockResolvedValue([
+        {
+          id: 'user-1',
+          status: 'active',
+          entity: { name: 'Campo Seattle' },
+        },
+      ] as any);
+      jest.spyOn(activityRepo, 'findOne').mockResolvedValue(null);
+      mockQueryBuilder.getMany.mockResolvedValue(mockActivities);
+
+      const result = await service.getRankings('user-1', { limit: 5 });
+
+      expect(result.topPerformers).toBeDefined();
+      expect(result.lowestCompliance).toBeDefined();
+      expect(result.inactiveUsers).toBeDefined();
+    });
+  });
+
+  describe('getExpenses', () => {
+    it('should return expense breakdown by type, entity, and user', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { canViewReports: true },
+        entity: { id: 'entity-1' },
+      };
+
+      const mockPeriod = {
+        id: 'period-1',
+        startDate: '2024-12-01',
+        endDate: '2024-12-14',
+        status: 'active',
+        entityId: 'entity-1',
+      };
+
+      const mockActivities = [
+        {
+          id: 'activity-1',
+          userId: 'user-1',
+          activityTypeId: 'type-1',
+          expenseAmount: '50.00',
+          activityType: { name: 'Visitas' },
+          user: {
+            id: 'user-1',
+            entity_id: 'entity-1',
+            full_name: 'María García',
+            entity: { id: 'entity-1', name: 'Campo Seattle' },
+          },
+        },
+        {
+          id: 'activity-2',
+          userId: 'user-1',
+          activityTypeId: 'type-1',
+          expenseAmount: '30.00',
+          activityType: { name: 'Visitas' },
+          user: {
+            id: 'user-1',
+            entity_id: 'entity-1',
+            full_name: 'María García',
+            entity: { id: 'entity-1', name: 'Campo Seattle' },
+          },
+        },
+      ];
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(periodRepo, 'findOne').mockResolvedValue(mockPeriod as any);
+      jest.spyOn(entityRepo, 'findOne').mockResolvedValue({ id: 'entity-1', children: [] } as any);
+      jest.spyOn(entityRepo, 'find').mockResolvedValue([]);
+      mockQueryBuilder.getMany.mockResolvedValue(mockActivities);
+
+      const result = await service.getExpenses('user-1', {});
+
+      expect(result.total).toBe(80);
+      expect(result.byType).toHaveLength(1);
+      expect(result.byType[0].total).toBe(80);
+      expect(result.byType[0].percent).toBe(100);
+      expect(result.byType[0].avgPerActivity).toBe(40);
+
+      expect(result.byUser).toHaveLength(1);
+      expect(result.byUser[0].total).toBe(80);
+      expect(result.byUser[0].percent).toBe(100);
+    });
+  });
+});

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -1,0 +1,422 @@
+import {
+  Injectable,
+  ForbiddenException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/user.entity';
+import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
+import { ReportQueryDto, RankingsQueryDto } from './dto/report-query.dto';
+import {
+  SummaryResponse,
+  BreakdownsResponse,
+  ComplianceResponse,
+  TrendsResponse,
+  ComparisonResponse,
+  RankingsResponse,
+  ExpensesResponse,
+} from './dto/report-responses.dto';
+import { ReportsAccessService } from './access/reports-access.service';
+import { ReportsTimeScopeService } from './time/reports-time-scope.service';
+import { ReportsActivityQueryFactory } from './query/reports-activity-query.factory';
+import { SummaryCalculator } from './calculators/summary.calculator';
+import { BreakdownsCalculator } from './calculators/breakdowns.calculator';
+import { ComplianceCalculator } from './calculators/compliance.calculator';
+import { TrendsCalculator } from './calculators/trends.calculator';
+import { ComparisonCalculator } from './calculators/comparison.calculator';
+import { RankingsCalculator } from './calculators/rankings.calculator';
+import { ExpensesCalculator } from './calculators/expenses.calculator';
+
+@Injectable()
+export class ReportsService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(ReportingPeriod)
+    private readonly periodRepo: Repository<ReportingPeriod>,
+    private readonly accessService: ReportsAccessService,
+    private readonly timeScopeService: ReportsTimeScopeService,
+    private readonly queryFactory: ReportsActivityQueryFactory,
+    private readonly summaryCalculator: SummaryCalculator,
+    private readonly breakdownsCalculator: BreakdownsCalculator,
+    private readonly complianceCalculator: ComplianceCalculator,
+    private readonly trendsCalculator: TrendsCalculator,
+    private readonly comparisonCalculator: ComparisonCalculator,
+    private readonly rankingsCalculator: RankingsCalculator,
+    private readonly expensesCalculator: ExpensesCalculator,
+  ) {}
+
+  async getSummary(actorUserId: string, query: ReportQueryDto): Promise<SummaryResponse> {
+    const actor = await this.userRepo.findOne({
+      where: { id: actorUserId },
+      relations: ['role', 'entity'],
+    });
+
+    if (!actor) {
+      throw new NotFoundException('User not found');
+    }
+
+    const canViewReports = actor.role.canViewReports;
+
+    const targetEntityId = query.entityId || actor.entity_id;
+    if (query.entityId && canViewReports) {
+      const isInScope = await this.accessService.validateEntityInUserScope(
+        actorUserId,
+        query.entityId,
+      );
+      if (!isInScope) {
+        throw new ForbiddenException('Entity is not in your scope');
+      }
+    } else if (query.entityId && !canViewReports) {
+      throw new ForbiddenException('You do not have permission to view entity reports');
+    }
+
+    if (query.userId) {
+      if (!canViewReports && query.userId !== actorUserId) {
+        throw new ForbiddenException('You can only view your own data');
+      }
+      if (canViewReports) {
+        const isInScope = await this.accessService.validateUserInScope(actorUserId, query.userId);
+        if (!isInScope) {
+          throw new ForbiddenException('User is not in your scope');
+        }
+      }
+    }
+
+    const entityIds =
+      canViewReports && !query.userId
+        ? await this.accessService.getEntityHierarchy(targetEntityId)
+        : [targetEntityId];
+
+    const timeScope = await this.timeScopeService.getOrDetermineTimeScope(query, actor.entity_id);
+    const qb = this.queryFactory.buildActivityQuery(
+      actorUserId,
+      entityIds,
+      timeScope,
+      query.userId || (!canViewReports ? actorUserId : undefined),
+    );
+
+    const activities = await qb.getMany();
+
+    return this.summaryCalculator.calculate(
+      activities,
+      targetEntityId,
+      entityIds,
+      canViewReports,
+      !!query.userId,
+      timeScope,
+    );
+  }
+
+  async getBreakdowns(actorUserId: string, query: ReportQueryDto): Promise<BreakdownsResponse> {
+    const actor = await this.userRepo.findOne({
+      where: { id: actorUserId },
+      relations: ['role', 'entity'],
+    });
+
+    if (!actor) {
+      throw new NotFoundException('User not found');
+    }
+
+    const canViewReports = actor.role.canViewReports;
+
+    const targetEntityId = query.entityId || actor.entity_id;
+    if (query.entityId && canViewReports) {
+      const isInScope = await this.accessService.validateEntityInUserScope(
+        actorUserId,
+        query.entityId,
+      );
+      if (!isInScope) {
+        throw new ForbiddenException('Entity is not in your scope');
+      }
+    } else if (query.entityId && !canViewReports) {
+      throw new ForbiddenException('You do not have permission to view entity reports');
+    }
+
+    if (query.userId) {
+      if (!canViewReports && query.userId !== actorUserId) {
+        throw new ForbiddenException('You can only view your own data');
+      }
+      if (canViewReports) {
+        const isInScope = await this.accessService.validateUserInScope(actorUserId, query.userId);
+        if (!isInScope) {
+          throw new ForbiddenException('User is not in your scope');
+        }
+      }
+    }
+
+    const entityIds =
+      canViewReports && !query.userId
+        ? await this.accessService.getEntityHierarchy(targetEntityId)
+        : [targetEntityId];
+
+    const timeScope = await this.timeScopeService.getOrDetermineTimeScope(query, actor.entity_id);
+    const qb = this.queryFactory.buildActivityQuery(
+      actorUserId,
+      entityIds,
+      timeScope,
+      query.userId || (!canViewReports ? actorUserId : undefined),
+    );
+
+    const activities = await qb.getMany();
+
+    return this.breakdownsCalculator.calculate(activities, canViewReports, !!query.userId);
+  }
+
+  async getCompliance(actorUserId: string, query: ReportQueryDto): Promise<ComplianceResponse> {
+    const actor = await this.userRepo.findOne({
+      where: { id: actorUserId },
+      relations: ['role', 'entity'],
+    });
+
+    if (!actor) {
+      throw new NotFoundException('User not found');
+    }
+
+    if (!actor.role.canViewReports) {
+      throw new ForbiddenException('You do not have permission to view compliance reports');
+    }
+
+    const targetEntityId = query.entityId || actor.entity_id;
+    if (query.entityId) {
+      const isInScope = await this.accessService.validateEntityInUserScope(
+        actorUserId,
+        query.entityId,
+      );
+      if (!isInScope) {
+        throw new ForbiddenException('Entity is not in your scope');
+      }
+    }
+
+    const entityIds = await this.accessService.getEntityHierarchy(targetEntityId);
+    const timeScope = await this.timeScopeService.getOrDetermineTimeScope(query, actor.entity_id);
+
+    const qb = this.queryFactory.buildActivityQuery(actorUserId, entityIds, timeScope);
+    const activities = await qb.getMany();
+
+    return this.complianceCalculator.calculate(activities, entityIds);
+  }
+
+  async getTrends(actorUserId: string, query: ReportQueryDto): Promise<TrendsResponse> {
+    const actor = await this.userRepo.findOne({
+      where: { id: actorUserId },
+      relations: ['role', 'entity'],
+    });
+
+    if (!actor) {
+      throw new NotFoundException('User not found');
+    }
+
+    const canViewReports = actor.role.canViewReports;
+    const targetEntityId = query.entityId || actor.entity_id;
+
+    if (query.entityId && canViewReports) {
+      const isInScope = await this.accessService.validateEntityInUserScope(
+        actorUserId,
+        query.entityId,
+      );
+      if (!isInScope) {
+        throw new ForbiddenException('Entity is not in your scope');
+      }
+    } else if (query.entityId && !canViewReports) {
+      throw new ForbiddenException('You do not have permission to view entity reports');
+    }
+
+    const periods = await this.periodRepo.find({
+      where: { entityId: targetEntityId },
+      order: { startDate: 'DESC' },
+      take: 5,
+    });
+
+    if (periods.length === 0) {
+      throw new NotFoundException('No reporting periods found');
+    }
+
+    const entityIds =
+      canViewReports && !query.userId
+        ? await this.accessService.getEntityHierarchy(targetEntityId)
+        : [targetEntityId];
+
+    const periodsData = await Promise.all(
+      periods.map(async (period) => {
+        const qb = this.queryFactory.buildActivityQuery(
+          actorUserId,
+          entityIds,
+          { periodIds: [period.id] },
+          query.userId || (!canViewReports ? actorUserId : undefined),
+        );
+        const activities = await qb.getMany();
+
+        return { period, activities };
+      }),
+    );
+
+    return this.trendsCalculator.calculate(periodsData, entityIds, canViewReports, !!query.userId);
+  }
+
+  async getComparison(actorUserId: string, query: ReportQueryDto): Promise<ComparisonResponse> {
+    const actor = await this.userRepo.findOne({
+      where: { id: actorUserId },
+      relations: ['role', 'entity'],
+    });
+
+    if (!actor) {
+      throw new NotFoundException('User not found');
+    }
+
+    const canViewReports = actor.role.canViewReports;
+    const targetEntityId = query.entityId || actor.entity_id;
+
+    if (query.entityId && canViewReports) {
+      const isInScope = await this.accessService.validateEntityInUserScope(
+        actorUserId,
+        query.entityId,
+      );
+      if (!isInScope) {
+        throw new ForbiddenException('Entity is not in your scope');
+      }
+    } else if (query.entityId && !canViewReports) {
+      throw new ForbiddenException('You do not have permission to view entity reports');
+    }
+
+    const periods = await this.periodRepo.find({
+      where: { entityId: targetEntityId },
+      order: { startDate: 'DESC' },
+      take: 2,
+    });
+
+    if (periods.length < 2) {
+      throw new BadRequestException('Not enough periods for comparison');
+    }
+
+    const [currentPeriod, previousPeriod] = periods;
+    const entityIds =
+      canViewReports && !query.userId
+        ? await this.accessService.getEntityHierarchy(targetEntityId)
+        : [targetEntityId];
+
+    const currentQb = this.queryFactory.buildActivityQuery(
+      actorUserId,
+      entityIds,
+      { periodIds: [currentPeriod.id] },
+      query.userId || (!canViewReports ? actorUserId : undefined),
+    );
+    const currentActivities = await currentQb.getMany();
+
+    const previousQb = this.queryFactory.buildActivityQuery(
+      actorUserId,
+      entityIds,
+      { periodIds: [previousPeriod.id] },
+      query.userId || (!canViewReports ? actorUserId : undefined),
+    );
+    const previousActivities = await previousQb.getMany();
+
+    return this.comparisonCalculator.calculate(
+      currentPeriod,
+      previousPeriod,
+      currentActivities,
+      previousActivities,
+      entityIds,
+      canViewReports,
+      !!query.userId,
+    );
+  }
+
+  async getRankings(actorUserId: string, query: RankingsQueryDto): Promise<RankingsResponse> {
+    const actor = await this.userRepo.findOne({
+      where: { id: actorUserId },
+      relations: ['role', 'entity'],
+    });
+
+    if (!actor) {
+      throw new NotFoundException('User not found');
+    }
+
+    if (!actor.role.canViewReports) {
+      throw new ForbiddenException('You do not have permission to view rankings');
+    }
+
+    const targetEntityId = query.entityId || actor.entity_id;
+    if (query.entityId) {
+      const isInScope = await this.accessService.validateEntityInUserScope(
+        actorUserId,
+        query.entityId,
+      );
+      if (!isInScope) {
+        throw new ForbiddenException('Entity is not in your scope');
+      }
+    }
+
+    const entityIds = await this.accessService.getEntityHierarchy(targetEntityId);
+    const timeScope = await this.timeScopeService.getOrDetermineTimeScope(query, actor.entity_id);
+    const limit = query.limit || 5;
+
+    const qb = this.queryFactory.buildActivityQuery(actorUserId, entityIds, timeScope);
+    const activities = await qb.getMany();
+
+    const recentPeriods = await this.periodRepo.find({
+      where: { entityId: targetEntityId },
+      order: { startDate: 'DESC' },
+      take: 3,
+    });
+
+    return this.rankingsCalculator.calculate(activities, entityIds, recentPeriods, limit);
+  }
+
+  async getExpenses(actorUserId: string, query: ReportQueryDto): Promise<ExpensesResponse> {
+    const actor = await this.userRepo.findOne({
+      where: { id: actorUserId },
+      relations: ['role', 'entity'],
+    });
+
+    if (!actor) {
+      throw new NotFoundException('User not found');
+    }
+
+    const canViewReports = actor.role.canViewReports;
+    const targetEntityId = query.entityId || actor.entity_id;
+
+    if (query.entityId && canViewReports) {
+      const isInScope = await this.accessService.validateEntityInUserScope(
+        actorUserId,
+        query.entityId,
+      );
+      if (!isInScope) {
+        throw new ForbiddenException('Entity is not in your scope');
+      }
+    } else if (query.entityId && !canViewReports) {
+      throw new ForbiddenException('You do not have permission to view entity reports');
+    }
+
+    if (query.userId) {
+      if (!canViewReports && query.userId !== actorUserId) {
+        throw new ForbiddenException('You can only view your own data');
+      }
+      if (canViewReports) {
+        const isInScope = await this.accessService.validateUserInScope(actorUserId, query.userId);
+        if (!isInScope) {
+          throw new ForbiddenException('User is not in your scope');
+        }
+      }
+    }
+
+    const entityIds =
+      canViewReports && !query.userId
+        ? await this.accessService.getEntityHierarchy(targetEntityId)
+        : [targetEntityId];
+
+    const timeScope = await this.timeScopeService.getOrDetermineTimeScope(query, actor.entity_id);
+    const qb = this.queryFactory.buildActivityQuery(
+      actorUserId,
+      entityIds,
+      timeScope,
+      query.userId || (!canViewReports ? actorUserId : undefined),
+    );
+
+    const activities = await qb.getMany();
+
+    return this.expensesCalculator.calculate(activities, canViewReports, !!query.userId);
+  }
+}

--- a/backend/src/reports/time/reports-time-scope.service.ts
+++ b/backend/src/reports/time/reports-time-scope.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ReportingPeriod } from '../../reporting-periods/reporting-period.entity';
+import { ReportingPeriodStatus } from '../../reporting-periods/reporting-period-status.enum';
+import { ReportQueryDto } from '../dto/report-query.dto';
+
+@Injectable()
+export class ReportsTimeScopeService {
+  constructor(
+    @InjectRepository(ReportingPeriod)
+    private readonly periodRepo: Repository<ReportingPeriod>,
+  ) {}
+
+  async getOrDetermineTimeScope(
+    query: ReportQueryDto,
+    userEntityId: string,
+  ): Promise<{
+    periodIds?: string[];
+    dateFrom?: string;
+    dateTo?: string;
+    period?: ReportingPeriod;
+  }> {
+    if (query.periodId) {
+      const period = await this.periodRepo.findOne({
+        where: { id: query.periodId },
+      });
+      if (!period) {
+        throw new NotFoundException('Reporting period not found');
+      }
+      return { periodIds: [query.periodId], period };
+    }
+
+    if (query.dateFrom && query.dateTo) {
+      return { dateFrom: query.dateFrom, dateTo: query.dateTo };
+    }
+
+    const activePeriod = await this.periodRepo.findOne({
+      where: { entityId: userEntityId, status: ReportingPeriodStatus.ACTIVE },
+    });
+
+    if (!activePeriod) {
+      throw new NotFoundException('No active reporting period found for your entity');
+    }
+
+    return { periodIds: [activePeriod.id], period: activePeriod };
+  }
+}

--- a/backend/src/roles/role.constants.ts
+++ b/backend/src/roles/role.constants.ts
@@ -19,11 +19,7 @@ export const LEADERSHIP_ROLES = [
 /**
  * Roles that can create and manage their own activities
  */
-export const MISSIONARY_ROLES = [
-  'Missionary',
-  'Field Secretary',
-  'Association Secretary',
-] as const;
+export const MISSIONARY_ROLES = ['Missionary', 'Field Secretary', 'Association Secretary'] as const;
 
 /**
  * Executive roles with entity management permissions

--- a/backend/src/roles/roles.controller.ts
+++ b/backend/src/roles/roles.controller.ts
@@ -118,11 +118,7 @@ export class RolesController {
     @Query('active') active?: string,
   ) {
     const activeFilter = active === 'true' ? true : active === 'false' ? false : undefined;
-    const assignments = await this.roleAssignment.listAssignments(
-      entityId,
-      userId,
-      activeFilter,
-    );
+    const assignments = await this.roleAssignment.listAssignments(entityId, userId, activeFilter);
     return assignments.map((a) => AssignmentResponseDto.fromEntity(a));
   }
 


### PR DESCRIPTION
## Summary
Implements comprehensive reports and analytics module with 7 endpoints for activity tracking, compliance monitoring, and expense reporting.

## Endpoints Added
- `GET /reports/summary` - Overall metrics and totals
- `GET /reports/breakdowns` - Data grouped by type, entity, and user
- `GET /reports/compliance` - User submission tracking
- `GET /reports/trends` - Historical data across periods
- `GET /reports/comparison` - Current vs previous period analysis
- `GET /reports/rankings` - Top performers and compliance metrics
- `GET /reports/expenses` - Expense breakdown and analysis

## Features
- Role-based access control (canViewReports permission)
- Hierarchical entity scoping
- Flexible time filtering (period ID, date ranges, or active period)
- Comprehensive unit tests
- Full documentation

## Technical Changes
- Added reports module with service, controller, DTOs
- Updated JwtStrategy to include role information
- Fixed pre-existing build error in migration script