### PR TITLE
feat: Add role-based activity filtering and dashboard improvements

### DIFF
--- a/backend/src/activities-type/activity-types.controller.ts
+++ b/backend/src/activities-type/activity-types.controller.ts
@@ -48,6 +48,28 @@ export class ActivityTypesController {
     return this.service.findAllByUserRoleAssignments(user.id);
   }
 
+  @Get('user-roles/me')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Get current user role assignments' })
+  @ApiResponse({ status: 200, description: 'List of user role assignments' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getMyRoleAssignments(@Req() req: Request) {
+    const { sub, iss } = (req.user as JwtValidatedUser) ?? {};
+    const user = await this.identityService.resolveUserBySubAndIssuer(sub, iss);
+    return this.service.getUserRoleAssignments(user.id);
+  }
+
+  @Get('by-role/:roleId')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'List activity types by specific role' })
+  @ApiResponse({ status: 200, description: 'List of activity types for the role' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getByRole(@Param('roleId', new ParseUUIDPipe()) roleId: string) {
+    return this.service.findAllByUserRole(roleId);
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get a single activity type by ID' })
   @ApiResponse({ status: 200, description: 'Activity type details' })

--- a/backend/src/activities-type/activity-types.service.ts
+++ b/backend/src/activities-type/activity-types.service.ts
@@ -85,6 +85,13 @@ export class ActivityTypesService {
       .getMany();
   }
 
+  async getUserRoleAssignments(userId: string): Promise<UserRoleAssignment[]> {
+    return this.uraRepo.find({
+      where: { user: { id: userId } },
+      relations: ['role', 'entity'],
+    });
+  }
+
   async findOne(id: string): Promise<ActivityType> {
     const found = await this.repo.findOne({ where: { id } });
     if (!found) throw new NotFoundException('Activity type not found.');

--- a/frontend/lib/models/activity_type.dart
+++ b/frontend/lib/models/activity_type.dart
@@ -1,19 +1,49 @@
-class ActivityType {
+class Role {
   final String id;
   final String name;
   final String description;
 
-  ActivityType({
+  Role({
     required this.id,
     required this.name,
     required this.description,
   });
 
+  factory Role.fromJson(Map<String, dynamic> json) {
+    return Role(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String? ?? '',
+    );
+  }
+}
+
+class ActivityType {
+  final String id;
+  final String name;
+  final String description;
+  final List<Role> allowedRoles;
+
+  ActivityType({
+    required this.id,
+    required this.name,
+    required this.description,
+    this.allowedRoles = const [],
+  });
+
   factory ActivityType.fromJson(Map<String, dynamic> json) {
+    final rolesJson = json['allowed_roles'] as List<dynamic>?;
+    final roles = rolesJson
+            ?.map((r) => Role.fromJson(r as Map<String, dynamic>))
+            .toList() ??
+        [];
+
     return ActivityType(
       id: json['id'] as String,
       name: json['name'] as String,
       description: json['description'] as String,
+      allowedRoles: roles,
     );
   }
 }
+

--- a/frontend/lib/models/activity_type.dart
+++ b/frontend/lib/models/activity_type.dart
@@ -46,4 +46,3 @@ class ActivityType {
     );
   }
 }
-

--- a/frontend/lib/models/dashboard_stats.dart
+++ b/frontend/lib/models/dashboard_stats.dart
@@ -40,10 +40,10 @@ class DashboardStats {
       final name = (itemMap['name'] as String? ?? '').toLowerCase();
       final count = (itemMap['count'] as num?)?.toInt() ?? 0;
 
-      if (name.contains('visita') &&
-          (name.contains('misioner') || name.contains('interesad'))) {
+      if (name.contains('visita')) {
         visits += count;
-      } else if (name.contains('estudio') && name.contains('bíblico')) {
+      } 
+      else if (name.contains('estudio') && name.contains('b') && name.contains('blic')) {
         bibleStudies += count;
       }
     }

--- a/frontend/lib/models/dashboard_stats.dart
+++ b/frontend/lib/models/dashboard_stats.dart
@@ -42,8 +42,9 @@ class DashboardStats {
 
       if (name.contains('visita')) {
         visits += count;
-      } 
-      else if (name.contains('estudio') && name.contains('b') && name.contains('blic')) {
+      } else if (name.contains('estudio') &&
+          name.contains('b') &&
+          name.contains('blic')) {
         bibleStudies += count;
       }
     }

--- a/frontend/lib/models/user_role_assignment.dart
+++ b/frontend/lib/models/user_role_assignment.dart
@@ -59,8 +59,10 @@ class UserRoleAssignment {
   factory UserRoleAssignment.fromJson(Map<String, dynamic> json) {
     return UserRoleAssignment(
       id: json['id'] as String,
-      role: UserRoleAssignmentRole.fromJson(json['role'] as Map<String, dynamic>),
-      entity: UserRoleAssignmentEntity.fromJson(json['entity'] as Map<String, dynamic>),
+      role:
+          UserRoleAssignmentRole.fromJson(json['role'] as Map<String, dynamic>),
+      entity: UserRoleAssignmentEntity.fromJson(
+          json['entity'] as Map<String, dynamic>),
       startDate: json['start_date'] as String,
       endDate: json['end_date'] as String,
     );

--- a/frontend/lib/models/user_role_assignment.dart
+++ b/frontend/lib/models/user_role_assignment.dart
@@ -1,0 +1,75 @@
+class UserRoleAssignmentRole {
+  final String id;
+  final String name;
+  final String description;
+
+  UserRoleAssignmentRole({
+    required this.id,
+    required this.name,
+    required this.description,
+  });
+
+  factory UserRoleAssignmentRole.fromJson(Map<String, dynamic> json) {
+    return UserRoleAssignmentRole(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String? ?? '',
+    );
+  }
+}
+
+class UserRoleAssignmentEntity {
+  final String id;
+  final String name;
+  final String description;
+  final String type;
+
+  UserRoleAssignmentEntity({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.type,
+  });
+
+  factory UserRoleAssignmentEntity.fromJson(Map<String, dynamic> json) {
+    return UserRoleAssignmentEntity(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String? ?? '',
+      type: json['type'] as String,
+    );
+  }
+}
+
+class UserRoleAssignment {
+  final String id;
+  final UserRoleAssignmentRole role;
+  final UserRoleAssignmentEntity entity;
+  final String startDate;
+  final String endDate;
+
+  UserRoleAssignment({
+    required this.id,
+    required this.role,
+    required this.entity,
+    required this.startDate,
+    required this.endDate,
+  });
+
+  factory UserRoleAssignment.fromJson(Map<String, dynamic> json) {
+    return UserRoleAssignment(
+      id: json['id'] as String,
+      role: UserRoleAssignmentRole.fromJson(json['role'] as Map<String, dynamic>),
+      entity: UserRoleAssignmentEntity.fromJson(json['entity'] as Map<String, dynamic>),
+      startDate: json['start_date'] as String,
+      endDate: json['end_date'] as String,
+    );
+  }
+
+  bool get isActive {
+    final now = DateTime.now();
+    final start = DateTime.parse(startDate);
+    final end = DateTime.parse(endDate);
+    return now.isAfter(start) && now.isBefore(end);
+  }
+}

--- a/frontend/lib/providers/auth.dart
+++ b/frontend/lib/providers/auth.dart
@@ -67,23 +67,18 @@ class AuthNotifier extends StateNotifier<AuthState> {
   bool _bootstrapped = false;
   bool _isRedirecting = false;
 
-  /// Generate a cryptographically secure random code_verifier for PKCE
-  /// Length: 43-128 characters, charset: A-Z a-z 0-9 - . _ ~
   String _generateCodeVerifier() {
     const charset =
         'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
     final random = Random.secure();
-    const length = 128; // Maximum length for better security
+    const length = 128;
     return List.generate(length, (_) => charset[random.nextInt(charset.length)])
         .join();
   }
 
-  /// Generate code_challenge from code_verifier using SHA256 and base64url encoding
-  /// Returns BASE64URL(SHA256(code_verifier)) without padding
   String _generateCodeChallenge(String verifier) {
     final bytes = utf8.encode(verifier);
     final digest = sha256.convert(bytes);
-    // Use base64Url encoding without padding
     return base64Url.encode(digest.bytes).replaceAll('=', '');
   }
 
@@ -179,7 +174,6 @@ class AuthNotifier extends StateNotifier<AuthState> {
         throw Exception('No authorization code found in callback URL');
       }
 
-      // Retrieve the PKCE code_verifier from localStorage
       final codeVerifier =
           web.window.localStorage.getItem('pkce_code_verifier');
       if (codeVerifier == null || codeVerifier.isEmpty) {
@@ -220,7 +214,6 @@ class AuthNotifier extends StateNotifier<AuthState> {
           final mergedUserInfo = {...userInfo, ...backendProfile};
 
           web.window.localStorage.setItem('auth_token', accessToken);
-          // Remove PKCE verifier after successful token exchange
           web.window.localStorage.removeItem('pkce_code_verifier');
           await _session.saveToken(accessToken);
 
@@ -276,7 +269,17 @@ class AuthNotifier extends StateNotifier<AuthState> {
         );
       } else {
         web.window.localStorage.removeItem('auth_token');
-        throw Exception('Invalid token');
+        await _session.clear();
+        state = state.copyWith(
+          isLoading: false,
+          isAuthenticated: false,
+          accessToken: null,
+          user: null,
+        );
+        if (!_isRedirecting) {
+          await login();
+        }
+        return;
       }
     } catch (e) {
       state = state.copyWith(
@@ -292,11 +295,9 @@ class AuthNotifier extends StateNotifier<AuthState> {
     _isRedirecting = true;
 
     try {
-      // Generate PKCE code_verifier and code_challenge
       final codeVerifier = _generateCodeVerifier();
       final codeChallenge = _generateCodeChallenge(codeVerifier);
 
-      // Store code_verifier in localStorage BEFORE redirecting
       web.window.localStorage.setItem('pkce_code_verifier', codeVerifier);
 
       debugPrint(
@@ -342,29 +343,42 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<void> logout() async {
     try {
       web.window.localStorage.removeItem('auth_token');
+      web.window.localStorage.removeItem('pkce_code_verifier');
+      
+      await _session.clear();
+      
+      state = AuthState.initial().copyWith(isLoading: true);
 
+      var returnUrl = AuthConfig.redirectUri.replaceAll(RegExp(r'/$'), '');
+      
       final logoutUrl = Uri.https(AuthConfig.domain, '/v2/logout', {
         'client_id': AuthConfig.clientId,
-        'returnTo': AuthConfig.redirectUri,
+        'returnTo': returnUrl,
       });
 
+      debugPrint('[AuthNotifier] Logging out, redirecting to: $logoutUrl');
+      
+      await Future.delayed(const Duration(milliseconds: 100));
+      
       web.window.location.assign(logoutUrl.toString());
-    } finally {
+    } catch (e) {
+      debugPrint('[AuthNotifier] Error during logout: $e');
       try {
+        web.window.localStorage.removeItem('auth_token');
+        web.window.localStorage.removeItem('pkce_code_verifier');
         await _session.clear();
       } catch (_) {}
-      state = AuthState.initial().copyWith(isLoading: false);
+      state = AuthState.initial();
+      web.window.location.reload();
     }
   }
 }
 
-/// Provider to check if current user can view hierarchy reports
 final canViewReportsProvider = Provider<bool>((ref) {
   final authState = ref.watch(authNotifierProvider);
   final primaryRole = authState.user?['primary_role'] as Map<String, dynamic>?;
   final roleName = primaryRole?['name'] as String?;
 
-  // Leadership roles that can view hierarchy reports
   const leadershipRoles = [
     'admin',
     'System Admin',

--- a/frontend/lib/providers/auth.dart
+++ b/frontend/lib/providers/auth.dart
@@ -344,22 +344,22 @@ class AuthNotifier extends StateNotifier<AuthState> {
     try {
       web.window.localStorage.removeItem('auth_token');
       web.window.localStorage.removeItem('pkce_code_verifier');
-      
+
       await _session.clear();
-      
+
       state = AuthState.initial().copyWith(isLoading: true);
 
       var returnUrl = AuthConfig.redirectUri.replaceAll(RegExp(r'/$'), '');
-      
+
       final logoutUrl = Uri.https(AuthConfig.domain, '/v2/logout', {
         'client_id': AuthConfig.clientId,
         'returnTo': returnUrl,
       });
 
       debugPrint('[AuthNotifier] Logging out, redirecting to: $logoutUrl');
-      
+
       await Future.delayed(const Duration(milliseconds: 100));
-      
+
       web.window.location.assign(logoutUrl.toString());
     } catch (e) {
       debugPrint('[AuthNotifier] Error during logout: $e');

--- a/frontend/lib/providers/dashboard_stats.dart
+++ b/frontend/lib/providers/dashboard_stats.dart
@@ -35,10 +35,12 @@ class DashboardStatsNotifier extends StateNotifier<AsyncValue<DashboardStats>> {
     final now = DateTime.now();
     final firstDay = DateTime(now.year, now.month, 1);
     final lastDay = DateTime(now.year, now.month + 1, 0);
-    
-    final periodStart = '${firstDay.year}-${firstDay.month.toString().padLeft(2, '0')}-${firstDay.day.toString().padLeft(2, '0')}';
-    final periodEnd = '${lastDay.year}-${lastDay.month.toString().padLeft(2, '0')}-${lastDay.day.toString().padLeft(2, '0')}';
-    
+
+    final periodStart =
+        '${firstDay.year}-${firstDay.month.toString().padLeft(2, '0')}-${firstDay.day.toString().padLeft(2, '0')}';
+    final periodEnd =
+        '${lastDay.year}-${lastDay.month.toString().padLeft(2, '0')}-${lastDay.day.toString().padLeft(2, '0')}';
+
     fetch(periodStart: periodStart, periodEnd: periodEnd);
   }
 }

--- a/frontend/lib/providers/dashboard_stats.dart
+++ b/frontend/lib/providers/dashboard_stats.dart
@@ -32,7 +32,14 @@ class DashboardStatsNotifier extends StateNotifier<AsyncValue<DashboardStats>> {
   }
 
   void refresh() {
-    fetch();
+    final now = DateTime.now();
+    final firstDay = DateTime(now.year, now.month, 1);
+    final lastDay = DateTime(now.year, now.month + 1, 0);
+    
+    final periodStart = '${firstDay.year}-${firstDay.month.toString().padLeft(2, '0')}-${firstDay.day.toString().padLeft(2, '0')}';
+    final periodEnd = '${lastDay.year}-${lastDay.month.toString().padLeft(2, '0')}-${lastDay.day.toString().padLeft(2, '0')}';
+    
+    fetch(periodStart: periodStart, periodEnd: periodEnd);
   }
 }
 

--- a/frontend/lib/services/activity_type.dart
+++ b/frontend/lib/services/activity_type.dart
@@ -51,7 +51,8 @@ class ActivityTypeService {
   Future<List<UserRoleAssignment>> fetchUserRoles() async {
     try {
       final decoded = await apiClient.get('/activity-types/user-roles/me');
-      debugPrint('[ActivityTypeService] Successfully fetched user role assignments');
+      debugPrint(
+          '[ActivityTypeService] Successfully fetched user role assignments');
 
       final list = _extractList(decoded);
       return list.map<UserRoleAssignment>((e) {
@@ -73,7 +74,8 @@ class ActivityTypeService {
   Future<List<ActivityType>> fetchByRole(String roleId) async {
     try {
       final decoded = await apiClient.get('/activity-types/by-role/$roleId');
-      debugPrint('[ActivityTypeService] Successfully fetched activity types for role $roleId');
+      debugPrint(
+          '[ActivityTypeService] Successfully fetched activity types for role $roleId');
 
       final list = _extractList(decoded);
       return list.map<ActivityType>((e) {
@@ -87,9 +89,9 @@ class ActivityTypeService {
         );
       }).toList();
     } catch (e) {
-      debugPrint('[ActivityTypeService] Error fetching activity types by role: $e');
+      debugPrint(
+          '[ActivityTypeService] Error fetching activity types by role: $e');
       rethrow;
     }
   }
 }
-

--- a/frontend/lib/services/activity_type.dart
+++ b/frontend/lib/services/activity_type.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import '../models/activity_type.dart';
+import '../models/user_role_assignment.dart';
 import '../core/api_client.dart';
 import '../core/errors/app_exception.dart';
 
@@ -46,4 +47,49 @@ class ActivityTypeService {
       rethrow;
     }
   }
+
+  Future<List<UserRoleAssignment>> fetchUserRoles() async {
+    try {
+      final decoded = await apiClient.get('/activity-types/user-roles/me');
+      debugPrint('[ActivityTypeService] Successfully fetched user role assignments');
+
+      final list = _extractList(decoded);
+      return list.map<UserRoleAssignment>((e) {
+        if (e is Map<String, dynamic>) return UserRoleAssignment.fromJson(e);
+        if (e is Map) {
+          return UserRoleAssignment.fromJson(Map<String, dynamic>.from(e));
+        }
+        throw const ValidationException(
+          userMessage: 'Received invalid data format from server',
+          technicalMessage: 'Item is not an object',
+        );
+      }).toList();
+    } catch (e) {
+      debugPrint('[ActivityTypeService] Error fetching user roles: $e');
+      rethrow;
+    }
+  }
+
+  Future<List<ActivityType>> fetchByRole(String roleId) async {
+    try {
+      final decoded = await apiClient.get('/activity-types/by-role/$roleId');
+      debugPrint('[ActivityTypeService] Successfully fetched activity types for role $roleId');
+
+      final list = _extractList(decoded);
+      return list.map<ActivityType>((e) {
+        if (e is Map<String, dynamic>) return ActivityType.fromJson(e);
+        if (e is Map) {
+          return ActivityType.fromJson(Map<String, dynamic>.from(e));
+        }
+        throw const ValidationException(
+          userMessage: 'Received invalid data format from server',
+          technicalMessage: 'Item is not an object',
+        );
+      }).toList();
+    } catch (e) {
+      debugPrint('[ActivityTypeService] Error fetching activity types by role: $e');
+      rethrow;
+    }
+  }
 }
+

--- a/frontend/lib/widgets/dialogs/activity_form_dialog.dart
+++ b/frontend/lib/widgets/dialogs/activity_form_dialog.dart
@@ -327,16 +327,18 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
                           );
                         }
 
-                        final roles = snapshot.data ?? const <UserRoleAssignment>[];
-                        final activeRoles = roles.where((r) => r.isActive).toList();
-                        
+                        final roles =
+                            snapshot.data ?? const <UserRoleAssignment>[];
+                        final activeRoles =
+                            roles.where((r) => r.isActive).toList();
+
                         if (activeRoles.isEmpty) {
                           return Text('No tienes roles asignados.',
                               style: theme.textTheme.bodyMedium);
                         }
 
                         return DropdownButtonFormField<UserRoleAssignment>(
-                        initialValue: _selectedRole,
+                          initialValue: _selectedRole,
                           isExpanded: true,
                           items: activeRoles
                               .map((r) => DropdownMenuItem<UserRoleAssignment>(
@@ -351,7 +353,8 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
                                     _selectedRole = v;
                                     _selectedType = null;
                                     if (v != null) {
-                                      _typesFuture = _typeService.fetchByRole(v.role.id);
+                                      _typesFuture =
+                                          _typeService.fetchByRole(v.role.id);
                                     }
                                   });
                                 },

--- a/frontend/lib/widgets/dialogs/activity_form_dialog.dart
+++ b/frontend/lib/widgets/dialogs/activity_form_dialog.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 
 import '../dialogs/calendar_dialog.dart';
 import '../../models/activity_type.dart';
+import '../../models/user_role_assignment.dart';
 import '../../services/activity_type.dart';
 import '../../core/validators.dart';
 import '../../core/api_client.dart';
@@ -35,8 +36,10 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
   final _formKey = GlobalKey<FormState>();
 
   late final ActivityTypeService _typeService;
+  late Future<List<UserRoleAssignment>> _rolesFuture;
   late Future<List<ActivityType>> _typesFuture;
 
+  UserRoleAssignment? _selectedRole;
   ActivityType? _selectedType;
 
   final TextEditingController _dateCtrl = TextEditingController();
@@ -68,6 +71,9 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
       apiClient: apiClient,
       path: widget.typesPath,
     );
+
+    _rolesFuture = _typeService.fetchUserRoles();
+    _typesFuture = _typeService.fetchAll();
 
     // Pre-populate fields if editing
     if (isEditMode) {
@@ -164,7 +170,6 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
       http.Response resp;
 
       if (isEditMode) {
-        // Update existing activity
         resp = await http.patch(
           Uri.parse('${widget.baseUrl}/activities/$_activityId'),
           headers: {
@@ -174,7 +179,6 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
           body: jsonEncode(payload),
         );
       } else {
-        // Create new activity
         resp = await http.post(
           Uri.parse('${widget.baseUrl}/activities'),
           headers: {
@@ -273,6 +277,99 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
                   children: [
                     Align(
                       alignment: Alignment.centerLeft,
+                      child: Text('Rol', style: theme.textTheme.labelLarge),
+                    ),
+                    const SizedBox(height: 8),
+                    FutureBuilder<List<UserRoleAssignment>>(
+                      future: _rolesFuture,
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState ==
+                            ConnectionState.waiting) {
+                          return const Padding(
+                            padding: EdgeInsets.symmetric(vertical: 12),
+                            child: Row(
+                              children: [
+                                SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2),
+                                ),
+                                SizedBox(width: 10),
+                                Text('Cargando roles...'),
+                              ],
+                            ),
+                          );
+                        }
+
+                        if (snapshot.hasError) {
+                          final err = snapshot.error?.toString() ?? 'Error';
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Error al cargar los roles: $err',
+                                style: theme.textTheme.bodyMedium
+                                    ?.copyWith(color: theme.colorScheme.error),
+                              ),
+                              const SizedBox(height: 8),
+                              OutlinedButton.icon(
+                                onPressed: _submitting
+                                    ? null
+                                    : () {
+                                        setState(() => _rolesFuture =
+                                            _typeService.fetchUserRoles());
+                                      },
+                                icon: const Icon(Icons.refresh),
+                                label: const Text('Reintentar'),
+                              ),
+                            ],
+                          );
+                        }
+
+                        final roles = snapshot.data ?? const <UserRoleAssignment>[];
+                        final activeRoles = roles.where((r) => r.isActive).toList();
+                        
+                        if (activeRoles.isEmpty) {
+                          return Text('No tienes roles asignados.',
+                              style: theme.textTheme.bodyMedium);
+                        }
+
+                        return DropdownButtonFormField<UserRoleAssignment>(
+                          value: _selectedRole,
+                          isExpanded: true,
+                          items: activeRoles
+                              .map((r) => DropdownMenuItem<UserRoleAssignment>(
+                                    value: r,
+                                    child: Text(r.role.name),
+                                  ))
+                              .toList(),
+                          onChanged: _submitting
+                              ? null
+                              : (v) {
+                                  setState(() {
+                                    _selectedRole = v;
+                                    _selectedType = null;
+                                    if (v != null) {
+                                      _typesFuture = _typeService.fetchByRole(v.role.id);
+                                    }
+                                  });
+                                },
+                          validator: (v) => Validators.requiredField(
+                            v,
+                            fieldName: 'El rol',
+                          ),
+                          decoration: const InputDecoration(
+                            border: OutlineInputBorder(),
+                            hintText: 'Selecciona un rol',
+                            isDense: true,
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    Align(
+                      alignment: Alignment.centerLeft,
                       child: Text('Tipo de actividad',
                           style: theme.textTheme.labelLarge),
                     ),
@@ -280,6 +377,15 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
                     FutureBuilder<List<ActivityType>>(
                       future: _typesFuture,
                       builder: (context, snapshot) {
+                        if (_selectedRole == null) {
+                          return Text(
+                            'Primero selecciona un rol',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: Colors.grey.shade600,
+                            ),
+                          );
+                        }
+
                         if (snapshot.connectionState ==
                             ConnectionState.waiting) {
                           return const Padding(

--- a/frontend/lib/widgets/dialogs/activity_form_dialog.dart
+++ b/frontend/lib/widgets/dialogs/activity_form_dialog.dart
@@ -336,7 +336,7 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
                         }
 
                         return DropdownButtonFormField<UserRoleAssignment>(
-                          value: _selectedRole,
+                        initialValue: _selectedRole,
                           isExpanded: true,
                           items: activeRoles
                               .map((r) => DropdownMenuItem<UserRoleAssignment>(

--- a/frontend/lib/widgets/dialogs/create_activity_dialog.dart
+++ b/frontend/lib/widgets/dialogs/create_activity_dialog.dart
@@ -272,7 +272,7 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                         }
 
                         return DropdownButtonFormField<UserRoleAssignment>(
-                          value: _selectedRole,
+                        initialValue: _selectedRole,
                           isExpanded: true,
                           items: activeRoles
                               .map((r) => DropdownMenuItem<UserRoleAssignment>(
@@ -399,7 +399,7 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                         }
 
                         return DropdownButtonFormField<ActivityType>(
-                          value: _selectedType,
+                        initialValue: _selectedType,
                           isExpanded: true,
                           items: types
                               .map((t) => DropdownMenuItem<ActivityType>(

--- a/frontend/lib/widgets/dialogs/create_activity_dialog.dart
+++ b/frontend/lib/widgets/dialogs/create_activity_dialog.dart
@@ -263,16 +263,18 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                           );
                         }
 
-                        final roles = snapshot.data ?? const <UserRoleAssignment>[];
-                        final activeRoles = roles.where((r) => r.isActive).toList();
-                        
+                        final roles =
+                            snapshot.data ?? const <UserRoleAssignment>[];
+                        final activeRoles =
+                            roles.where((r) => r.isActive).toList();
+
                         if (activeRoles.isEmpty) {
                           return Text('No tienes roles asignados.',
                               style: theme.textTheme.bodyMedium);
                         }
 
                         return DropdownButtonFormField<UserRoleAssignment>(
-                        initialValue: _selectedRole,
+                          initialValue: _selectedRole,
                           isExpanded: true,
                           items: activeRoles
                               .map((r) => DropdownMenuItem<UserRoleAssignment>(
@@ -287,7 +289,8 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                                     _selectedRole = v;
                                     _selectedType = null;
                                     if (v != null) {
-                                      _typesFuture = _typeService.fetchByRole(v.role.id);
+                                      _typesFuture =
+                                          _typeService.fetchByRole(v.role.id);
                                     }
                                   });
                                 },
@@ -399,7 +402,7 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                         }
 
                         return DropdownButtonFormField<ActivityType>(
-                        initialValue: _selectedType,
+                          initialValue: _selectedType,
                           isExpanded: true,
                           items: types
                               .map((t) => DropdownMenuItem<ActivityType>(

--- a/frontend/lib/widgets/dialogs/create_activity_dialog.dart
+++ b/frontend/lib/widgets/dialogs/create_activity_dialog.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 
 import '../dialogs/calendar_dialog.dart';
 import '../../models/activity_type.dart';
+import '../../models/user_role_assignment.dart';
 import '../../services/activity_type.dart';
 import '../../core/validators.dart';
 import '../../core/api_client.dart';
@@ -32,8 +33,10 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
   final _formKey = GlobalKey<FormState>();
 
   late final ActivityTypeService _typeService;
+  late Future<List<UserRoleAssignment>> _rolesFuture;
   late Future<List<ActivityType>> _typesFuture;
 
+  UserRoleAssignment? _selectedRole;
   ActivityType? _selectedType;
 
   final TextEditingController _dateCtrl = TextEditingController();
@@ -62,6 +65,7 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
       path: widget.typesPath,
     );
     _dateCtrl.text = DateFormat.yMMMMd('es').format(_selectedDate);
+    _rolesFuture = _typeService.fetchUserRoles();
     _typesFuture = _typeService.fetchAll();
   }
 
@@ -209,6 +213,99 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                   children: [
                     Align(
                       alignment: Alignment.centerLeft,
+                      child: Text('Rol', style: theme.textTheme.labelLarge),
+                    ),
+                    const SizedBox(height: 8),
+                    FutureBuilder<List<UserRoleAssignment>>(
+                      future: _rolesFuture,
+                      builder: (context, snapshot) {
+                        if (snapshot.connectionState ==
+                            ConnectionState.waiting) {
+                          return const Padding(
+                            padding: EdgeInsets.symmetric(vertical: 12),
+                            child: Row(
+                              children: [
+                                SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2),
+                                ),
+                                SizedBox(width: 10),
+                                Text('Cargando roles...'),
+                              ],
+                            ),
+                          );
+                        }
+
+                        if (snapshot.hasError) {
+                          final err = snapshot.error?.toString() ?? 'Error';
+                          return Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Error al cargar los roles: $err',
+                                style: theme.textTheme.bodyMedium
+                                    ?.copyWith(color: theme.colorScheme.error),
+                              ),
+                              const SizedBox(height: 8),
+                              OutlinedButton.icon(
+                                onPressed: _submitting
+                                    ? null
+                                    : () {
+                                        setState(() => _rolesFuture =
+                                            _typeService.fetchUserRoles());
+                                      },
+                                icon: const Icon(Icons.refresh),
+                                label: const Text('Reintentar'),
+                              ),
+                            ],
+                          );
+                        }
+
+                        final roles = snapshot.data ?? const <UserRoleAssignment>[];
+                        final activeRoles = roles.where((r) => r.isActive).toList();
+                        
+                        if (activeRoles.isEmpty) {
+                          return Text('No tienes roles asignados.',
+                              style: theme.textTheme.bodyMedium);
+                        }
+
+                        return DropdownButtonFormField<UserRoleAssignment>(
+                          value: _selectedRole,
+                          isExpanded: true,
+                          items: activeRoles
+                              .map((r) => DropdownMenuItem<UserRoleAssignment>(
+                                    value: r,
+                                    child: Text(r.role.name),
+                                  ))
+                              .toList(),
+                          onChanged: _submitting
+                              ? null
+                              : (v) {
+                                  setState(() {
+                                    _selectedRole = v;
+                                    _selectedType = null;
+                                    if (v != null) {
+                                      _typesFuture = _typeService.fetchByRole(v.role.id);
+                                    }
+                                  });
+                                },
+                          validator: (v) => Validators.requiredField(
+                            v,
+                            fieldName: 'El rol',
+                          ),
+                          decoration: const InputDecoration(
+                            border: OutlineInputBorder(),
+                            hintText: 'Selecciona un rol',
+                            isDense: true,
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                    Align(
+                      alignment: Alignment.centerLeft,
                       child: Text('Tipo de actividad',
                           style: theme.textTheme.labelLarge),
                     ),
@@ -216,6 +313,15 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                     FutureBuilder<List<ActivityType>>(
                       future: _typesFuture,
                       builder: (context, snapshot) {
+                        if (_selectedRole == null) {
+                          return Text(
+                            'Primero selecciona un rol',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: Colors.grey.shade600,
+                            ),
+                          );
+                        }
+
                         if (snapshot.connectionState ==
                             ConnectionState.waiting) {
                           return const Padding(
@@ -293,7 +399,6 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
                         }
 
                         return DropdownButtonFormField<ActivityType>(
-                          // ignore: deprecated_member_use
                           value: _selectedType,
                           isExpanded: true,
                           items: types


### PR DESCRIPTION
## Changes

### Features
- Added role selector in activity creation and edit forms
- Activity types are now filtered based on user's selected role
- Users can only see activity types relevant to their assigned roles (e.g., Missionary, Director de Jóvenes)

### Bug Fixes
- Fixed dashboard statistics to show current month data only
- Fixed "Estudios Bíblicos" activity counting (now handles accent variations)
- Fixed "Visitas" statistics to count all visit types (visita a interesados, visitas a miembros, visitas a infantes, etc.)
- Fixed logout functionality to properly clear session and redirect to login

### Technical Changes
**Backend:**
- Added `GET /activity-types/user-roles/me` endpoint to fetch user role assignments
- Added `GET /activity-types/by-role/:roleId` endpoint to filter activity types by role
- Added `getUserRoleAssignments()` method in ActivityTypesService

**Frontend:**
- Created `UserRoleAssignment` model with role and entity information
- Extended `ActivityType` model to include `allowedRoles` field
- Added role selection dropdown in activity forms
- Updated dashboard stats provider to filter by current month
- Improved activity name matching logic for better Spanish text handling
- Updated logout flow to clear local storage and session properly

## Testing
- Tested role filtering with multiple user roles
- Verified dashboard stats accuracy for current month
- Confirmed all visit activities are counted correctly
- Validated logout redirects to login screen