### PR TITLE
feat: Add Reports page with monthly activity summaries

### DIFF
--- a/frontend/lib/models/report_breakdown.dart
+++ b/frontend/lib/models/report_breakdown.dart
@@ -1,0 +1,19 @@
+class ReportBreakdown {
+  final String activityTypeName;
+  final int count;
+  final double totalExpenses;
+
+  const ReportBreakdown({
+    required this.activityTypeName,
+    required this.count,
+    required this.totalExpenses,
+  });
+
+  factory ReportBreakdown.fromApi(Map<String, dynamic> data) {
+    return ReportBreakdown(
+      activityTypeName: data['name'] as String? ?? '',
+      count: (data['count'] as num?)?.toInt() ?? 0,
+      totalExpenses: (data['expenses'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+}

--- a/frontend/lib/models/report_summary.dart
+++ b/frontend/lib/models/report_summary.dart
@@ -1,0 +1,47 @@
+class ReportSummary {
+  final int totalActivities;
+  final double totalExpenses;
+  final bool isReported;
+  final String periodStart;
+  final String periodEnd;
+  final String status; // 'Activo', 'Inactivo', etc.
+
+  const ReportSummary({
+    required this.totalActivities,
+    required this.totalExpenses,
+    required this.isReported,
+    required this.periodStart,
+    required this.periodEnd,
+    required this.status,
+  });
+
+  factory ReportSummary.fromApi(Map<String, dynamic> data) {
+    final totals = data['totals'] as Map<String, dynamic>? ?? {};
+    final period = data['period'] as Map<String, dynamic>? ?? {};
+    
+    final activities = (totals['activities'] as num?)?.toInt() ?? 0;
+    final expenses = (totals['expenses'] as num?)?.toDouble() ?? 0.0;
+    final usersSubmitted = (totals['usersSubmitted'] as num?)?.toInt() ?? 0;
+    final isReported = usersSubmitted > 0;
+    
+    return ReportSummary(
+      totalActivities: activities,
+      totalExpenses: expenses,
+      isReported: isReported,
+      periodStart: period['startDate'] as String? ?? '',
+      periodEnd: period['endDate'] as String? ?? '',
+      status: period['status'] as String? ?? 'Activo',
+    );
+  }
+
+  factory ReportSummary.empty() {
+    return const ReportSummary(
+      totalActivities: 0,
+      totalExpenses: 0.0,
+      isReported: false,
+      periodStart: '',
+      periodEnd: '',
+      status: 'Activo',
+    );
+  }
+}

--- a/frontend/lib/models/report_summary.dart
+++ b/frontend/lib/models/report_summary.dart
@@ -18,12 +18,12 @@ class ReportSummary {
   factory ReportSummary.fromApi(Map<String, dynamic> data) {
     final totals = data['totals'] as Map<String, dynamic>? ?? {};
     final period = data['period'] as Map<String, dynamic>? ?? {};
-    
+
     final activities = (totals['activities'] as num?)?.toInt() ?? 0;
     final expenses = (totals['expenses'] as num?)?.toDouble() ?? 0.0;
     final usersSubmitted = (totals['usersSubmitted'] as num?)?.toInt() ?? 0;
     final isReported = usersSubmitted > 0;
-    
+
     return ReportSummary(
       totalActivities: activities,
       totalExpenses: expenses,

--- a/frontend/lib/pages/dashboard.dart
+++ b/frontend/lib/pages/dashboard.dart
@@ -120,6 +120,7 @@ class _DashboardPageState extends ConsumerState<DashboardPage> {
                   userName: userName,
                   userEmail: userEmail,
                   userPicture: authState.user?['picture'],
+                  activeRoute: Routes.dashboard,
                   onCreateActivity: _openCreateDialog,
                 ),
               Expanded(

--- a/frontend/lib/pages/reports_view.dart
+++ b/frontend/lib/pages/reports_view.dart
@@ -1,17 +1,222 @@
 import 'package:flutter/material.dart';
-import '../../widgets/layouts/app_shell.dart';
-import '../../widgets/layouts/responsive_container.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../widgets/layouts/app_shell.dart';
+import '../widgets/layouts/responsive_container.dart';
+import '../widgets/reports/time_selector.dart';
+import '../widgets/reports/summary_cards.dart';
+import '../widgets/reports/breakdown_table.dart';
 import '../routes.dart';
+import '../services/reports_service.dart';
+import '../auth/auth_utils.dart';
+import '../models/report_summary.dart';
+import '../models/report_breakdown.dart';
 
-class ReportsViewPage extends StatelessWidget {
+class ReportsViewPage extends ConsumerStatefulWidget {
   const ReportsViewPage({super.key});
+
+  @override
+  ConsumerState<ReportsViewPage> createState() => _ReportsViewPageState();
+}
+
+class _ReportsViewPageState extends ConsumerState<ReportsViewPage> {
+  late ReportsService _reportsService;
+  bool _isLoading = false;
+  ReportSummary? _summary;
+  List<ReportBreakdown> _breakdown = [];
+  DateTime _periodStart = DateTime.now();
+  DateTime _periodEnd = DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    _reportsService = ReportsService.localhost(
+      () async => await AuthUtils.getAccessTokenEnsured(ref) ?? '',
+    );
+    _initializePeriod();
+    _loadReports();
+  }
+
+  void _initializePeriod() {
+    final now = DateTime.now();
+    _periodStart = DateTime(now.year, now.month, 1);
+    _periodEnd = DateTime(now.year, now.month + 1, 0);
+  }
+
+  Future<void> _loadReports() async {
+    if (!mounted) return;
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final periodStart = _periodStart.toIso8601String();
+      final periodEnd = _periodEnd.toIso8601String();
+
+      final summary = await _reportsService.getPersonalSummary(
+        periodStart: periodStart,
+        periodEnd: periodEnd,
+      );
+
+      final breakdown = await _reportsService.getPersonalBreakdown(
+        periodStart: periodStart,
+        periodEnd: periodEnd,
+      );
+
+      if (mounted) {
+        setState(() {
+          _summary = summary;
+          _breakdown = breakdown;
+          _isLoading = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error al cargar reportes: $e')),
+        );
+      }
+    }
+  }
+
+  void _previousPeriod() {
+    setState(() {
+      _periodStart = DateTime(
+        _periodStart.year,
+        _periodStart.month - 1,
+        1,
+      );
+      _periodEnd = DateTime(
+        _periodStart.year,
+        _periodStart.month + 1,
+        0,
+      );
+    });
+    _loadReports();
+  }
+
+  void _nextPeriod() {
+    setState(() {
+      _periodStart = DateTime(
+        _periodStart.year,
+        _periodStart.month + 1,
+        1,
+      );
+      _periodEnd = DateTime(
+        _periodStart.year,
+        _periodStart.month + 2,
+        0,
+      );
+    });
+    _loadReports();
+  }
 
   @override
   Widget build(BuildContext context) {
     return AppShell(
       activeRoute: Routes.reports,
-      body: const ResponsiveContainer(
-        child: Center(child: Text('Aquí verás tus reportes (TODO).')),
+      body: ResponsiveContainer(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Page Title
+              const Text(
+                'Mis Reportes',
+                style: TextStyle(
+                  fontSize: 28,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // Period Selector Card
+              Card(
+                elevation: 0,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  side: BorderSide(color: Colors.grey.shade300, width: 1),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      TimeSelector(
+                        periodStart: _periodStart,
+                        periodEnd: _periodEnd,
+                        onPrevious: _previousPeriod,
+                        onNext: _nextPeriod,
+                      ),
+                      const SizedBox(height: 16),
+                      Row(
+                        children: [
+                          Text(
+                            'Estado: ${_summary?.status ?? "Activo"}',
+                            style: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          if (_summary?.isReported ?? false)
+                            Row(
+                              children: const [
+                                Icon(
+                                  Icons.check_circle,
+                                  color: Colors.green,
+                                  size: 18,
+                                ),
+                                SizedBox(width: 4),
+                                Text(
+                                  'Has reportado',
+                                  style: TextStyle(
+                                    fontSize: 14,
+                                    color: Colors.green,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // Loading or Summary Cards
+              if (_isLoading)
+                const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(40.0),
+                    child: CircularProgressIndicator(),
+                  ),
+                )
+              else if (_summary != null) ...[
+                SummaryCards(
+                  activitiesCount: _summary!.totalActivities,
+                  expenses: _summary!.totalExpenses,
+                  isReported: _summary!.isReported,
+                ),
+                const SizedBox(height: 32),
+                BreakdownTable(breakdown: _breakdown),
+              ] else
+                const Center(
+                  child: Padding(
+                    padding: EdgeInsets.all(40.0),
+                    child: Text('No hay datos disponibles'),
+                  ),
+                ),
+
+              const SizedBox(height: 40),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/frontend/lib/providers/reports_provider.dart
+++ b/frontend/lib/providers/reports_provider.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/report_summary.dart';
+import '../models/report_breakdown.dart';
+
+class ReportsState {
+  final bool isLoading;
+  final ReportSummary? summary;
+  final List<ReportBreakdown> breakdown;
+  final String? error;
+  final DateTime periodStart;
+  final DateTime periodEnd;
+
+  const ReportsState({
+    required this.isLoading,
+    this.summary,
+    required this.breakdown,
+    this.error,
+    required this.periodStart,
+    required this.periodEnd,
+  });
+
+  factory ReportsState.initial() {
+    final now = DateTime.now();
+    final periodStart = DateTime(now.year, now.month, 1);
+    final periodEnd = DateTime(now.year, now.month + 1, 0);
+
+    return ReportsState(
+      isLoading: false,
+      summary: null,
+      breakdown: const [],
+      error: null,
+      periodStart: periodStart,
+      periodEnd: periodEnd,
+    );
+  }
+
+  ReportsState copyWith({
+    bool? isLoading,
+    ReportSummary? summary,
+    List<ReportBreakdown>? breakdown,
+    String? error,
+    DateTime? periodStart,
+    DateTime? periodEnd,
+  }) {
+    return ReportsState(
+      isLoading: isLoading ?? this.isLoading,
+      summary: summary ?? this.summary,
+      breakdown: breakdown ?? this.breakdown,
+      error: error,
+      periodStart: periodStart ?? this.periodStart,
+      periodEnd: periodEnd ?? this.periodEnd,
+    );
+  }
+}
+
+final reportsProvider = StateProvider<ReportsState>((ref) {
+  return ReportsState.initial();
+});

--- a/frontend/lib/services/reports_service.dart
+++ b/frontend/lib/services/reports_service.dart
@@ -36,6 +36,7 @@ class ReportsService {
       return ReportSummary.empty();
     }
   }
+
   Future<List<ReportBreakdown>> getPersonalBreakdown({
     required String periodStart,
     required String periodEnd,

--- a/frontend/lib/services/reports_service.dart
+++ b/frontend/lib/services/reports_service.dart
@@ -1,0 +1,60 @@
+import '../config/api_config.dart';
+import '../core/api_client.dart';
+import '../models/report_summary.dart';
+import '../models/report_breakdown.dart';
+
+class ReportsService {
+  ReportsService({
+    required this.apiClient,
+  });
+
+  final ApiClient apiClient;
+
+  factory ReportsService.localhost(AccessTokenProvider getAccessToken) {
+    final apiClient = ApiClient(
+      baseUrl: ApiConfig.baseUrl,
+      getAccessToken: getAccessToken,
+    );
+    return ReportsService(apiClient: apiClient);
+  }
+
+  Future<ReportSummary> getPersonalSummary({
+    required String periodStart,
+    required String periodEnd,
+  }) async {
+    try {
+      final data = await apiClient.get(
+        'reports/summary',
+        queryParameters: {
+          'dateFrom': periodStart,
+          'dateTo': periodEnd,
+        },
+      );
+
+      return ReportSummary.fromApi(data as Map<String, dynamic>);
+    } catch (e) {
+      return ReportSummary.empty();
+    }
+  }
+  Future<List<ReportBreakdown>> getPersonalBreakdown({
+    required String periodStart,
+    required String periodEnd,
+  }) async {
+    try {
+      final data = await apiClient.get(
+        'reports/breakdowns',
+        queryParameters: {
+          'dateFrom': periodStart,
+          'dateTo': periodEnd,
+        },
+      );
+
+      final items = data['byType'] as List<dynamic>? ?? [];
+      return items
+          .map((item) => ReportBreakdown.fromApi(item as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      return [];
+    }
+  }
+}

--- a/frontend/lib/widgets/layouts/app_shell.dart
+++ b/frontend/lib/widgets/layouts/app_shell.dart
@@ -39,6 +39,7 @@ class AppShell extends ConsumerWidget {
                       userName: userName,
                       userEmail: userEmail,
                       userPicture: userPicture,
+                      activeRoute: activeRoute,
                       onCreateActivity: () =>
                           Navigator.pushNamed(context, '/activities/new'),
                     ),

--- a/frontend/lib/widgets/nav/sidebar_nav.dart
+++ b/frontend/lib/widgets/nav/sidebar_nav.dart
@@ -9,6 +9,7 @@ class SidebarNav extends StatelessWidget {
   final String userEmail;
   final String? userPicture;
   final VoidCallback onCreateActivity;
+  final String activeRoute;
 
   const SidebarNav({
     super.key,
@@ -16,6 +17,7 @@ class SidebarNav extends StatelessWidget {
     required this.userEmail,
     this.userPicture,
     required this.onCreateActivity,
+    required this.activeRoute,
   });
 
   @override
@@ -146,6 +148,7 @@ class SidebarNav extends StatelessWidget {
   }
 
   Widget _buildDashboardNavItem(BuildContext context) {
+    final isActive = activeRoute == Routes.dashboard;
     return Padding(
       padding: const EdgeInsetsDirectional.fromSTEB(
         LayoutConstants.spacing16,
@@ -153,44 +156,47 @@ class SidebarNav extends StatelessWidget {
         LayoutConstants.spacing16,
         0.0,
       ),
-      child: Container(
-        width: double.infinity,
-        height: LayoutConstants.navItemHeight,
-        decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.2),
-          borderRadius: BorderRadius.circular(LayoutConstants.borderRadius12),
-        ),
-        child: Padding(
-          padding: const EdgeInsetsDirectional.fromSTEB(
-            LayoutConstants.spacing8,
-            0.0,
-            LayoutConstants.spacing6,
-            0.0,
+      child: InkWell(
+        onTap: () => Navigator.pushNamed(context, Routes.dashboard),
+        child: Container(
+          width: double.infinity,
+          height: LayoutConstants.navItemHeight,
+          decoration: BoxDecoration(
+            color: isActive ? Colors.white.withValues(alpha: 0.2) : Colors.transparent,
+            borderRadius: BorderRadius.circular(LayoutConstants.borderRadius12),
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.max,
-            children: [
-              const Icon(
-                Icons.dashboard,
-                color: Colors.white,
-                size: LayoutConstants.iconSize,
-              ),
-              Padding(
-                padding: const EdgeInsetsDirectional.fromSTEB(
-                  LayoutConstants.spacing12,
-                  0.0,
-                  0.0,
-                  0.0,
+          child: Padding(
+            padding: const EdgeInsetsDirectional.fromSTEB(
+              LayoutConstants.spacing8,
+              0.0,
+              LayoutConstants.spacing6,
+              0.0,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.max,
+              children: [
+                const Icon(
+                  Icons.dashboard,
+                  color: Colors.white,
+                  size: LayoutConstants.iconSize,
                 ),
-                child: Text(
-                  'Dashboard',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Colors.white,
-                        letterSpacing: 0.0,
-                      ),
+                Padding(
+                  padding: const EdgeInsetsDirectional.fromSTEB(
+                    LayoutConstants.spacing12,
+                    0.0,
+                    0.0,
+                    0.0,
+                  ),
+                  child: Text(
+                    'Dashboard',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.white,
+                          letterSpacing: 0.0,
+                        ),
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),
@@ -253,6 +259,7 @@ class SidebarNav extends StatelessWidget {
   }
 
   Widget _buildReportsNavItem(BuildContext context) {
+    final isActive = activeRoute == Routes.reports;
     return Padding(
       padding: const EdgeInsetsDirectional.fromSTEB(
         LayoutConstants.spacing16,
@@ -266,7 +273,7 @@ class SidebarNav extends StatelessWidget {
           width: double.infinity,
           height: LayoutConstants.navItemHeight,
           decoration: BoxDecoration(
-            color: Colors.transparent,
+            color: isActive ? Colors.white.withValues(alpha: 0.2) : Colors.transparent,
             borderRadius: BorderRadius.circular(LayoutConstants.borderRadius12),
           ),
           child: Padding(

--- a/frontend/lib/widgets/nav/sidebar_nav.dart
+++ b/frontend/lib/widgets/nav/sidebar_nav.dart
@@ -162,7 +162,9 @@ class SidebarNav extends StatelessWidget {
           width: double.infinity,
           height: LayoutConstants.navItemHeight,
           decoration: BoxDecoration(
-            color: isActive ? Colors.white.withValues(alpha: 0.2) : Colors.transparent,
+            color: isActive
+                ? Colors.white.withValues(alpha: 0.2)
+                : Colors.transparent,
             borderRadius: BorderRadius.circular(LayoutConstants.borderRadius12),
           ),
           child: Padding(
@@ -273,7 +275,9 @@ class SidebarNav extends StatelessWidget {
           width: double.infinity,
           height: LayoutConstants.navItemHeight,
           decoration: BoxDecoration(
-            color: isActive ? Colors.white.withValues(alpha: 0.2) : Colors.transparent,
+            color: isActive
+                ? Colors.white.withValues(alpha: 0.2)
+                : Colors.transparent,
             borderRadius: BorderRadius.circular(LayoutConstants.borderRadius12),
           ),
           child: Padding(

--- a/frontend/lib/widgets/reports/breakdown_table.dart
+++ b/frontend/lib/widgets/reports/breakdown_table.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import '../../models/report_breakdown.dart';
+
+class BreakdownTable extends StatelessWidget {
+  final List<ReportBreakdown> breakdown;
+
+  const BreakdownTable({
+    super.key,
+    required this.breakdown,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'MIS ACTIVIDADES POR TIPO',
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.5,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Card(
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(color: Colors.grey.shade300, width: 1),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: breakdown.isEmpty
+                ? const Center(
+                    child: Padding(
+                      padding: EdgeInsets.all(24.0),
+                      child: Text(
+                        'No hay actividades en este período',
+                        style: TextStyle(
+                          color: Colors.grey,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ),
+                  )
+                : Table(
+                    columnWidths: const {
+                      0: FlexColumnWidth(3),
+                      1: FlexColumnWidth(1),
+                      2: FlexColumnWidth(2),
+                    },
+                    children: [
+                      // Header row
+                      TableRow(
+                        decoration: BoxDecoration(
+                          border: Border(
+                            bottom: BorderSide(
+                              color: Colors.grey.shade300,
+                              width: 1,
+                            ),
+                          ),
+                        ),
+                        children: const [
+                          Padding(
+                            padding: EdgeInsets.symmetric(
+                              vertical: 12,
+                              horizontal: 8,
+                            ),
+                            child: Text(
+                              'Tipo de Actividad',
+                              style: TextStyle(
+                                fontWeight: FontWeight.w700,
+                                fontSize: 14,
+                              ),
+                            ),
+                          ),
+                          Padding(
+                            padding: EdgeInsets.symmetric(
+                              vertical: 12,
+                              horizontal: 8,
+                            ),
+                            child: Text(
+                              'Cantidad',
+                              style: TextStyle(
+                                fontWeight: FontWeight.w700,
+                                fontSize: 14,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                          Padding(
+                            padding: EdgeInsets.symmetric(
+                              vertical: 12,
+                              horizontal: 8,
+                            ),
+                            child: Text(
+                              'Gastos',
+                              style: TextStyle(
+                                fontWeight: FontWeight.w700,
+                                fontSize: 14,
+                              ),
+                              textAlign: TextAlign.right,
+                            ),
+                          ),
+                        ],
+                      ),
+                      ...breakdown.map((item) {
+                        return TableRow(
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                vertical: 12,
+                                horizontal: 8,
+                              ),
+                              child: Text(
+                                item.activityTypeName,
+                                style: const TextStyle(fontSize: 14),
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                vertical: 12,
+                                horizontal: 8,
+                              ),
+                              child: Text(
+                                item.count.toString(),
+                                style: const TextStyle(fontSize: 14),
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                vertical: 12,
+                                horizontal: 8,
+                              ),
+                              child: Text(
+                                '\$${item.totalExpenses.toStringAsFixed(2)}',
+                                style: const TextStyle(fontSize: 14),
+                                textAlign: TextAlign.right,
+                              ),
+                            ),
+                          ],
+                        );
+                      }),
+                    ],
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/widgets/reports/summary_cards.dart
+++ b/frontend/lib/widgets/reports/summary_cards.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+class SummaryCards extends StatelessWidget {
+  final int activitiesCount;
+  final double expenses;
+  final bool isReported;
+
+  const SummaryCards({
+    super.key,
+    required this.activitiesCount,
+    required this.expenses,
+    required this.isReported,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: _SummaryCard(
+            title: 'Actividades',
+            value: activitiesCount.toString(),
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: _SummaryCard(
+            title: 'Gastos',
+            value: '\$${expenses.toStringAsFixed(2)}',
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: _SummaryCard(
+            title: 'Reportado',
+            value: isReported ? '✓' : '✗',
+            valueColor: isReported ? Colors.green : Colors.orange,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  final String title;
+  final String value;
+  final Color? valueColor;
+
+  const _SummaryCard({
+    required this.title,
+    required this.value,
+    this.valueColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: Colors.grey.shade300, width: 1),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              value,
+              style: TextStyle(
+                fontSize: 32,
+                fontWeight: FontWeight.w700,
+                color: valueColor ?? Theme.of(context).colorScheme.primary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+                color: Colors.black87,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/widgets/reports/time_selector.dart
+++ b/frontend/lib/widgets/reports/time_selector.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class TimeSelector extends StatelessWidget {
+  final DateTime periodStart;
+  final DateTime periodEnd;
+  final VoidCallback onPrevious;
+  final VoidCallback onNext;
+
+  const TimeSelector({
+    super.key,
+    required this.periodStart,
+    required this.periodEnd,
+    required this.onPrevious,
+    required this.onNext,
+  });
+
+  String _formatPeriod() {
+    final startDay = periodStart.day;
+    final endDay = periodEnd.day;
+    final monthName = DateFormat('MMM', 'es').format(periodStart);
+    final year = periodStart.year;
+
+    return '$monthName $startDay-$endDay, $year';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          'Período: ${_formatPeriod()}',
+          style: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        Row(
+          children: [
+            IconButton(
+              icon: const Icon(Icons.arrow_back_ios, size: 18),
+              onPressed: onPrevious,
+              tooltip: 'Período anterior',
+            ),
+            const SizedBox(width: 8),
+            IconButton(
+              icon: const Icon(Icons.arrow_forward_ios, size: 18),
+              onPressed: onNext,
+              tooltip: 'Período siguiente',
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## What's New

Added a new Reports page that shows missionaries their monthly activity statistics.

### Features
- View total activities and expenses for any month
- Navigate between months using arrow buttons
- See activities broken down by type (visits, studies, etc.)
- Visual indicator showing if period has been reported

### Changes Made
- Created Reports page at `/reports`
- Added 3 summary cards: Activities count, Total expenses, Report status
- Added table showing activities grouped by type
- Fixed sidebar navigation to work both ways (Dashboard ↔ Reports)
- Fixed date filtering to show activities from database

### Files Added
- `lib/pages/reports_view.dart` - Main reports page
- `lib/models/report_summary.dart` - Data model for summaries
- `lib/models/report_breakdown.dart` - Data model for breakdowns
- `lib/services/reports_service.dart` - API calls to backend
- `lib/widgets/reports/` - Reusable report components

### Bug Fixes
- Fixed API endpoints to match backend (`/reports/summary`, `/reports/breakdowns`)
- Fixed date parameters (`dateFrom`/`dateTo` instead of `periodStart`/`periodEnd`)
- Fixed month navigation bug (November was showing October dates)
- Added click handler to Dashboard nav item
- Added active route highlighting in sidebar

### Testing
Tested with December and November 2025 data - both months load correctly.