### PR TITLE
feat: add cloud database support and Honduras seeding scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "migration:generate": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js migration:generate -d src/database/data-source.ts -n",
     "migration:run": "ts-node -r tsconfig-paths/register ./node_modules",
     "admin:bootstrap": "ts-node -r tsconfig-paths/register scripts/bootstrap-admin.ts",
+    "seed:roles": "ts-node -r tsconfig-paths/register scripts/seed-roles-and-activities.ts",
     "seed:honduras-structure": "ts-node -r tsconfig-paths/register scripts/honduras-structure.seed.ts",
     "seed:honduras-users": "ts-node -r tsconfig-paths/register scripts/seed-honduras-users.ts"
   },

--- a/backend/scripts/honduras-structure.seed.ts
+++ b/backend/scripts/honduras-structure.seed.ts
@@ -41,9 +41,17 @@ async function run() {
     }
   }
 
+  const platform = await createIfNotExists({
+    name: 'Plataforma Global',
+    type: EntityType.PLATFORM,
+    code: 'PLAT',
+    description: 'Plataforma raíz del sistema',
+  });
+
   const union = await createIfNotExists({
     name: 'Unión Hondureña',
     type: EntityType.UNION,
+    parentId: platform.id,
     code: 'UHN',
     location: 'Honduras',
     description: 'Estructura de ejemplo para datos iniciales',

--- a/backend/scripts/seed-honduras-users.ts
+++ b/backend/scripts/seed-honduras-users.ts
@@ -16,49 +16,49 @@ const USERS = [
     email: 'daniel.contreras@uhn.test',
     full_name: 'Daniel Contreras',
     sub: 'auth0|69583d736ccfb90819e2300c',
-    role: 'ADMIN',
+    roles: ['ADMIN'],
     entity: 'Unión Hondureña',
   },
   {
     email: 'admin.central@uhn.test',
     full_name: 'Admin Asociación Central',
     sub: 'auth0|69583e476d2265af6faf2db8',
-    role: 'ADMIN',
+    roles: ['ADMIN'],
     entity: 'Asociación Central',
   },
   {
     email: 'admin.noroccidental@uhn.test',
     full_name: 'Admin Asociación Nor-occidental',
     sub: 'auth0|69583e5e6ccfb90819e23085',
-    role: 'ADMIN',
+    roles: ['ADMIN'],
     entity: 'Asociación Nor-occidental',
   },
   {
     email: 'admin.nororiental@uhn.test',
     full_name: 'Admin Asociación Nor-oriental',
     sub: 'auth0|69583e8889bb367a376574dd',
-    role: 'ADMIN',
+    roles: ['ADMIN'],
     entity: 'Asociación Nor-oriental',
   },
   {
     email: 'obrero.copan@uhn.test',
     full_name: 'Obrero Campo Copán',
     sub: 'auth0|69583ec26d2265af6faf2deb',
-    role: 'MISSIONARY',
+    roles: ['MISSIONARY', 'Anciano'],
     entity: 'Campo Copán',
   },
   {
     email: 'obrero.tegucigalpa@uhn.test',
     full_name: 'Obrero Campo Tegucigalpa',
     sub: 'auth0|69583ed7292a80e2ca479bda',
-    role: 'MISSIONARY',
+    roles: ['MISSIONARY', 'Director de Jóvenes'],
     entity: 'Campo Tegucigalpa',
   },
   {
     email: 'obrero.sps@uhn.test',
     full_name: 'Obrero Campo San Pedro Sula',
     sub: 'auth0|69583eec89bb367a37657519',
-    role: 'MISSIONARY',
+    roles: ['MISSIONARY', 'Director de Obra Misionera'],
     entity: 'Campo San Pedro Sula',
   },
 ];
@@ -77,8 +77,16 @@ async function run() {
     const entity = await entityRepo.findOne({ where: { name: u.entity } });
     if (!entity) throw new Error(`Entidad no encontrada: ${u.entity}`);
 
-    const role = await roleRepo.findOne({ where: { name: u.role } });
-    if (!role) throw new Error(`Rol no encontrado: ${u.role}`);
+    // Get all roles for this user
+    const userRoles: Role[] = [];
+    for (const roleName of u.roles) {
+      const role = await roleRepo.findOne({ where: { name: roleName } });
+      if (!role) throw new Error(`Rol no encontrado: ${roleName}`);
+      userRoles.push(role);
+    }
+
+    // Use first role as primary
+    const primaryRole = userRoles[0];
 
     let user = await userRepo.findOneBy({ email: u.email });
 
@@ -89,7 +97,7 @@ async function run() {
       user.username = u.email;
       user.full_name = u.full_name;
       user.status = UserStatus.ACTIVE;
-      user.role = role;
+      user.role = primaryRole;
       user.entity = entity;
 
       await userRepo.save(user);
@@ -111,34 +119,38 @@ async function run() {
       await idpRepo.save(idp);
     }
 
-    const existingAssignment = await assignmentRepo.findOne({
-      where: {
-        user: { id: user.id },
-        role: { id: role.id },
-        entity: { id: entity.id },
-      },
-      relations: ['user', 'role', 'entity'],
-    });
-
-    if (!existingAssignment) {
-      const startDate = new Date().toISOString().split('T')[0];
-      // Calculate end date based on entity's term length (default 5 years)
-      const endYear = new Date().getFullYear() + (entity.term_length_years || 5);
-      const endDate = `${endYear}-12-31`;
-      
-      const assignment = assignmentRepo.create({
-        user,
-        role,
-        entity,
-        start_date: startDate,
-        end_date: endDate,
-        created_by: user.id,
-        updated_by: user.id,
+    // Create assignments for all roles
+    for (const role of userRoles) {
+      const existingAssignment = await assignmentRepo.findOne({
+        where: {
+          user: { id: user.id },
+          role: { id: role.id },
+          entity: { id: entity.id },
+        },
+        relations: ['user', 'role', 'entity'],
       });
-      await assignmentRepo.save(assignment);
+
+      if (!existingAssignment) {
+        const startDate = new Date().toISOString().split('T')[0];
+        // Calculate end date based on entity's term length (default 5 years)
+        const endYear = new Date().getFullYear() + (entity.term_length_years || 5);
+        const endDate = `${endYear}-12-31`;
+        
+        const assignment = assignmentRepo.create({
+          user,
+          role,
+          entity,
+          start_date: startDate,
+          end_date: endDate,
+          created_by: user.id,
+          updated_by: user.id,
+        });
+        await assignmentRepo.save(assignment);
+        console.log(`  ✓ Asignado rol: ${role.name}`);
+      }
     }
 
-    console.log(`Usuario listo: ${u.email}`);
+    console.log(`Usuario listo: ${u.email} (${u.roles.length} roles)`);
   }
 
   console.log('🎉 Seed de usuarios Honduras COMPLETADO');

--- a/backend/scripts/seed-honduras-users.ts
+++ b/backend/scripts/seed-honduras-users.ts
@@ -16,49 +16,49 @@ const USERS = [
     email: 'daniel.contreras@uhn.test',
     full_name: 'Daniel Contreras',
     sub: 'auth0|69583d736ccfb90819e2300c',
-    role: 'SYSTEM_ADMIN',
+    role: 'ADMIN',
     entity: 'Unión Hondureña',
   },
   {
     email: 'admin.central@uhn.test',
     full_name: 'Admin Asociación Central',
     sub: 'auth0|69583e476d2265af6faf2db8',
-    role: 'ASSOCIATION_ADMIN',
+    role: 'ADMIN',
     entity: 'Asociación Central',
   },
   {
     email: 'admin.noroccidental@uhn.test',
     full_name: 'Admin Asociación Nor-occidental',
     sub: 'auth0|69583e5e6ccfb90819e23085',
-    role: 'ASSOCIATION_ADMIN',
+    role: 'ADMIN',
     entity: 'Asociación Nor-occidental',
   },
   {
     email: 'admin.nororiental@uhn.test',
     full_name: 'Admin Asociación Nor-oriental',
     sub: 'auth0|69583e8889bb367a376574dd',
-    role: 'ASSOCIATION_ADMIN',
+    role: 'ADMIN',
     entity: 'Asociación Nor-oriental',
   },
   {
     email: 'obrero.copan@uhn.test',
     full_name: 'Obrero Campo Copán',
     sub: 'auth0|69583ec26d2265af6faf2deb',
-    role: 'FIELD_WORKER',
+    role: 'MISSIONARY',
     entity: 'Campo Copán',
   },
   {
     email: 'obrero.tegucigalpa@uhn.test',
     full_name: 'Obrero Campo Tegucigalpa',
     sub: 'auth0|69583ed7292a80e2ca479bda',
-    role: 'FIELD_WORKER',
+    role: 'MISSIONARY',
     entity: 'Campo Tegucigalpa',
   },
   {
     email: 'obrero.sps@uhn.test',
     full_name: 'Obrero Campo San Pedro Sula',
     sub: 'auth0|69583eec89bb367a37657519',
-    role: 'FIELD_WORKER',
+    role: 'MISSIONARY',
     entity: 'Campo San Pedro Sula',
   },
 ];
@@ -89,6 +89,8 @@ async function run() {
       user.username = u.email;
       user.full_name = u.full_name;
       user.status = UserStatus.ACTIVE;
+      user.role = role;
+      user.entity = entity;
 
       await userRepo.save(user);
     }
@@ -119,10 +121,19 @@ async function run() {
     });
 
     if (!existingAssignment) {
+      const startDate = new Date().toISOString().split('T')[0];
+      // Calculate end date based on entity's term length (default 5 years)
+      const endYear = new Date().getFullYear() + (entity.term_length_years || 5);
+      const endDate = `${endYear}-12-31`;
+      
       const assignment = assignmentRepo.create({
         user,
         role,
         entity,
+        start_date: startDate,
+        end_date: endDate,
+        created_by: user.id,
+        updated_by: user.id,
       });
       await assignmentRepo.save(assignment);
     }

--- a/backend/scripts/seed-roles-and-activities.ts
+++ b/backend/scripts/seed-roles-and-activities.ts
@@ -25,6 +25,32 @@ async function seedRolesAndActivities() {
 
   const roleActivityMappings: RoleActivityMapping[] = [
     {
+      roleName: 'ADMIN',
+      roleDescription: 'Administrador del sistema con acceso completo',
+      activityTypes: [],
+    },
+    {
+      roleName: 'MISSIONARY',
+      roleDescription: 'Misionero/Obrero de campo con actividades evangelísticas',
+      activityTypes: [
+        { name: 'Visitas a miembros', description: 'Visitas a miembros de la iglesia' },
+        { name: 'Visitas a interesados', description: 'Visitas a personas interesadas' },
+        { name: 'Visita a infantes', description: 'Visitas a infantes' },
+        { name: 'Estudios bíblicos', description: 'Estudios bíblicos' },
+        { name: 'Cultos en hogares', description: 'Cultos realizados en hogares' },
+        { name: 'Conversaciones oportunas', description: 'Conversaciones evangelísticas oportunas' },
+        { name: 'Contactos Misioneros', description: 'Contactos con fines misioneros' },
+        { name: 'Predicaciones', description: 'Predicaciones y sermones' },
+        { name: 'Dirección de programas', description: 'Dirección de programas de la iglesia' },
+        { name: 'Seminarios', description: 'Seminarios y capacitaciones' },
+        { name: 'Reuniones de comité', description: 'Reuniones de comité' },
+        { name: 'Reunión de iglesia', description: 'Reunión de iglesia regular' },
+        { name: 'Viaje', description: 'Viajes relacionados con el ministerio' },
+        { name: 'Oficina', description: 'Trabajo de oficina y administrativo' },
+        { name: 'Días libres', description: 'Días libres' },
+      ],
+    },
+    {
       roleName: 'Ministro',
       roleDescription: 'Ministro con privilegios completos para actividades ministeriales',
       activityTypes: [

--- a/backend/src/activities-type/activity-types.controller.spec.ts
+++ b/backend/src/activities-type/activity-types.controller.spec.ts
@@ -65,6 +65,7 @@ describe('ActivityTypesController', () => {
     const mockService = {
       findAll: jest.fn(),
       findAllByUserRole: jest.fn(),
+      findAllByUserRoleAssignments: jest.fn(),
       findOne: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
@@ -127,7 +128,7 @@ describe('ActivityTypesController', () => {
       const authorizedTypes = [mockActivityTypes[0]];
 
       identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
-      service.findAllByUserRole.mockResolvedValue(authorizedTypes as ActivityType[]);
+      service.findAllByUserRoleAssignments.mockResolvedValue(authorizedTypes as ActivityType[]);
 
       const result = await controller.getAuthorized(mockRequest);
 
@@ -135,7 +136,7 @@ describe('ActivityTypesController', () => {
         'auth0|123456',
         'https://test.auth0.com/',
       );
-      expect(service.findAllByUserRole).toHaveBeenCalledWith('role-missionary');
+      expect(service.findAllByUserRoleAssignments).toHaveBeenCalledWith('user-123');
       expect(result).toEqual(authorizedTypes);
     });
 
@@ -153,7 +154,7 @@ describe('ActivityTypesController', () => {
       } as Request & { user: JwtValidatedUser };
 
       identityService.resolveUserBySubAndIssuer.mockResolvedValue(mockUser as any);
-      service.findAllByUserRole.mockResolvedValue([]);
+      service.findAllByUserRoleAssignments.mockResolvedValue([]);
 
       const result = await controller.getAuthorized(mockRequest);
 

--- a/backend/src/activities-type/activity-types.controller.ts
+++ b/backend/src/activities-type/activity-types.controller.ts
@@ -45,7 +45,7 @@ export class ActivityTypesController {
   async getAuthorized(@Req() req: Request) {
     const { sub, iss } = (req.user as JwtValidatedUser) ?? {};
     const user = await this.identityService.resolveUserBySubAndIssuer(sub, iss);
-    return this.service.findAllByUserRole(user.role_id);
+    return this.service.findAllByUserRoleAssignments(user.id);
   }
 
   @Get(':id')

--- a/backend/src/activities-type/activity-types.module.ts
+++ b/backend/src/activities-type/activity-types.module.ts
@@ -4,6 +4,7 @@ import { ActivityType } from './activity-type.entity';
 import { ActivityTypesService } from './activity-types.service';
 import { ActivityTypesController } from './activity-types.controller';
 import { Role } from '../roles/role.entity';
+import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 import { ACTIVITY_TYPE_USAGE_POLICY } from './usage/activity-type-usage.policy';
 import type { ActivityTypeUsagePolicy } from './usage/activity-type-usage.policy';
 import { NullActivityTypeUsagePolicy } from './usage/null-activity-type-usage.policy';
@@ -12,7 +13,7 @@ import { IdpIdentity } from '../idp-identities/idp-identity.entity';
 import { User } from '../users/user.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ActivityType, Role, IdpIdentity, User])],
+  imports: [TypeOrmModule.forFeature([ActivityType, Role, UserRoleAssignment, IdpIdentity, User])],
   controllers: [ActivityTypesController],
   providers: [
     ActivityTypesService,

--- a/backend/src/activities-type/activity-types.service.ts
+++ b/backend/src/activities-type/activity-types.service.ts
@@ -5,6 +5,7 @@ import { ActivityType } from './activity-type.entity';
 import { CreateActivityTypeDto } from './dto/create-activity-type.dto';
 import { UpdateActivityTypeDto } from './dto/update-activity-type.dto';
 import { Role } from '../roles/role.entity';
+import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 import {
   ACTIVITY_TYPE_USAGE_POLICY,
   ActivityTypeUsagePolicy,
@@ -15,6 +16,7 @@ export class ActivityTypesService {
   constructor(
     @InjectRepository(ActivityType) private readonly repo: Repository<ActivityType>,
     @InjectRepository(Role) private readonly rolesRepo: Repository<Role>,
+    @InjectRepository(UserRoleAssignment) private readonly uraRepo: Repository<UserRoleAssignment>,
     @Inject(ACTIVITY_TYPE_USAGE_POLICY) private readonly usagePolicy: ActivityTypeUsagePolicy,
   ) {}
 
@@ -59,6 +61,27 @@ export class ActivityTypesService {
       .createQueryBuilder('activity_type')
       .leftJoinAndSelect('activity_type.allowed_roles', 'role')
       .where('role.id = :roleId', { roleId: userRoleId })
+      .getMany();
+  }
+
+  async findAllByUserRoleAssignments(userId: string): Promise<ActivityType[]> {
+    // Get all role IDs from user's active role assignments
+    const roleAssignments = await this.uraRepo.find({
+      where: { user: { id: userId } },
+      relations: ['role'],
+    });
+
+    if (roleAssignments.length === 0) {
+      return [];
+    }
+
+    const roleIds = roleAssignments.map((assignment) => assignment.role.id);
+
+    // Get all activity types that match any of the user's roles
+    return this.repo
+      .createQueryBuilder('activity_type')
+      .leftJoinAndSelect('activity_type.allowed_roles', 'role')
+      .where('role.id IN (:...roleIds)', { roleIds })
       .getMany();
   }
 

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -33,7 +33,10 @@ import { ReportsModule } from './reports/reports.module';
       database: process.env.DB_NAME,
       autoLoadEntities: true,
       synchronize: process.env.NODE_ENV !== 'production',
-      ssl: process.env.NODE_ENV === 'production',
+      ssl:
+        process.env.DB_HOST?.includes('neon.tech') || process.env.NODE_ENV === 'production'
+          ? { rejectUnauthorized: false }
+          : false,
     }),
     EntitiesModule,
     AdminModule,

--- a/backend/src/entities/tests/activity-types.service.spec.ts
+++ b/backend/src/entities/tests/activity-types.service.spec.ts
@@ -6,6 +6,7 @@ import { Repository, In, ObjectLiteral } from 'typeorm';
 import { ActivityTypesService } from '../../activities-type/activity-types.service';
 import { ActivityType, GrowthDirection } from '../../activities-type/activity-type.entity';
 import { Role } from '../../roles/role.entity';
+import { UserRoleAssignment } from '../../roles/user-role-assignment.entity';
 import { ACTIVITY_TYPE_USAGE_POLICY } from '../../activities-type/usage/activity-type-usage.policy';
 
 class UsagePolicyStub {
@@ -28,6 +29,7 @@ describe('ActivityTypesService', () => {
   let service: ActivityTypesService;
   let activityTypeRepo: jest.Mocked<Repository<ActivityType>>;
   let roleRepo: jest.Mocked<Repository<Role>>;
+  let uraRepo: jest.Mocked<Repository<UserRoleAssignment>>;
   let usagePolicy: UsagePolicyStub;
 
   const roleMissionary: Role = {
@@ -71,6 +73,7 @@ describe('ActivityTypesService', () => {
   beforeEach(async () => {
     activityTypeRepo = createMockRepo<ActivityType>();
     roleRepo = createMockRepo<Role>();
+    uraRepo = createMockRepo<UserRoleAssignment>();
     usagePolicy = new UsagePolicyStub();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -78,6 +81,7 @@ describe('ActivityTypesService', () => {
         ActivityTypesService,
         { provide: getRepositoryToken(ActivityType), useValue: activityTypeRepo },
         { provide: getRepositoryToken(Role), useValue: roleRepo },
+        { provide: getRepositoryToken(UserRoleAssignment), useValue: uraRepo },
         { provide: ACTIVITY_TYPE_USAGE_POLICY, useValue: usagePolicy },
       ],
     })


### PR DESCRIPTION
This PR adds support for cloud PostgreSQL databases and implements complete seeding scripts for Honduras organizational structure and users.

### Database Configuration:
- **SSL Support for Cloud Databases**: Updated TypeORM configuration to detect and enable SSL for Neon PostgreSQL (cloud-hosted database)
- SSL is automatically enabled when `DB_HOST` includes "neon.tech" or in production environments
- Uses `rejectUnauthorized: false` for compatibility with cloud database certificates

### Seeding Infrastructure:
- **New npm Scripts**:
  - `seed:roles` - Seeds roles and activity types
  - `seed:honduras-structure` - Creates Honduras organizational hierarchy
  - `seed:honduras-users` - Seeds Honduras users with role assignments

### Honduras Organizational Structure:
- Created platform entity (Plataforma Global)
- Created Unión Hondureña with 3 associations:
  - Asociación Nor-occidental
  - Asociación Central  
  - Asociación Nor-oriental
- Created 9 field entities across the 3 associations

### User Management:
- Added role seeding with proper activity types:
  - `ADMIN` role for system and association administrators
  - `MISSIONARY` role for field workers with evangelistic activities
- Seeded 7 Honduras users:
  - 4 administrators (union and association level)
  - 3 field workers (missionaries)
- Fixed user role assignment with required fields: `start_date`, `end_date`, `created_by`, `updated_by`

### Technical Fixes:
- Fixed entity hierarchy validation (UNION entities now require PLATFORM parent)
- Updated role names to match existing `RoleEnum` values
- Added missionary activity types for field workers
- Proper handling of snake_case database column names

### Testing:
-  Successfully connects to Neon PostgreSQL
- Platform and organizational hierarchy created correctly
-  Roles and activity types seeded successfully
- Users created with proper role assignments
-  Field workers can create activities