### PR TITLE
fix: exclude legacy scripts from TypeScript compilation

### DIFF
--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "scripts/legacy"]
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -24,5 +24,6 @@
     "strict": true,
     "types": ["node", "jest"]
   },
-  "include": ["src", "scripts"]
+  "include": ["src", "scripts"],
+  "exclude": ["scripts/legacy"]
 }


### PR DESCRIPTION
This PR fixes TypeScript compilation errors by excluding the legacy scripts folder from the build process.

### Problem:
- Legacy scripts in `scripts/legacy/` were causing compilation errors due to outdated import paths
- These scripts are not intended to be run in the current codebase
- Build and type checking were failing with module resolution errors

### Solution:
- Added `scripts/legacy` to the exclusion list in `tsconfig.json`
- Added `scripts/legacy` to the exclusion list in `tsconfig.build.json`

### Changes:
- Updated `backend/tsconfig.json` to exclude legacy scripts
- Updated `backend/tsconfig.build.json` to exclude legacy scripts

### Testing:
-  Build completes successfully without errors
-  Type checking passes
-  Tests run without issues