### PR TITLE
feat: Add GitHub Actions workflow for Cloudflare Pages deployment

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy /build/web --project-name=secretary-backend
+          command: pages deploy frontend/build/web --project-name=secretary-backend --commit-dirty=true

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -28,7 +28,12 @@ jobs:
         run: flutter pub get
 
       - name: Build Flutter web
-        run: flutter build web --release
+        run: |
+          flutter build web --release \
+            --dart-define=AUTH0_DOMAIN=${{ secrets.AUTH0_DOMAIN }} \
+            --dart-define=AUTH0_CLIENT_ID=${{ secrets.AUTH0_CLIENT_ID }} \
+            --dart-define=AUTH0_REDIRECT_URI=${{ secrets.AUTH0_REDIRECT_URI }} \
+            --dart-define=AUTH0_AUDIENCE=${{ secrets.AUTH0_AUDIENCE }}
 
       - name: Deploy to Cloudflare Pages (Wrangler)
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - deploy-cloudflare
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - deploy-cloudflare
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy frontend/build/web --project-name=secretary-frontend
+          command: pages deploy frontend/build/web --project-name=secretary-backend

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -33,7 +33,8 @@ jobs:
             --dart-define=AUTH0_DOMAIN=${{ secrets.AUTH0_DOMAIN }} \
             --dart-define=AUTH0_CLIENT_ID=${{ secrets.AUTH0_CLIENT_ID }} \
             --dart-define=AUTH0_REDIRECT_URI=${{ secrets.AUTH0_REDIRECT_URI }} \
-            --dart-define=AUTH0_AUDIENCE=${{ secrets.AUTH0_AUDIENCE }}
+            --dart-define=AUTH0_AUDIENCE=${{ secrets.AUTH0_AUDIENCE }} \
+            --dart-define=API_BASE_URL=${{ secrets.API_BASE_URL }}
 
       - name: Deploy to Cloudflare Pages (Wrangler)
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy frontend/build/web --project-name=secretary-backend
+          command: pages deploy /build/web --project-name=secretary-backend

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -15,26 +15,24 @@ jobs:
         working-directory: ./frontend
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Setup Flutter
-      uses: subosito/flutter-action@v2
-      with:
-        channel: 'stable'
-        cache: true
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
 
-    - name: Install dependencies
-      run: flutter pub get
+      - name: Install dependencies
+        run: flutter pub get
 
-    - name: Build Flutter web
-      run: flutter build web --release
+      - name: Build Flutter web
+        run: flutter build web --release
 
-    - name: Deploy to Cloudflare Pages
-      uses: cloudflare/pages-action@v1
-      with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        projectName: secretary-frontend
-        directory: frontend/build/web
-        gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy to Cloudflare Pages (Wrangler)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy frontend/build/web --project-name=secretary-frontend

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,0 +1,40 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - main
+      - deploy-cloudflare
+  workflow_dispatch:
+
+jobs:
+  deploy-frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./frontend
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        channel: 'stable'
+        cache: true
+
+    - name: Install dependencies
+      run: flutter pub get
+
+    - name: Build Flutter web
+      run: flutter build web --release
+
+    - name: Deploy to Cloudflare Pages
+      uses: cloudflare/pages-action@v1
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        projectName: secretary-frontend
+        directory: frontend/build/web
+        gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,8 +6,12 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  const allowedOrigins = process.env.CORS_ORIGINS
+    ? process.env.CORS_ORIGINS.split(',')
+    : ['http://localhost:8080', 'http://localhost:3000'];
+
   app.enableCors({
-    origin: ['http://localhost:8080', 'http://localhost:3000'],
+    origin: allowedOrigins,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: true,


### PR DESCRIPTION
## Summary
Adds automated deployment of the Flutter frontend to Cloudflare Pages using GitHub Actions.

## Changes
- Created `.github/workflows/deploy-cloudflare.yml` workflow
- Configured automatic deployment on push to `main` and `deploy-cloudflare` branches
- Added manual deployment trigger via `workflow_dispatch`
- Uses Wrangler v3 for deploying to Cloudflare Pages

## How It Works
The workflow:
1. Checks out the code
2. Sets up Flutter with caching enabled
3. Installs dependencies with `flutter pub get`
4. Builds the production web bundle with `flutter build web --release`
5. Deploys the `frontend/build/web` directory to Cloudflare Pages


## Testing
After setup, the workflow can be tested by:
- Pushing to this branch
- Manually triggering from the Actions tab