### PR TITLE
feat(backend): add Swagger/OpenAPI documentation

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.0.1",
+        "@nestjs/swagger": "^11.2.3",
         "@nestjs/typeorm": "^11.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
@@ -1918,6 +1919,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
@@ -2720,6 +2727,39 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.3.tgz",
+      "integrity": "sha512-a0xFfjeqk69uHIUpP8u0ryn4cKuHdra2Ug96L858i0N200Hxho+n3j+TlQXyOF4EstLSGjTfxI1Xb2E1lUxeNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.1",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.3.0",
+        "swagger-ui-dist": "5.30.2"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.8",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.8.tgz",
@@ -2860,6 +2900,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -4671,7 +4718,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -8629,10 +8675,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11201,6 +11246,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.30.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.30.2.tgz",
+      "integrity": "sha512-HWCg1DTNE/Nmapt+0m2EPXFwNKNeKK4PwMjkwveN/zn1cV2Kxi9SURd+m0SpdcSgWEK/O64sf8bzXdtUhigtHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.0.1",
+    "@nestjs/swagger": "^11.2.3",
     "@nestjs/typeorm": "^11.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",

--- a/backend/src/activities-type/activity-types.controller.ts
+++ b/backend/src/activities-type/activity-types.controller.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
   Req,
 } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { ActivityTypesService } from './activity-types.service';
 import { CreateActivityTypeDto } from './dto/create-activity-type.dto';
 import { UpdateActivityTypeDto } from './dto/update-activity-type.dto';
@@ -20,6 +21,7 @@ import { IdentityResolutionService } from '../auth/identity-resolution.service';
 import { Request } from 'express';
 import { JwtValidatedUser } from '../auth/jwt.strategy';
 
+@ApiTags('Activity Types')
 @Controller('activity-types')
 export class ActivityTypesController {
   constructor(
@@ -28,12 +30,18 @@ export class ActivityTypesController {
   ) {}
 
   @Get()
+  @ApiOperation({ summary: 'List all activity types' })
+  @ApiResponse({ status: 200, description: 'List of all activity types' })
   async list() {
     return this.service.findAll();
   }
 
-  @UseGuards(JwtAuthGuard)
   @Get('authorized')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'List activity types authorized for current user' })
+  @ApiResponse({ status: 200, description: 'List of authorized activity types' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getAuthorized(@Req() req: Request) {
     const { sub, iss } = (req.user as JwtValidatedUser) ?? {};
     const user = await this.identityService.resolveUserBySubAndIssuer(sub, iss);
@@ -41,27 +49,47 @@ export class ActivityTypesController {
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a single activity type by ID' })
+  @ApiResponse({ status: 200, description: 'Activity type details' })
+  @ApiResponse({ status: 404, description: 'Activity type not found' })
   async getOne(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.service.findOne(id);
   }
 
+  @Post()
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('admin')
-  @Post()
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Create a new activity type (Admin only)' })
+  @ApiResponse({ status: 201, description: 'Activity type created successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
   async create(@Body() dto: CreateActivityTypeDto) {
     return this.service.create(dto);
   }
 
+  @Put(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('admin')
-  @Put(':id')
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Update an activity type (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Activity type updated successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
+  @ApiResponse({ status: 404, description: 'Activity type not found' })
   async update(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: UpdateActivityTypeDto) {
     return this.service.update(id, dto);
   }
 
+  @Delete(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('admin')
-  @Delete(':id')
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Delete an activity type (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Activity type deleted successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
+  @ApiResponse({ status: 404, description: 'Activity type not found' })
   async remove(@Param('id', new ParseUUIDPipe()) id: string) {
     await this.service.remove(id);
     return { message: 'Activity type deleted.' };

--- a/backend/src/activities-type/dto/create-activity-type.dto.ts
+++ b/backend/src/activities-type/dto/create-activity-type.dto.ts
@@ -1,14 +1,28 @@
 import { IsArray, ArrayNotEmpty, IsString, IsUUID, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateActivityTypeDto {
+  @ApiProperty({
+    description: 'Name of the activity type',
+    example: 'Bible Study',
+  })
   @IsString()
   @IsNotEmpty()
   name!: string;
 
+  @ApiProperty({
+    description: 'Description of what this activity type represents',
+    example: 'Regular Bible study sessions with community members',
+  })
   @IsString()
   @IsNotEmpty()
   description!: string;
 
+  @ApiProperty({
+    description: 'Array of role UUIDs that can use this activity type',
+    type: [String],
+    example: ['123e4567-e89b-12d3-a456-426614174000'],
+  })
   @IsArray()
   @ArrayNotEmpty()
   @IsUUID('4', { each: true })

--- a/backend/src/activities-type/dto/update-activity-type.dto.ts
+++ b/backend/src/activities-type/dto/update-activity-type.dto.ts
@@ -1,16 +1,23 @@
 import { IsArray, IsOptional, IsString, IsUUID, IsNotEmpty } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateActivityTypeDto {
+  @ApiPropertyOptional({ description: 'Name of the activity type' })
   @IsString()
   @IsOptional()
   @IsNotEmpty()
   name?: string;
 
+  @ApiPropertyOptional({ description: 'Description of the activity type' })
   @IsString()
   @IsOptional()
   @IsNotEmpty()
   description?: string;
 
+  @ApiPropertyOptional({
+    description: 'Array of role UUIDs that can use this activity type',
+    type: [String],
+  })
   @IsArray()
   @IsOptional()
   @IsUUID('4', { each: true })

--- a/backend/src/activity/activities.controller.ts
+++ b/backend/src/activity/activities.controller.ts
@@ -14,6 +14,7 @@ import {
   ParseIntPipe,
   BadRequestException,
 } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { ActivitiesService } from './activities.service';
 import { CreateActivityDto } from './dto/create-activity.dto';
 import { UpdateActivityDto } from './dto/update-activity.dto';
@@ -29,6 +30,8 @@ import { ActivityType } from '../activities-type/activity-type.entity';
 import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
 import { Activity } from './activity.entity';
 
+@ApiTags('Activities')
+@ApiBearerAuth('JWT-auth')
 @UseGuards(JwtAuthGuard)
 @Controller('activities')
 export class ActivitiesController {
@@ -70,6 +73,10 @@ export class ActivitiesController {
   }
 
   @Post()
+  @ApiOperation({ summary: 'Create a new activity' })
+  @ApiResponse({ status: 201, description: 'Activity created successfully', type: ActivityResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async create(@Req() req: Request, @Body() dto: CreateActivityDto): Promise<ActivityResponseDto> {
     const { sub, iss } = (req.user as any) ?? {};
     const user = await this.identity.resolveUserBySubAndIssuer(sub, iss);
@@ -94,15 +101,34 @@ export class ActivitiesController {
   }
 
   @Get()
+  @ApiOperation({ summary: 'List my activities with pagination and filters' })
+  @ApiResponse({ status: 200, description: 'Paginated list of activities' })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (default: 1)' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page (default: 20)' })
+  @ApiQuery({ name: 'startDate', required: false, description: 'Filter from date (YYYY-MM-DD)' })
+  @ApiQuery({ name: 'endDate', required: false, description: 'Filter until date (YYYY-MM-DD)' })
+  @ApiQuery({ name: 'activityTypeId', required: false, description: 'Filter by activity type UUID' })
+  @ApiQuery({ name: 'hasExpense', required: false, enum: ['true', 'false'], description: 'Filter by expense status' })
   async findMine(
     @Req() req: Request,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
     @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit = 20,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('activityTypeId') activityTypeId?: string,
+    @Query('hasExpense') hasExpense?: string,
   ) {
     const { sub, iss } = (req.user as any) ?? {};
     const user = await this.identity.resolveUserBySubAndIssuer(sub, iss);
 
-    const [items, total] = await this.activities.findMine(user.id, page, limit);
+    const filters = {
+      startDate: startDate || undefined,
+      endDate: endDate || undefined,
+      activityTypeId: activityTypeId || undefined,
+      hasExpense: hasExpense === 'true' ? true : hasExpense === 'false' ? false : undefined,
+    };
+
+    const [items, total] = await this.activities.findMine(user.id, page, limit, filters);
 
     const [owner, typesMap, reportingPeriodsMap] = await Promise.all([
       this.usersRepo.findOneByOrFail({ id: user.id }),
@@ -143,6 +169,9 @@ export class ActivitiesController {
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a single activity by ID' })
+  @ApiResponse({ status: 200, description: 'Activity details', type: ActivityResponseDto })
+  @ApiResponse({ status: 404, description: 'Activity not found' })
   async getOne(@Req() req: Request, @Param('id', new ParseUUIDPipe()) id: string) {
     const { sub, iss } = (req.user as any) ?? {};
     const user = await this.identity.resolveUserBySubAndIssuer(sub, iss);
@@ -166,6 +195,10 @@ export class ActivitiesController {
   }
 
   @Patch(':id')
+  @ApiOperation({ summary: 'Update an activity' })
+  @ApiResponse({ status: 200, description: 'Activity updated successfully', type: ActivityResponseDto })
+  @ApiResponse({ status: 404, description: 'Activity not found' })
+  @ApiResponse({ status: 403, description: 'Activity is locked and cannot be modified' })
   async update(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -193,6 +226,11 @@ export class ActivitiesController {
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Archive (soft delete) an activity' })
+  @ApiResponse({ status: 200, description: 'Activity archived successfully' })
+  @ApiResponse({ status: 400, description: 'Confirmation required (confirm=true)' })
+  @ApiResponse({ status: 404, description: 'Activity not found' })
+  @ApiQuery({ name: 'confirm', required: true, description: 'Must be "true" to confirm deletion' })
   async archive(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -209,6 +247,10 @@ export class ActivitiesController {
   }
 
   @Get('stats/monthly-expenses')
+  @ApiOperation({ summary: 'Get monthly expense total for the current user' })
+  @ApiResponse({ status: 200, description: 'Monthly expense total' })
+  @ApiQuery({ name: 'year', required: false, type: Number, description: 'Year (default: current year)' })
+  @ApiQuery({ name: 'month', required: false, type: Number, description: 'Month 1-12 (default: current month)' })
   async getMonthlyExpenses(
     @Req() req: Request,
     @Query('year', new DefaultValuePipe(new Date().getFullYear()), ParseIntPipe) year: number,

--- a/backend/src/activity/dto/activity-response.dto.ts
+++ b/backend/src/activity/dto/activity-response.dto.ts
@@ -1,22 +1,51 @@
 import { Activity } from '../activity.entity';
 import { ReportingPeriod } from '../../reporting-periods/reporting-period.entity';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ActivityResponseDto {
+  @ApiProperty({ description: 'Unique identifier of the activity' })
   id!: string;
+
+  @ApiProperty({ description: 'UUID of the activity type' })
   activityTypeId!: string;
+
+  @ApiProperty({ description: 'Name of the activity type' })
   activityTypeName!: string;
+
+  @ApiProperty({ description: 'Date of the activity', example: '2024-01-15' })
   activityDate!: string;
+
+  @ApiPropertyOptional({ description: 'Description of the activity' })
   description?: string | null;
+
+  @ApiProperty({ description: 'Whether the activity has an expense' })
   hasExpense!: boolean;
+
+  @ApiPropertyOptional({ description: 'Expense amount if applicable' })
   expenseAmount?: string | null;
+
+  @ApiProperty({ description: 'Activity status', example: 'submitted' })
   status!: string;
+
+  @ApiProperty({ description: 'Whether the activity is locked (cannot be modified)' })
   locked!: boolean;
+
+  @ApiPropertyOptional({ description: 'UUID of the associated reporting period' })
   reportingPeriodId?: string | null;
+
+  @ApiPropertyOptional({ description: 'Name of the associated reporting period' })
   reportingPeriodName?: string | null;
+
+  @ApiProperty({ description: 'Creation timestamp' })
   createdAt!: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
   updatedAt!: Date;
 
+  @ApiProperty({ description: 'UUID of the activity owner' })
   ownerUserId!: string;
+
+  @ApiProperty({ description: 'Username of the activity owner' })
   ownerUsername!: string;
 
   static fromEntity(

--- a/backend/src/activity/dto/create-activity.dto.ts
+++ b/backend/src/activity/dto/create-activity.dto.ts
@@ -11,28 +11,51 @@ import {
   IsDefined,
 } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateActivityDto {
+  @ApiProperty({
+    description: 'UUID of the activity type',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @Transform(({ obj }) => obj.activityTypeId ?? obj.activity_type_id)
   @IsUUID()
   @IsDefined()
   activityTypeId!: string;
 
+  @ApiProperty({
+    description: 'Date of the activity in ISO 8601 format',
+    example: '2024-01-15',
+  })
   @Transform(({ obj }) => obj.activityDate ?? obj.activity_date)
   @IsDateString()
   @IsDefined()
   activityDate!: string;
 
+  @ApiPropertyOptional({
+    description: 'Optional description of the activity',
+    maxLength: 5000,
+    example: 'Met with team to discuss project timeline',
+  })
   @Transform(({ obj }) => obj.description ?? null)
   @IsOptional()
   @IsString()
   @MaxLength(5000)
   description?: string | null;
 
+  @ApiProperty({
+    description: 'Whether the activity has an associated expense',
+    example: false,
+    default: false,
+  })
   @Transform(({ obj }) => obj.hasExpense ?? obj.has_expense ?? false)
   @IsBoolean()
   hasExpense!: boolean;
 
+  @ApiPropertyOptional({
+    description: 'Expense amount as a string (required when hasExpense is true)',
+    example: '150.00',
+  })
   @Transform(({ obj }) => obj.expenseAmount ?? obj.expense_amount)
   @ValidateIf((o) => o.hasExpense === true)
   @IsNotEmpty()

--- a/backend/src/activity/dto/update-activity.dto.ts
+++ b/backend/src/activity/dto/update-activity.dto.ts
@@ -1,26 +1,32 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateActivityDto } from './create-activity.dto';
 import { IsOptional, IsUUID } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateActivityDto extends PartialType(CreateActivityDto) {
+  @ApiPropertyOptional({ description: 'UUID of the activity type' })
   @Transform(({ obj }) => obj.activityTypeId ?? obj.activity_type_id)
   @IsOptional()
   @IsUUID()
   activityTypeId?: string;
 
+  @ApiPropertyOptional({ description: 'Date of the activity in ISO 8601 format' })
   @Transform(({ obj }) => obj.activityDate ?? obj.activity_date)
   @IsOptional()
   activityDate?: string;
 
+  @ApiPropertyOptional({ description: 'Optional description of the activity' })
   @Transform(({ obj }) => obj.description ?? null)
   @IsOptional()
   description?: string | null;
 
+  @ApiPropertyOptional({ description: 'Whether the activity has an associated expense' })
   @Transform(({ obj }) => obj.hasExpense ?? obj.has_expense)
   @IsOptional()
   hasExpense?: boolean;
 
+  @ApiPropertyOptional({ description: 'Expense amount as a string' })
   @Transform(({ obj }) => obj.expenseAmount ?? obj.expense_amount)
   @IsOptional()
   expenseAmount?: string;

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,13 +1,20 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
+@ApiTags('Admin')
+@ApiBearerAuth('JWT-auth')
 @Controller('admin')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class AdminController {
-  @Roles('read:admin_dashboard')
   @Get('dashboard')
+  @Roles('read:admin_dashboard')
+  @ApiOperation({ summary: 'Get admin dashboard' })
+  @ApiResponse({ status: 200, description: 'Welcome message for admin' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin permission' })
   getDashboard() {
     return { message: 'Welcome Admin' };
   }

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,8 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
+@ApiTags('Health')
 @Controller()
 export class AppController {
   @Get()
+  @ApiOperation({ summary: 'Health check endpoint' })
+  @ApiResponse({ status: 200, description: 'API is running' })
   getRootMessage() {
     return {
       status: 'ok',

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,26 +1,49 @@
 import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiProperty } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { RolesGuard } from './roles.guard';
 import { Roles } from './roles.decorator';
+
 class LinkIdentityDto {
+  @ApiProperty({ description: 'User ID to link the identity to' })
   user_id!: string;
+
+  @ApiProperty({ description: 'Identity provider name (e.g., auth0, google)' })
   provider!: string;
+
+  @ApiProperty({ description: 'Identity provider issuer URL' })
   issuer!: string;
+
+  @ApiProperty({ description: 'Subject identifier from the identity provider' })
   subject!: string;
+
+  @ApiProperty({ description: 'Audience for the identity', required: false })
   audience?: string;
+
+  @ApiProperty({ description: 'Email from the identity provider', required: false })
   email?: string;
+
+  @ApiProperty({ description: 'Whether email is verified', required: false })
   email_verified?: boolean;
+
+  @ApiProperty({ description: 'Display name from the identity provider', required: false })
   name?: string;
 }
 
+@ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly auth: AuthService) {}
 
+  @Post('link-identity')
   @UseGuards(AuthGuard('jwt'), RolesGuard)
   @Roles('admin')
-  @Post('link-identity')
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Link an identity provider to a user (Admin only)' })
+  @ApiResponse({ status: 201, description: 'Identity linked successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
   async linkIdentity(@Body() dto: LinkIdentityDto) {
     const identity = await this.auth.linkIdentityToUser({
       user_id: dto.user_id,

--- a/backend/src/entities/dto/create-entity.dto.ts
+++ b/backend/src/entities/dto/create-entity.dto.ts
@@ -1,25 +1,49 @@
 import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
 import { EntityType } from '../entity.entity';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateEntityDto {
+  @ApiProperty({
+    description: 'Name of the entity',
+    example: 'Central Union',
+  })
   @IsString()
   name!: string;
 
+  @ApiProperty({
+    description: 'Type of entity in the hierarchy',
+    enum: EntityType,
+    example: 'UNION',
+  })
   @IsEnum(EntityType)
   type!: EntityType;
 
+  @ApiPropertyOptional({
+    description: 'UUID of the parent entity',
+  })
   @IsOptional()
   @IsUUID()
   parentId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Unique code for the entity',
+    example: 'CU-001',
+  })
   @IsOptional()
   @IsString()
   code?: string;
 
+  @ApiPropertyOptional({
+    description: 'Description of the entity',
+  })
   @IsOptional()
   @IsString()
   description?: string;
 
+  @ApiPropertyOptional({
+    description: 'Physical location of the entity',
+    example: 'New York, NY',
+  })
   @IsOptional()
   @IsString()
   location?: string;

--- a/backend/src/entities/dto/update-entity.dto.ts
+++ b/backend/src/entities/dto/update-entity.dto.ts
@@ -1,31 +1,39 @@
 import { IsOptional, IsEnum, IsString, IsUUID, IsBoolean } from 'class-validator';
 import { EntityType } from '../entity.entity';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateEntityDto {
+  @ApiPropertyOptional({ description: 'Name of the entity' })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiPropertyOptional({ description: 'Type of entity', enum: EntityType })
   @IsOptional()
   @IsEnum(EntityType)
   type?: EntityType;
 
+  @ApiPropertyOptional({ description: 'UUID of the parent entity' })
   @IsOptional()
   @IsUUID()
   parentId?: string;
 
+  @ApiPropertyOptional({ description: 'Unique code for the entity' })
   @IsOptional()
   @IsString()
   code?: string;
 
+  @ApiPropertyOptional({ description: 'Description of the entity' })
   @IsOptional()
   @IsString()
   description?: string;
 
+  @ApiPropertyOptional({ description: 'Physical location of the entity' })
   @IsOptional()
   @IsString()
   location?: string;
 
+  @ApiPropertyOptional({ description: 'Whether the entity is active' })
   @IsOptional()
   @IsBoolean()
   is_active?: boolean;

--- a/backend/src/entities/entities.controller.ts
+++ b/backend/src/entities/entities.controller.ts
@@ -14,6 +14,7 @@ import {
   UseGuards,
   Query,
 } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery, ApiParam } from '@nestjs/swagger';
 import { Request } from 'express';
 import { AuthGuard } from '@nestjs/passport';
 import { PoliciesGuard } from '../casl/policies.guard';
@@ -24,6 +25,8 @@ import { CreateEntityDto } from './dto/create-entity.dto';
 import { UpdateEntityDto } from './dto/update-entity.dto';
 import { EntityType, Entity } from './entity.entity';
 
+@ApiTags('Entities')
+@ApiBearerAuth('JWT-auth')
 @Controller('entities')
 @UseGuards(AuthGuard('jwt'), PoliciesGuard)
 export class EntitiesController {
@@ -40,6 +43,9 @@ export class EntitiesController {
 
   @Post(':type')
   @CheckPolicies((ability) => ability.can(Action.Create, Entity))
+  @ApiOperation({ summary: 'Create an entity of specified type' })
+  @ApiParam({ name: 'type', enum: ['PLATFORM', 'UNION', 'ASSOCIATION', 'FIELD'] })
+  @ApiResponse({ status: 201, description: 'Entity created successfully' })
   async createAny(@Param('type') typeStr: string, @Body() dto: CreateEntityDto) {
     const type = this.parseType(typeStr);
     try {
@@ -53,16 +59,23 @@ export class EntitiesController {
   }
 
   @Get()
+  @ApiOperation({ summary: 'List all entities' })
+  @ApiResponse({ status: 200, description: 'List of all entities' })
   async findAll() {
     return this.entitiesService.findAll();
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a single entity by ID' })
+  @ApiResponse({ status: 200, description: 'Entity details' })
   async findOne(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.entitiesService.findOne(id);
   }
 
   @Patch(':id')
+  @ApiOperation({ summary: 'Update an entity' })
+  @ApiResponse({ status: 200, description: 'Entity updated' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async update(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -79,6 +92,9 @@ export class EntitiesController {
   }
 
   @Delete(':id')
+  @ApiOperation({ summary: 'Delete an entity' })
+  @ApiResponse({ status: 200, description: 'Entity deleted' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async remove(@Req() req: Request, @Param('id', new ParseUUIDPipe()) id: string) {
     const entity = await this.entitiesService.findOne(id);
     const ability = (req as any).ability as AppAbility;
@@ -91,6 +107,9 @@ export class EntitiesController {
   }
 
   @Get('hierarchy/valid-parents')
+  @ApiOperation({ summary: 'Get valid parent entities for a given type' })
+  @ApiQuery({ name: 'type', enum: ['PLATFORM', 'UNION', 'ASSOCIATION', 'FIELD'], required: true })
+  @ApiResponse({ status: 200, description: 'List of valid parent entities' })
   async getValidParentsByQuery(@Query('type') typeStr?: string) {
     if (!typeStr) {
       throw new BadRequestException('Query param "type" is required');
@@ -100,11 +119,15 @@ export class EntitiesController {
   }
 
   @Get(':id/children')
+  @ApiOperation({ summary: 'Get child entities of a parent entity' })
+  @ApiResponse({ status: 200, description: 'List of child entities' })
   async getChildren(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.entitiesService.findChildren(id);
   }
 
   @Patch(':id/deactivate')
+  @ApiOperation({ summary: 'Deactivate an entity' })
+  @ApiResponse({ status: 200, description: 'Entity deactivated' })
   async deactivate(@Req() req: Request, @Param('id', new ParseUUIDPipe()) id: string) {
     const entity = await this.entitiesService.findOne(id);
     const ability = (req as any).ability as AppAbility;
@@ -117,6 +140,8 @@ export class EntitiesController {
   }
 
   @Patch(':id/activate')
+  @ApiOperation({ summary: 'Activate an entity' })
+  @ApiResponse({ status: 200, description: 'Entity activated' })
   async activate(@Req() req: Request, @Param('id', new ParseUUIDPipe()) id: string) {
     const entity = await this.entitiesService.findOne(id);
     const ability = (req as any).ability as AppAbility;

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,7 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { Logger } from '@nestjs/common';
-import { ValidationPipe } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -22,8 +22,28 @@ async function bootstrap() {
     }),
   );
 
+  // Swagger configuration
+  const config = new DocumentBuilder()
+    .setTitle('Secretary API')
+    .setDescription('Activity Management System API for tracking organizational activities and reporting periods')
+    .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description: 'Enter your Auth0 JWT token',
+      },
+      'JWT-auth',
+    )
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
+
   const port = Number(process.env.PORT ?? 3000);
   Logger.log(`Starting on port: ${port}`);
+  Logger.log(`Swagger docs available at: http://localhost:${port}/api/docs`);
 
   await app.listen(port);
 }

--- a/backend/src/reporting-periods/dto/create-exception.dto.ts
+++ b/backend/src/reporting-periods/dto/create-exception.dto.ts
@@ -1,15 +1,32 @@
 import { IsUUID, IsDateString, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateExceptionDto {
+  @ApiProperty({
+    description: 'UUID of the user to grant exception to',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @IsUUID()
   userId!: string;
 
+  @ApiProperty({
+    description: 'Start date of the exception period',
+    example: '2024-01-15',
+  })
   @IsDateString()
   startDate!: string;
 
+  @ApiProperty({
+    description: 'End date of the exception period',
+    example: '2024-01-20',
+  })
   @IsDateString()
   endDate!: string;
 
+  @ApiPropertyOptional({
+    description: 'Reason for granting the exception',
+    example: 'User was on medical leave',
+  })
   @IsOptional()
   @IsString()
   reason?: string;

--- a/backend/src/reporting-periods/dto/create-reporting-period.dto.ts
+++ b/backend/src/reporting-periods/dto/create-reporting-period.dto.ts
@@ -1,31 +1,52 @@
 import { IsNotEmpty, IsString, IsOptional, IsDateString, IsEnum, IsUUID } from 'class-validator';
 import { ReportingPeriodStatus } from '../reporting-period-status.enum';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateReportingPeriodDto {
+  @ApiProperty({
+    description: 'UUID of the entity this reporting period belongs to',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @IsNotEmpty()
   @IsUUID()
   entityId!: string;
 
-  @IsNotEmpty()
-  @IsUUID()
-  termId!: string;
-
+  @ApiProperty({
+    description: 'Name of the reporting period',
+    example: 'January 2024',
+  })
   @IsNotEmpty()
   @IsString()
   name!: string;
 
+  @ApiPropertyOptional({
+    description: 'Description of the reporting period',
+  })
   @IsOptional()
   @IsString()
   description?: string;
 
+  @ApiProperty({
+    description: 'Start date of the reporting period',
+    example: '2024-01-01',
+  })
   @IsNotEmpty()
   @IsDateString()
   startDate!: string;
 
+  @ApiProperty({
+    description: 'End date of the reporting period',
+    example: '2024-01-14',
+  })
   @IsNotEmpty()
   @IsDateString()
   endDate!: string;
 
+  @ApiPropertyOptional({
+    description: 'Initial status of the reporting period',
+    enum: ReportingPeriodStatus,
+    default: ReportingPeriodStatus.ACTIVE,
+  })
   @IsOptional()
   @IsEnum(ReportingPeriodStatus)
   status?: ReportingPeriodStatus;

--- a/backend/src/reporting-periods/dto/exception-response.dto.ts
+++ b/backend/src/reporting-periods/dto/exception-response.dto.ts
@@ -1,15 +1,35 @@
 import { ReportingPeriodException } from '../reporting-period-exception.entity';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ExceptionResponseDto {
+  @ApiProperty({ description: 'Unique identifier of the exception' })
   id!: string;
+
+  @ApiProperty({ description: 'UUID of the user who has the exception' })
   userId!: string;
+
+  @ApiProperty({ description: 'Username of the user' })
   username!: string;
+
+  @ApiProperty({ description: 'Email of the user' })
   userEmail!: string;
+
+  @ApiProperty({ description: 'UUID of the reporting period' })
   reportingPeriodId!: string;
+
+  @ApiProperty({ description: 'Start date of the exception', example: '2024-01-15' })
   startDate!: string;
+
+  @ApiProperty({ description: 'End date of the exception', example: '2024-01-20' })
   endDate!: string;
+
+  @ApiPropertyOptional({ description: 'Reason for the exception' })
   reason?: string | null;
+
+  @ApiProperty({ description: 'UUID of the admin who granted the exception' })
   grantedBy!: string;
+
+  @ApiProperty({ description: 'Timestamp when the exception was granted' })
   grantedAt!: Date;
 
   static fromEntity(

--- a/backend/src/reporting-periods/dto/reporting-period-response.dto.ts
+++ b/backend/src/reporting-periods/dto/reporting-period-response.dto.ts
@@ -1,14 +1,32 @@
 import { ReportingPeriod } from '../reporting-period.entity';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ReportingPeriodResponseDto {
+  @ApiProperty({ description: 'Unique identifier of the reporting period' })
   id!: string;
+
+  @ApiProperty({ description: 'Name of the reporting period', example: 'January 2024' })
   name!: string;
+
+  @ApiPropertyOptional({ description: 'Description of the reporting period' })
   description?: string | null;
+
+  @ApiProperty({ description: 'Start date of the period', example: '2024-01-01' })
   startDate!: string;
+
+  @ApiProperty({ description: 'End date of the period', example: '2024-01-14' })
   endDate!: string;
+
+  @ApiProperty({ description: 'Current status of the period', example: 'active' })
   status!: string;
+
+  @ApiProperty({ description: 'Whether the period is locked for submissions' })
   isLocked!: boolean;
+
+  @ApiProperty({ description: 'Creation timestamp' })
   createdAt!: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
   updatedAt!: Date;
 
   static fromEntity(period: ReportingPeriod): ReportingPeriodResponseDto {

--- a/backend/src/reporting-periods/dto/update-reporting-period.dto.ts
+++ b/backend/src/reporting-periods/dto/update-reporting-period.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateReportingPeriodDto } from './create-reporting-period.dto';
 
 export class UpdateReportingPeriodDto extends PartialType(CreateReportingPeriodDto) {}

--- a/backend/src/reporting-periods/reporting-periods.controller.ts
+++ b/backend/src/reporting-periods/reporting-periods.controller.ts
@@ -11,6 +11,7 @@ import {
   ParseUUIDPipe,
   Query,
 } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { ReportingPeriodsService } from './reporting-periods.service';
 import { CreateReportingPeriodDto } from './dto/create-reporting-period.dto';
 import { UpdateReportingPeriodDto } from './dto/update-reporting-period.dto';
@@ -26,6 +27,8 @@ import { Repository } from 'typeorm';
 import { User } from '../users/user.entity';
 import { Request } from 'express';
 
+@ApiTags('Reporting Periods')
+@ApiBearerAuth('JWT-auth')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('reporting-periods')
 export class ReportingPeriodsController {
@@ -38,6 +41,8 @@ export class ReportingPeriodsController {
 
   @Post('admin')
   @Roles('admin')
+  @ApiOperation({ summary: 'Create a new reporting period (Admin only)' })
+  @ApiResponse({ status: 201, description: 'Reporting period created', type: ReportingPeriodResponseDto })
   async create(
     @Req() req: Request,
     @Body() dto: CreateReportingPeriodDto,
@@ -50,15 +55,17 @@ export class ReportingPeriodsController {
   }
 
   @Get()
-  async findAll(
-    @Query('entityId') entityId?: string,
-    @Query('termId') termId?: string,
-  ): Promise<ReportingPeriodResponseDto[]> {
-    const periods = await this.reportingPeriodsService.findAll(entityId, termId);
+  @ApiOperation({ summary: 'List all reporting periods' })
+  @ApiResponse({ status: 200, description: 'List of reporting periods', type: [ReportingPeriodResponseDto] })
+  @ApiQuery({ name: 'entityId', required: false, description: 'Filter by entity UUID' })
+  async findAll(@Query('entityId') entityId?: string): Promise<ReportingPeriodResponseDto[]> {
+    const periods = await this.reportingPeriodsService.findAll(entityId);
     return periods.map((period) => ReportingPeriodResponseDto.fromEntity(period));
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a single reporting period by ID' })
+  @ApiResponse({ status: 200, description: 'Reporting period details', type: ReportingPeriodResponseDto })
   async findOne(@Param('id', new ParseUUIDPipe()) id: string): Promise<ReportingPeriodResponseDto> {
     const period = await this.reportingPeriodsService.findOne(id);
     return ReportingPeriodResponseDto.fromEntity(period);
@@ -66,6 +73,8 @@ export class ReportingPeriodsController {
 
   @Patch(':id')
   @Roles('admin')
+  @ApiOperation({ summary: 'Update a reporting period (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Reporting period updated', type: ReportingPeriodResponseDto })
   async update(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -80,6 +89,8 @@ export class ReportingPeriodsController {
 
   @Patch(':id/lock')
   @Roles('admin')
+  @ApiOperation({ summary: 'Lock a reporting period (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Reporting period locked', type: ReportingPeriodResponseDto })
   async lock(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -93,6 +104,8 @@ export class ReportingPeriodsController {
 
   @Patch(':id/unlock')
   @Roles('admin')
+  @ApiOperation({ summary: 'Unlock a reporting period (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Reporting period unlocked', type: ReportingPeriodResponseDto })
   async unlock(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -106,6 +119,8 @@ export class ReportingPeriodsController {
 
   @Patch(':id/close')
   @Roles('admin')
+  @ApiOperation({ summary: 'Close a reporting period (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Reporting period closed', type: ReportingPeriodResponseDto })
   async close(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -119,6 +134,8 @@ export class ReportingPeriodsController {
 
   @Post(':periodId/exceptions')
   @Roles('admin')
+  @ApiOperation({ summary: 'Create or update an exception for a user (Admin only)' })
+  @ApiResponse({ status: 201, description: 'Exception created/updated', type: ExceptionResponseDto })
   async createException(
     @Req() req: Request,
     @Param('periodId', new ParseUUIDPipe()) periodId: string,
@@ -139,6 +156,8 @@ export class ReportingPeriodsController {
 
   @Delete(':periodId/exceptions/:userId')
   @Roles('admin')
+  @ApiOperation({ summary: 'Revoke an exception for a user (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Exception revoked' })
   async revokeException(
     @Param('periodId', new ParseUUIDPipe()) periodId: string,
     @Param('userId', new ParseUUIDPipe()) userId: string,
@@ -149,6 +168,8 @@ export class ReportingPeriodsController {
 
   @Get(':periodId/exceptions')
   @Roles('admin')
+  @ApiOperation({ summary: 'List all exceptions for a reporting period (Admin only)' })
+  @ApiResponse({ status: 200, description: 'List of exceptions', type: [ExceptionResponseDto] })
   async listExceptions(
     @Param('periodId', new ParseUUIDPipe()) periodId: string,
   ): Promise<ExceptionResponseDto[]> {
@@ -160,6 +181,8 @@ export class ReportingPeriodsController {
 
   @Delete(':id')
   @Roles('admin')
+  @ApiOperation({ summary: 'Delete a reporting period (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Reporting period deleted' })
   async remove(@Param('id', new ParseUUIDPipe()) id: string): Promise<{ ok: boolean }> {
     await this.reportingPeriodsService.remove(id);
     return { ok: true };

--- a/backend/src/reports/dto/report-query.dto.ts
+++ b/backend/src/reports/dto/report-query.dto.ts
@@ -8,30 +8,53 @@ import {
   ValidateIf,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ReportQueryDto {
+  @ApiPropertyOptional({
+    description: 'Filter by specific reporting period UUID',
+  })
   @IsOptional()
   @IsUUID()
   periodId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Start date for date range filter',
+    example: '2024-01-01',
+  })
   @IsOptional()
   @IsDateString()
   dateFrom?: string;
 
+  @ApiPropertyOptional({
+    description: 'End date for date range filter',
+    example: '2024-01-31',
+  })
   @IsOptional()
   @IsDateString()
   dateTo?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by entity UUID (includes child entities)',
+  })
   @IsOptional()
   @IsUUID()
   entityId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by specific user UUID',
+  })
   @IsOptional()
   @IsUUID()
   userId?: string;
 }
 
 export class RankingsQueryDto extends ReportQueryDto {
+  @ApiPropertyOptional({
+    description: 'Maximum number of rankings to return',
+    default: 5,
+    minimum: 1,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/backend/src/reports/reports.controller.ts
+++ b/backend/src/reports/reports.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { ReportsService } from './reports.service';
 import { ReportQueryDto, RankingsQueryDto } from './dto/report-query.dto';
 import {
@@ -15,6 +16,8 @@ import { IdentityResolutionService } from '../auth/identity-resolution.service';
 import { Request } from 'express';
 import { JwtValidatedUser } from '../auth/jwt.strategy';
 
+@ApiTags('Reports')
+@ApiBearerAuth('JWT-auth')
 @Controller('reports')
 @UseGuards(JwtAuthGuard)
 export class ReportsController {
@@ -30,12 +33,16 @@ export class ReportsController {
   }
 
   @Get('summary')
+  @ApiOperation({ summary: 'Get activity summary statistics' })
+  @ApiResponse({ status: 200, description: 'Summary statistics for the period' })
   async getSummary(@Req() req: Request, @Query() query: ReportQueryDto): Promise<SummaryResponse> {
     const userId = await this.getUserIdFromRequest(req);
     return this.reportsService.getSummary(userId, query);
   }
 
   @Get('breakdowns')
+  @ApiOperation({ summary: 'Get activity breakdowns by type, entity, and user' })
+  @ApiResponse({ status: 200, description: 'Breakdown statistics' })
   async getBreakdowns(
     @Req() req: Request,
     @Query() query: ReportQueryDto,
@@ -45,6 +52,8 @@ export class ReportsController {
   }
 
   @Get('compliance')
+  @ApiOperation({ summary: 'Get compliance report (submitted vs not submitted users)' })
+  @ApiResponse({ status: 200, description: 'Compliance statistics' })
   async getCompliance(
     @Req() req: Request,
     @Query() query: ReportQueryDto,
@@ -54,12 +63,16 @@ export class ReportsController {
   }
 
   @Get('trends')
+  @ApiOperation({ summary: 'Get activity trends over multiple periods' })
+  @ApiResponse({ status: 200, description: 'Trend data across periods' })
   async getTrends(@Req() req: Request, @Query() query: ReportQueryDto): Promise<TrendsResponse> {
     const userId = await this.getUserIdFromRequest(req);
     return this.reportsService.getTrends(userId, query);
   }
 
   @Get('comparison')
+  @ApiOperation({ summary: 'Compare current period with previous period' })
+  @ApiResponse({ status: 200, description: 'Period comparison with changes' })
   async getComparison(
     @Req() req: Request,
     @Query() query: ReportQueryDto,
@@ -69,6 +82,8 @@ export class ReportsController {
   }
 
   @Get('rankings')
+  @ApiOperation({ summary: 'Get top performers, lowest compliance, and inactive users' })
+  @ApiResponse({ status: 200, description: 'Ranking data' })
   async getRankings(
     @Req() req: Request,
     @Query() query: RankingsQueryDto,
@@ -78,6 +93,8 @@ export class ReportsController {
   }
 
   @Get('expenses')
+  @ApiOperation({ summary: 'Get expense breakdown by type, entity, and user' })
+  @ApiResponse({ status: 200, description: 'Expense statistics' })
   async getExpenses(
     @Req() req: Request,
     @Query() query: ReportQueryDto,

--- a/backend/src/roles/dto/assign-role.dto.ts
+++ b/backend/src/roles/dto/assign-role.dto.ts
@@ -1,5 +1,6 @@
 import { IsUUID, IsEnum, IsOptional, IsDateString } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export enum RoleEnum {
   ADMIN = 'ADMIN',
@@ -7,21 +8,39 @@ export enum RoleEnum {
   PASTOR = 'PASTOR',
   MINISTER = 'MINISTER',
   EXECUTIVE = 'EXECUTIVE',
+  DEPARTMENTAL = 'DEPARTMENTAL',
 }
 
 export class AssignRoleDto {
+  @ApiProperty({
+    description: 'UUID of the user to assign the role to',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @IsUUID()
   userId!: string;
 
+  @ApiProperty({
+    description: 'Role to assign',
+    enum: RoleEnum,
+    example: 'MISSIONARY',
+  })
   @Transform(({ value }) => String(value).trim().toUpperCase())
   @IsEnum(RoleEnum, {
-    message: 'Invalid role enum value. Allowed: ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE',
+    message: 'Invalid role enum value. Allowed: ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE, DEPARTMENTAL',
   })
   role!: RoleEnum;
 
+  @ApiProperty({
+    description: 'UUID of the entity where the role applies',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @IsUUID()
   entityId!: string;
 
+  @ApiPropertyOptional({
+    description: 'Start date for the role assignment',
+    example: '2024-01-01',
+  })
   @IsOptional()
   @IsDateString()
   startDate?: string;

--- a/backend/src/roles/dto/assignment-response.dto.ts
+++ b/backend/src/roles/dto/assignment-response.dto.ts
@@ -1,17 +1,41 @@
 import { UserRoleAssignment } from '../user-role-assignment.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class AssignmentResponseDto {
+  @ApiProperty({ description: 'Unique identifier of the assignment' })
   id!: string;
+
+  @ApiProperty({ description: 'UUID of the user' })
   userId!: string;
+
+  @ApiProperty({ description: 'Username of the assigned user' })
   username!: string;
+
+  @ApiProperty({ description: 'UUID of the role' })
   roleId!: string;
+
+  @ApiProperty({ description: 'Name of the role', example: 'MISSIONARY' })
   roleName!: string;
+
+  @ApiProperty({ description: 'UUID of the entity' })
   entityId!: string;
+
+  @ApiProperty({ description: 'Name of the entity' })
   entityName!: string;
+
+  @ApiProperty({ description: 'Start date of the assignment', example: '2024-01-01' })
   startDate!: string;
+
+  @ApiProperty({ description: 'End date of the assignment', example: '9999-12-31' })
   endDate!: string;
+
+  @ApiProperty({ description: 'Whether the assignment is currently active' })
   isActive!: boolean;
+
+  @ApiProperty({ description: 'Creation timestamp' })
   createdAt!: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
   updatedAt!: Date;
 
   static fromEntity(assignment: UserRoleAssignment): AssignmentResponseDto {

--- a/backend/src/roles/dto/bulk-assign-role.dto.ts
+++ b/backend/src/roles/dto/bulk-assign-role.dto.ts
@@ -1,22 +1,41 @@
 import { IsUUID, IsEnum, IsArray, ArrayNotEmpty, IsOptional, IsDateString } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { RoleEnum } from './assign-role.dto';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class BulkAssignRoleDto {
+  @ApiProperty({
+    description: 'UUID of the user to assign roles to',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @IsUUID()
   userId!: string;
 
+  @ApiProperty({
+    description: 'Role to assign',
+    enum: RoleEnum,
+    example: 'MISSIONARY',
+  })
   @Transform(({ value }) => String(value).trim().toUpperCase())
   @IsEnum(RoleEnum, {
-    message: 'Invalid role enum value. Allowed: ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE',
+    message: 'Invalid role enum value. Allowed: ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE, DEPARTMENTAL',
   })
   role!: RoleEnum;
 
+  @ApiProperty({
+    description: 'Array of entity UUIDs to assign the role for',
+    type: [String],
+    example: ['123e4567-e89b-12d3-a456-426614174000', '123e4567-e89b-12d3-a456-426614174001'],
+  })
   @IsArray()
   @ArrayNotEmpty()
   @IsUUID('4', { each: true })
   entityIds!: string[];
 
+  @ApiPropertyOptional({
+    description: 'Start date for all assignments',
+    example: '2024-01-01',
+  })
   @IsOptional()
   @IsDateString()
   startDate?: string;

--- a/backend/src/roles/dto/create-role.dto.ts
+++ b/backend/src/roles/dto/create-role.dto.ts
@@ -1,11 +1,21 @@
 import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateRoleDto {
+  @ApiProperty({
+    description: 'Name of the role',
+    maxLength: 80,
+    example: 'MISSIONARY',
+  })
   @IsString()
   @IsNotEmpty()
   @MaxLength(80)
   name!: string;
 
+  @ApiPropertyOptional({
+    description: 'Description of the role',
+    maxLength: 255,
+  })
   @IsString()
   @IsOptional()
   @MaxLength(255)

--- a/backend/src/roles/dto/get-user-entities-by-role.dto.ts
+++ b/backend/src/roles/dto/get-user-entities-by-role.dto.ts
@@ -1,14 +1,24 @@
 import { IsUUID, IsEnum } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { RoleEnum } from './assign-role.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class GetUserEntitiesByRoleDto {
+  @ApiProperty({
+    description: 'UUID of the user',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @IsUUID()
   userId!: string;
 
+  @ApiProperty({
+    description: 'Role to filter by',
+    enum: RoleEnum,
+    example: 'MISSIONARY',
+  })
   @Transform(({ value }) => String(value).trim().toUpperCase())
   @IsEnum(RoleEnum, {
-    message: 'Invalid role enum value. Allowed: ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE',
+    message: 'Invalid role enum value. Allowed: ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE, DEPARTMENTAL',
   })
   role!: RoleEnum;
 }

--- a/backend/src/roles/dto/remove-role.dto.ts
+++ b/backend/src/roles/dto/remove-role.dto.ts
@@ -1,6 +1,11 @@
 import { IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class RemoveRoleDto {
+  @ApiProperty({
+    description: 'UUID of the role assignment to remove',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @IsUUID()
   assignmentId!: string;
 }

--- a/backend/src/roles/dto/update-assignment.dto.ts
+++ b/backend/src/roles/dto/update-assignment.dto.ts
@@ -1,6 +1,11 @@
 import { IsDateString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateAssignmentDto {
+  @ApiProperty({
+    description: 'New end date for the assignment',
+    example: '2024-12-31',
+  })
   @IsDateString()
   endDate!: string;
 }

--- a/backend/src/roles/dto/update-role.dto.ts
+++ b/backend/src/roles/dto/update-role.dto.ts
@@ -1,11 +1,14 @@
 import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateRoleDto {
+  @ApiPropertyOptional({ description: 'Name of the role', maxLength: 80 })
   @IsString()
   @IsOptional()
   @MaxLength(80)
   name?: string;
 
+  @ApiPropertyOptional({ description: 'Description of the role', maxLength: 255 })
   @IsString()
   @IsOptional()
   @MaxLength(255)

--- a/backend/src/roles/roles.controller.ts
+++ b/backend/src/roles/roles.controller.ts
@@ -12,6 +12,7 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
 import { RolesService } from './roles.service';
 import { CreateRoleDto } from './dto/create-role.dto';
@@ -26,6 +27,8 @@ import { GetUserEntitiesByRoleDto } from './dto/get-user-entities-by-role.dto';
 import { UpdateAssignmentDto } from './dto/update-assignment.dto';
 import { AssignmentResponseDto } from './dto/assignment-response.dto';
 
+@ApiTags('Roles')
+@ApiBearerAuth('JWT-auth')
 @Controller('roles')
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 export class RolesController {
@@ -36,6 +39,8 @@ export class RolesController {
 
   @Get('users-by-role')
   @Roles('admin')
+  @ApiOperation({ summary: 'List users by role (Admin only)' })
+  @ApiQuery({ name: 'role', required: true, description: 'Role name to filter by' })
   usersByRole(@Query('role') role: string) {
     const normalized = String(role).trim();
     return this.roleAssignment.listUsersByRole(normalized);
@@ -49,6 +54,7 @@ export class RolesController {
 
   @Post('assign')
   @Roles('admin')
+  @ApiOperation({ summary: 'Assign a role to a user (Admin only)' })
   @UsePipes(new ValidationPipe({ transform: true }))
   assign(@Body() dto: AssignRoleDto) {
     return this.roleAssignment.assign(dto);

--- a/backend/src/users/admin-users.controller.ts
+++ b/backend/src/users/admin-users.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Post, Get, Patch, Param, Body, UseGuards } from '@nestjs/common';
+import { Controller, Post, Get, Patch, Param, Body, UseGuards, ParseUUIDPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -6,6 +7,8 @@ import { AuthGuard } from '@nestjs/passport';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 
+@ApiTags('Admin Users')
+@ApiBearerAuth('JWT-auth')
 @Controller('admin/users')
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 @Roles('admin')
@@ -13,23 +16,41 @@ export class AdminUsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Post()
+  @ApiOperation({ summary: 'Create a new user (Admin only)' })
+  @ApiResponse({ status: 201, description: 'User created successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
   async create(@Body() dto: CreateUserDto) {
     const user = await this.usersService.create(dto);
     return { message: 'User created successfully', user };
   }
 
   @Get()
+  @ApiOperation({ summary: 'List all users (Admin only)' })
+  @ApiResponse({ status: 200, description: 'List of all users' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
   async list() {
     return this.usersService.findAll();
   }
 
   @Get(':id')
-  async get(@Param('id') id: string) {
+  @ApiOperation({ summary: 'Get a single user by ID (Admin only)' })
+  @ApiResponse({ status: 200, description: 'User details' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async get(@Param('id', new ParseUUIDPipe()) id: string) {
     return this.usersService.findOne(id);
   }
 
   @Patch(':id')
-  async update(@Param('id') id: string, @Body() dto: UpdateUserDto) {
+  @ApiOperation({ summary: 'Update a user (Admin only)' })
+  @ApiResponse({ status: 200, description: 'User updated successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  async update(@Param('id', new ParseUUIDPipe()) id: string, @Body() dto: UpdateUserDto) {
     const user = await this.usersService.update(id, dto);
     return { message: 'User updated successfully', user };
   }

--- a/backend/src/users/dto/create-user.dto.ts
+++ b/backend/src/users/dto/create-user.dto.ts
@@ -1,27 +1,54 @@
 import { IsEmail, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateUserDto {
+  @ApiProperty({
+    description: 'Unique username for the user',
+    example: 'john.doe',
+  })
   @IsNotEmpty()
   @IsString()
   username!: string;
 
+  @ApiProperty({
+    description: 'Email address of the user',
+    example: 'john.doe@example.com',
+  })
   @IsEmail()
   email!: string;
 
+  @ApiProperty({
+    description: 'UUID of the primary role for the user',
+  })
   @IsUUID()
   role_id!: string;
 
+  @ApiProperty({
+    description: 'UUID of the entity the user belongs to',
+  })
   @IsUUID()
   entity_id!: string;
 
+  @ApiPropertyOptional({
+    description: 'Full name of the user',
+    example: 'John Doe',
+  })
   @IsOptional()
   @IsString()
   full_name?: string;
 
+  @ApiPropertyOptional({
+    description: 'First name of the user',
+    example: 'John',
+  })
   @IsOptional()
   @IsString()
   first_name?: string;
 
+  @ApiPropertyOptional({
+    description: 'Family name of the user',
+    example: 'Doe',
+  })
   @IsOptional()
   @IsString()
   family_name?: string;

--- a/backend/src/users/dto/update-user.dto.ts
+++ b/backend/src/users/dto/update-user.dto.ts
@@ -1,35 +1,44 @@
 import { IsEmail, IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
 import { UserStatus } from '../user-status.enum';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateUserDto {
+  @ApiPropertyOptional({ description: 'Username' })
   @IsOptional()
   @IsString()
   username?: string;
 
+  @ApiPropertyOptional({ description: 'Email address' })
   @IsOptional()
   @IsEmail()
   email?: string;
 
+  @ApiPropertyOptional({ description: 'UUID of the primary role' })
   @IsOptional()
   @IsUUID()
   role_id?: string;
 
+  @ApiPropertyOptional({ description: 'UUID of the entity' })
   @IsOptional()
   @IsUUID()
   entity_id?: string;
 
+  @ApiPropertyOptional({ description: 'User status', enum: UserStatus })
   @IsOptional()
   @IsEnum(UserStatus)
   status?: UserStatus;
 
+  @ApiPropertyOptional({ description: 'Full name' })
   @IsOptional()
   @IsString()
   full_name?: string;
 
+  @ApiPropertyOptional({ description: 'First name' })
   @IsOptional()
   @IsString()
   first_name?: string;
 
+  @ApiPropertyOptional({ description: 'Family name' })
   @IsOptional()
   @IsString()
   family_name?: string;

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Get, UseGuards, Req } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { IdentityResolutionService } from '../auth/identity-resolution.service';
 import { Request } from 'express';
 import { JwtValidatedUser } from '../auth/jwt.strategy';
 
+@ApiTags('Users')
 @Controller('users')
 export class UsersController {
   constructor(
@@ -12,8 +14,12 @@ export class UsersController {
     private readonly identityService: IdentityResolutionService,
   ) {}
 
-  @UseGuards(JwtAuthGuard)
   @Get('me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Get current user profile' })
+  @ApiResponse({ status: 200, description: 'Current user profile with role assignments' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getMyProfile(@Req() req: Request) {
     const { sub, iss } = (req.user as JwtValidatedUser) ?? {};
     const user = await this.identityService.resolveUserBySubAndIssuer(sub, iss);


### PR DESCRIPTION
## Summary
- Add interactive API documentation using Swagger/OpenAPI
- Swagger UI available at `/api/docs`
- All endpoints documented with descriptions and response schemas
- JWT authentication configured for testing secured endpoints

## Changes
- Add @nestjs/swagger dependency
- Configure Swagger in main.ts with JWT bearer auth support
- Add @ApiProperty decorators to all DTOs
- Add @ApiTags, @ApiOperation, @ApiResponse decorators to all controllers

## Testing
1. Start the backend: `npm run start:dev`
2. Open http://localhost:3000/api/docs
3. Verify all endpoints are listed with documentation
4. Test authentication using the "Authorize" button