### PR TITLE
fix: Adjust union president access and normalize role names

### DIFF
--- a/backend/scripts/seed-honduras-users.ts
+++ b/backend/scripts/seed-honduras-users.ts
@@ -16,49 +16,49 @@ const USERS = [
     email: 'daniel.contreras@uhn.test',
     full_name: 'Daniel Contreras',
     sub: 'auth0|69583d736ccfb90819e2300c',
-    roles: ['ADMIN'],
+    roles: ['Union President'],
     entity: 'Unión Hondureña',
   },
   {
     email: 'admin.central@uhn.test',
     full_name: 'Admin Asociación Central',
     sub: 'auth0|69583e476d2265af6faf2db8',
-    roles: ['ADMIN'],
+    roles: ['Association President'],
     entity: 'Asociación Central',
   },
   {
     email: 'admin.noroccidental@uhn.test',
     full_name: 'Admin Asociación Nor-occidental',
     sub: 'auth0|69583e5e6ccfb90819e23085',
-    roles: ['ADMIN'],
+    roles: ['Association President'],
     entity: 'Asociación Nor-occidental',
   },
   {
     email: 'admin.nororiental@uhn.test',
     full_name: 'Admin Asociación Nor-oriental',
     sub: 'auth0|69583e8889bb367a376574dd',
-    roles: ['ADMIN'],
+    roles: ['Association President'],
     entity: 'Asociación Nor-oriental',
   },
   {
     email: 'obrero.copan@uhn.test',
     full_name: 'Obrero Campo Copán',
     sub: 'auth0|69583ec26d2265af6faf2deb',
-    roles: ['MISSIONARY', 'Anciano'],
+    roles: ['Missionary', 'Anciano'],
     entity: 'Campo Copán',
   },
   {
     email: 'obrero.tegucigalpa@uhn.test',
     full_name: 'Obrero Campo Tegucigalpa',
     sub: 'auth0|69583ed7292a80e2ca479bda',
-    roles: ['MISSIONARY', 'Director de Jóvenes'],
+    roles: ['Missionary', 'Director de Jóvenes'],
     entity: 'Campo Tegucigalpa',
   },
   {
     email: 'obrero.sps@uhn.test',
     full_name: 'Obrero Campo San Pedro Sula',
     sub: 'auth0|69583eec89bb367a37657519',
-    roles: ['MISSIONARY', 'Director de Obra Misionera'],
+    roles: ['Missionary', 'Director de Obra Misionera'],
     entity: 'Campo San Pedro Sula',
   },
 ];
@@ -100,6 +100,11 @@ async function run() {
       user.role = primaryRole;
       user.entity = entity;
 
+      await userRepo.save(user);
+    } else {
+      // Update existing user's primary role and entity
+      user.role = primaryRole;
+      user.entity = entity;
       await userRepo.save(user);
     }
 

--- a/backend/scripts/seed-roles-and-activities.ts
+++ b/backend/scripts/seed-roles-and-activities.ts
@@ -24,13 +24,45 @@ async function seedRolesAndActivities() {
   const activityTypeRepo = app.get<Repository<ActivityType>>(getRepositoryToken(ActivityType));
 
   const roleActivityMappings: RoleActivityMapping[] = [
+    // Leadership roles (from role.constants.ts LEADERSHIP_ROLES)
     {
-      roleName: 'ADMIN',
+      roleName: 'System Admin',
       roleDescription: 'Administrador del sistema con acceso completo',
       activityTypes: [],
     },
     {
-      roleName: 'MISSIONARY',
+      roleName: 'Union President',
+      roleDescription: 'Presidente de Unión con visibilidad completa de la unión',
+      activityTypes: [],
+    },
+    {
+      roleName: 'Association President',
+      roleDescription: 'Presidente de Asociación con visibilidad de la asociación',
+      activityTypes: [],
+    },
+    {
+      roleName: 'Field Director',
+      roleDescription: 'Director de Campo con visibilidad del campo',
+      activityTypes: [],
+    },
+    {
+      roleName: 'Union Secretary',
+      roleDescription: 'Secretario de Unión con gestión de actividades de la unión',
+      activityTypes: [],
+    },
+    {
+      roleName: 'Association Secretary',
+      roleDescription: 'Secretario de Asociación con gestión de actividades de la asociación',
+      activityTypes: [],
+    },
+    {
+      roleName: 'Field Secretary',
+      roleDescription: 'Secretario de Campo con gestión de actividades del campo',
+      activityTypes: [],
+    },
+    // Missionary role (from role.constants.ts MISSIONARY_ROLES)
+    {
+      roleName: 'Missionary',
       roleDescription: 'Misionero/Obrero de campo con actividades evangelísticas',
       activityTypes: [
         { name: 'Visitas a miembros', description: 'Visitas a miembros de la iglesia' },


### PR DESCRIPTION
### Changes
- Updated Honduras seed data to use normalized role names instead of legacy ADMIN/MISSIONARY constants
- Changed ADMIN roles to appropriate leadership roles (Union President, Association President)
- Changed MISSIONARY to Missionary (proper case)
- Fixed role assignments in seed-honduras-users.ts to correctly assign:
  - Union President for Unión Hondureña
  - Association President for association-level administrators
  - Missionary for field workers
- Added logic to update existing users' primary role and entity on re-seed
- Expanded role seeding to include all leadership roles: System Admin, Union President, Association President, Field Director, and Secretary roles at all levels
- Added comments to clarify role categories (Leadership roles vs Missionary roles)

### Impact
- Ensures Honduras users have correct role-based access levels
- Aligns seed data with the role constants defined in the application
- Prevents duplicate user creation and properly updates existing user roles