### PR TITLE
feat(entities): add currency symbol support

### DIFF
--- a/backend/src/entities/dto/create-entity.dto.ts
+++ b/backend/src/entities/dto/create-entity.dto.ts
@@ -47,4 +47,12 @@ export class CreateEntityDto {
   @IsOptional()
   @IsString()
   location?: string;
+
+  @ApiPropertyOptional({
+    description: 'Currency symbol for displaying monetary values (typically set at Union level)',
+    example: 'L',
+  })
+  @IsOptional()
+  @IsString()
+  currencySymbol?: string;
 }

--- a/backend/src/entities/dto/update-entity.dto.ts
+++ b/backend/src/entities/dto/update-entity.dto.ts
@@ -37,4 +37,12 @@ export class UpdateEntityDto {
   @IsOptional()
   @IsBoolean()
   is_active?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Currency symbol for displaying monetary values (typically set at Union level)',
+    example: 'L',
+  })
+  @IsOptional()
+  @IsString()
+  currencySymbol?: string;
 }

--- a/backend/src/entities/entities.service.ts
+++ b/backend/src/entities/entities.service.ts
@@ -10,6 +10,8 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { ILike, Not, Repository } from 'typeorm';
 import { Entity, EntityType } from './entity.entity';
+
+const DEFAULT_CURRENCY_SYMBOL = '$';
 import { CreateEntityDto } from './dto/create-entity.dto';
 import { UpdateEntityDto } from './dto/update-entity.dto';
 import { HierarchyValidationService } from './hierarchy-validation.service';
@@ -62,6 +64,7 @@ export class EntitiesService {
       code: dto.code,
       description: dto.description,
       location: dto.location,
+      currency_symbol: dto.currencySymbol,
       parent_id: dto.parentId || null,
     };
     const entity = this.repo.create(entityData);
@@ -144,9 +147,14 @@ export class EntitiesService {
 
     const toSave: Entity = {
       ...current,
-      ...dto,
       name: nextName,
       type: nextType,
+      code: dto.code !== undefined ? dto.code : current.code,
+      description: dto.description !== undefined ? dto.description : current.description,
+      location: dto.location !== undefined ? dto.location : current.location,
+      currency_symbol:
+        dto.currencySymbol !== undefined ? dto.currencySymbol : current.currency_symbol,
+      is_active: dto.is_active !== undefined ? dto.is_active : current.is_active,
       parent_id: nextParentId,
     } as Entity;
 
@@ -257,9 +265,7 @@ export class EntitiesService {
    */
   private async buildTreeNode(entity: Entity): Promise<EntityTreeNode> {
     const children = await this.findChildren(entity.id);
-    const childNodes = await Promise.all(
-      children.map((child) => this.buildTreeNode(child)),
-    );
+    const childNodes = await Promise.all(children.map((child) => this.buildTreeNode(child)));
 
     return {
       id: entity.id,
@@ -269,5 +275,39 @@ export class EntitiesService {
       is_active: entity.is_active,
       children: childNodes,
     };
+  }
+
+  /**
+   * Get the effective currency symbol for an entity.
+   * Traverses up the hierarchy to find the Union's currency_symbol.
+   * Returns default '$' if no currency is set.
+   * @param entityId - The entity ID to resolve currency for
+   * @returns The effective currency symbol
+   */
+  async getEffectiveCurrencySymbol(entityId: string): Promise<string> {
+    let current = await this.findOne(entityId);
+
+    // Traverse up to find the Union with currency_symbol set
+    while (current) {
+      // If this entity has a currency symbol, return it
+      if (current.currency_symbol) {
+        return current.currency_symbol;
+      }
+
+      // If we're at a Union without currency_symbol, return default
+      if (current.type === EntityType.UNION) {
+        return DEFAULT_CURRENCY_SYMBOL;
+      }
+
+      // If we're at Platform level, stop (Platform doesn't have currency)
+      if (current.type === EntityType.PLATFORM || !current.parent_id) {
+        return DEFAULT_CURRENCY_SYMBOL;
+      }
+
+      // Move up to parent
+      current = await this.findOne(current.parent_id);
+    }
+
+    return DEFAULT_CURRENCY_SYMBOL;
   }
 }

--- a/backend/src/entities/entity.entity.ts
+++ b/backend/src/entities/entity.entity.ts
@@ -41,6 +41,9 @@ export class Entity {
   @Column({ length: 255, nullable: true })
   location?: string;
 
+  @Column({ length: 10, nullable: true, name: 'currency_symbol' })
+  currency_symbol?: string;
+
   @Column({ default: true })
   is_active!: boolean;
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagg
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { IdentityResolutionService } from '../auth/identity-resolution.service';
+import { EntitiesService } from '../entities/entities.service';
 import { Request } from 'express';
 import { JwtValidatedUser } from '../auth/jwt.strategy';
 
@@ -12,6 +13,7 @@ export class UsersController {
   constructor(
     private readonly usersService: UsersService,
     private readonly identityService: IdentityResolutionService,
+    private readonly entitiesService: EntitiesService,
   ) {}
 
   @Get('me')
@@ -24,6 +26,9 @@ export class UsersController {
     const { sub, iss } = (req.user as JwtValidatedUser) ?? {};
     const user = await this.identityService.resolveUserBySubAndIssuer(sub, iss);
     const profile = await this.usersService.findUserProfile(user.id);
+    const currencySymbol = await this.entitiesService.getEffectiveCurrencySymbol(
+      profile.user.entity_id,
+    );
     return {
       id: profile.user.id,
       username: profile.user.username,
@@ -34,6 +39,7 @@ export class UsersController {
       status: profile.user.status,
       created_at: profile.user.created_at,
       updated_at: profile.user.updated_at,
+      currency_symbol: currencySymbol,
       primary_role: {
         id: profile.user.role.id,
         name: profile.user.role.name,
@@ -45,6 +51,7 @@ export class UsersController {
         description: profile.user.entity.description,
         type: profile.user.entity.type,
         parent_id: profile.user.entity.parent_id,
+        currency_symbol: profile.user.entity.currency_symbol,
       },
       role_assignments: profile.roleAssignments.map((assignment) => ({
         id: assignment.id,
@@ -59,6 +66,7 @@ export class UsersController {
           description: assignment.entity.description,
           type: assignment.entity.type,
           parent_id: assignment.entity.parent_id,
+          currency_symbol: assignment.entity.currency_symbol,
         },
         created_at: assignment.created_at,
         updated_at: assignment.updated_at,

--- a/frontend/lib/pages/hierarchy_reports_page.dart
+++ b/frontend/lib/pages/hierarchy_reports_page.dart
@@ -13,6 +13,7 @@ import '../widgets/reports/activity_distribution_chart.dart';
 import '../models/users_report.dart';
 import '../providers/hierarchy_reports_provider.dart';
 import '../providers/auth.dart';
+import '../utils/currency_formatter.dart';
 
 /// Content-only widget for hierarchy reports - shell is handled by AppShell via router
 class HierarchyReportsContent extends ConsumerStatefulWidget {
@@ -184,6 +185,7 @@ class _HierarchyReportsContentState
                           child: ActivityDistributionChart.fromBreakdowns(
                             breakdowns: state.activityBreakdown,
                             title: 'Actividades por Tipo',
+                            currencySymbol: ref.watch(currencySymbolProvider),
                           ),
                         ),
                         const SizedBox(width: 16),
@@ -192,6 +194,7 @@ class _HierarchyReportsContentState
                             breakdowns: state.activityBreakdown,
                             title: 'Gastos por Tipo',
                             showExpenses: true,
+                            currencySymbol: ref.watch(currencySymbolProvider),
                           ),
                         ),
                       ],
@@ -203,12 +206,14 @@ class _HierarchyReportsContentState
                       ActivityDistributionChart.fromBreakdowns(
                         breakdowns: state.activityBreakdown,
                         title: 'Actividades por Tipo',
+                        currencySymbol: ref.watch(currencySymbolProvider),
                       ),
                       const SizedBox(height: 16),
                       ActivityDistributionChart.fromBreakdowns(
                         breakdowns: state.activityBreakdown,
                         title: 'Gastos por Tipo',
                         showExpenses: true,
+                        currencySymbol: ref.watch(currencySymbolProvider),
                       ),
                     ],
                   );
@@ -220,6 +225,7 @@ class _HierarchyReportsContentState
             if (state.summary!.hasHierarchyBreakdown)
               HierarchyBreakdownCard(
                 breakdown: state.summary!.hierarchyBreakdown,
+                currencySymbol: ref.watch(currencySymbolProvider),
                 onEntityTap: (entityId) {
                   ref
                       .read(hierarchyReportsProvider.notifier)
@@ -235,6 +241,7 @@ class _HierarchyReportsContentState
               currentSort: state.usersSortBy,
               currentSortOrder: state.usersSortOrder,
               currentComplianceFilter: state.usersComplianceFilter,
+              currencySymbol: ref.watch(currencySymbolProvider),
               onPageChange: (page) {
                 ref.read(hierarchyReportsProvider.notifier).setUsersPage(page);
               },
@@ -400,7 +407,7 @@ class _HierarchyReportsContentState
                 ),
                 _StatCard(
                   label: 'Gastos',
-                  value: '\$${summary.totalExpenses.toStringAsFixed(2)}',
+                  value: CurrencyFormatter.format(summary.totalExpenses, ref.watch(currencySymbolProvider)),
                   icon: Icons.attach_money,
                 ),
                 _StatCard(

--- a/frontend/lib/pages/user_activities_page.dart
+++ b/frontend/lib/pages/user_activities_page.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import '../models/user_activities.dart';
 import '../models/report_period_type.dart';
 import '../providers/hierarchy_reports_provider.dart';
+import '../providers/auth.dart';
+import '../utils/currency_formatter.dart';
 import '../widgets/reports/activity_detail_dialog.dart';
 import '../widgets/reports/period_type_selector.dart';
 import '../widgets/reports/enhanced_time_selector.dart';
@@ -455,7 +457,7 @@ class _UserActivitiesPageState extends ConsumerState<UserActivitiesPage> {
               theme,
               icon: Icons.attach_money,
               label: 'Gastos',
-              value: '\$${totals.expenses.toStringAsFixed(2)}',
+              value: CurrencyFormatter.format(totals.expenses, ref.watch(currencySymbolProvider)),
             ),
           ],
         ),
@@ -560,7 +562,7 @@ class _UserActivitiesPageState extends ConsumerState<UserActivitiesPage> {
           if (activity.hasExpense)
             Chip(
               avatar: const Icon(Icons.attach_money, size: 14),
-              label: Text('\$${activity.expenseAmount ?? '0'}'),
+              label: Text(CurrencyFormatter.formatString(activity.expenseAmount, ref.watch(currencySymbolProvider))),
               visualDensity: VisualDensity.compact,
               backgroundColor: theme.colorScheme.tertiaryContainer,
             ),
@@ -582,6 +584,7 @@ class _UserActivitiesPageState extends ConsumerState<UserActivitiesPage> {
       context,
       activity: activity,
       userName: _response?.user.name,
+      currencySymbol: ref.read(currencySymbolProvider),
     );
   }
 

--- a/frontend/lib/providers/auth.dart
+++ b/frontend/lib/providers/auth.dart
@@ -156,7 +156,10 @@ class AuthNotifier extends StateNotifier<AuthState> {
         'name': profile.primaryEntity.name,
         'description': profile.primaryEntity.description,
         'type': profile.primaryEntity.type,
+        'currency_symbol': profile.primaryEntity.currencySymbol,
       };
+
+      result['currency_symbol'] = profile.currencySymbol;
 
       return result;
     } catch (e) {
@@ -392,4 +395,13 @@ final canViewReportsProvider = Provider<bool>((ref) {
   ];
 
   return roleName != null && leadershipRoles.contains(roleName);
+});
+
+/// Provider for the user's effective currency symbol.
+/// Returns the currency symbol from the user's profile (resolved from their Union).
+/// Defaults to '$' if not available.
+final currencySymbolProvider = Provider<String>((ref) {
+  final authState = ref.watch(authNotifierProvider);
+  final currencySymbol = authState.user?['currency_symbol'] as String?;
+  return currencySymbol ?? '\$';
 });

--- a/frontend/lib/services/user.dart
+++ b/frontend/lib/services/user.dart
@@ -14,6 +14,7 @@ class UserProfile {
   final String status;
   final DateTime createdAt;
   final DateTime updatedAt;
+  final String currencySymbol;
   final UserRole primaryRole;
   final UserEntity primaryEntity;
   final List<RoleAssignment> roleAssignments;
@@ -28,6 +29,7 @@ class UserProfile {
     required this.status,
     required this.createdAt,
     required this.updatedAt,
+    required this.currencySymbol,
     required this.primaryRole,
     required this.primaryEntity,
     required this.roleAssignments,
@@ -44,6 +46,7 @@ class UserProfile {
       status: json['status'] as String,
       createdAt: DateTime.parse(json['created_at'] as String),
       updatedAt: DateTime.parse(json['updated_at'] as String),
+      currencySymbol: json['currency_symbol'] as String? ?? '\$',
       primaryRole:
           UserRole.fromJson(json['primary_role'] as Map<String, dynamic>),
       primaryEntity:
@@ -81,6 +84,7 @@ class UserEntity {
   final String description;
   final String type;
   final String? parentId;
+  final String? currencySymbol;
 
   UserEntity({
     required this.id,
@@ -88,6 +92,7 @@ class UserEntity {
     required this.description,
     required this.type,
     this.parentId,
+    this.currencySymbol,
   });
 
   factory UserEntity.fromJson(Map<String, dynamic> json) {
@@ -97,6 +102,7 @@ class UserEntity {
       description: json['description'] as String,
       type: json['type'] as String,
       parentId: json['parent_id'] as String?,
+      currencySymbol: json['currency_symbol'] as String?,
     );
   }
 }

--- a/frontend/lib/utils/currency_formatter.dart
+++ b/frontend/lib/utils/currency_formatter.dart
@@ -1,0 +1,19 @@
+/// Utility class for currency formatting.
+class CurrencyFormatter {
+  /// Formats a numeric value with the given currency symbol.
+  ///
+  /// Example: formatCurrency(123.45, 'L') => 'L123.45'
+  static String format(double value, String currencySymbol, {int decimals = 2}) {
+    return '$currencySymbol${value.toStringAsFixed(decimals)}';
+  }
+
+  /// Formats a string value (which may already be a number) with the given currency symbol.
+  ///
+  /// Example: formatString('123.45', 'L') => 'L123.45'
+  static String formatString(String? value, String currencySymbol) {
+    if (value == null || value.isEmpty) {
+      return '${currencySymbol}0';
+    }
+    return '$currencySymbol$value';
+  }
+}

--- a/frontend/lib/widgets/hierarchy/hierarchy_breakdown_card.dart
+++ b/frontend/lib/widgets/hierarchy/hierarchy_breakdown_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../models/hierarchy_breakdown.dart';
 import '../../models/entity_hierarchy.dart';
+import '../../utils/currency_formatter.dart';
 
 /// A card widget displaying per-entity breakdown in a data table
 class HierarchyBreakdownCard extends StatelessWidget {
@@ -9,11 +10,13 @@ class HierarchyBreakdownCard extends StatelessWidget {
     required this.breakdown,
     this.onEntityTap,
     this.title = 'Desglose por Entidad',
+    this.currencySymbol = '\$',
   });
 
   final List<HierarchyEntityBreakdown> breakdown;
   final ValueChanged<String>? onEntityTap;
   final String title;
+  final String currencySymbol;
 
   @override
   Widget build(BuildContext context) {
@@ -113,7 +116,7 @@ class HierarchyBreakdownCard extends StatelessWidget {
                       ),
                       DataCell(Text(entity.entityType.displayName)),
                       DataCell(Text('${entity.activities}')),
-                      DataCell(Text('\$${entity.expenses.toStringAsFixed(2)}')),
+                      DataCell(Text(CurrencyFormatter.format(entity.expenses, currencySymbol))),
                       DataCell(_ComplianceBadge(rate: entity.complianceRate)),
                     ],
                   );

--- a/frontend/lib/widgets/reports/activity_detail_dialog.dart
+++ b/frontend/lib/widgets/reports/activity_detail_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/user_activities.dart';
+import '../../utils/currency_formatter.dart';
 
 /// Dialog to display full activity details
 class ActivityDetailDialog extends StatelessWidget {
@@ -7,21 +8,25 @@ class ActivityDetailDialog extends StatelessWidget {
     super.key,
     required this.activity,
     this.userName,
+    this.currencySymbol = '\$',
   });
 
   final UserActivity activity;
   final String? userName;
+  final String currencySymbol;
 
   static Future<void> show(
     BuildContext context, {
     required UserActivity activity,
     String? userName,
+    String currencySymbol = '\$',
   }) {
     return showDialog(
       context: context,
       builder: (context) => ActivityDetailDialog(
         activity: activity,
         userName: userName,
+        currencySymbol: currencySymbol,
       ),
     );
   }
@@ -93,7 +98,7 @@ class ActivityDetailDialog extends StatelessWidget {
                 theme,
                 icon: Icons.attach_money,
                 label: 'Gasto',
-                value: '\$${activity.expenseAmount ?? '0'}',
+                value: CurrencyFormatter.formatString(activity.expenseAmount, currencySymbol),
                 valueColor: theme.colorScheme.tertiary,
               ),
               const SizedBox(height: 12),

--- a/frontend/lib/widgets/reports/activity_distribution_chart.dart
+++ b/frontend/lib/widgets/reports/activity_distribution_chart.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
 import '../../models/report_breakdown.dart';
 import '../../models/user_activities.dart';
+import '../../utils/currency_formatter.dart';
 
 /// Data item for activity distribution chart
 class ActivityDistributionItem {
@@ -38,12 +39,14 @@ class ActivityDistributionChart extends StatefulWidget {
     this.title = 'Distribución de Actividades',
     this.showExpenses = false,
     this.height = 250,
+    this.currencySymbol = '\$',
   });
 
   final List<ActivityDistributionItem> items;
   final String title;
   final bool showExpenses;
   final double height;
+  final String currencySymbol;
 
   /// Create from ReportBreakdown list
   factory ActivityDistributionChart.fromBreakdowns({
@@ -52,6 +55,7 @@ class ActivityDistributionChart extends StatefulWidget {
     String title = 'Distribución de Actividades',
     bool showExpenses = false,
     double height = 250,
+    String currencySymbol = '\$',
   }) {
     // Sort by count or expenses descending
     final sorted = List<ReportBreakdown>.from(breakdowns);
@@ -75,6 +79,7 @@ class ActivityDistributionChart extends StatefulWidget {
       title: title,
       showExpenses: showExpenses,
       height: height,
+      currencySymbol: currencySymbol,
     );
   }
 
@@ -85,6 +90,7 @@ class ActivityDistributionChart extends StatefulWidget {
     String title = 'Distribución de Actividades',
     bool showExpenses = false,
     double height = 250,
+    String currencySymbol = '\$',
   }) {
     // Group activities by type
     final typeMap = <String, _TypeAccumulator>{};
@@ -124,6 +130,7 @@ class ActivityDistributionChart extends StatefulWidget {
       title: title,
       showExpenses: showExpenses,
       height: height,
+      currencySymbol: currencySymbol,
     );
   }
 
@@ -302,7 +309,7 @@ class _ActivityDistributionChartState extends State<ActivityDistributionChart> {
       ),
       child: Text(
         widget.showExpenses
-            ? '\$${item.expenses.toStringAsFixed(0)}'
+            ? CurrencyFormatter.format(item.expenses, widget.currencySymbol, decimals: 0)
             : '${item.count}',
         style: const TextStyle(
           color: Colors.white,
@@ -345,7 +352,7 @@ class _ActivityDistributionChartState extends State<ActivityDistributionChart> {
                 const SizedBox(width: 4),
                 Text(
                   widget.showExpenses
-                      ? '\$${item.expenses.toStringAsFixed(0)}'
+                      ? CurrencyFormatter.format(item.expenses, widget.currencySymbol, decimals: 0)
                       : '${item.count}',
                   style: theme.textTheme.bodySmall?.copyWith(
                     fontWeight: FontWeight.bold,

--- a/frontend/lib/widgets/reports/breakdown_table.dart
+++ b/frontend/lib/widgets/reports/breakdown_table.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import '../../models/report_breakdown.dart';
+import '../../utils/currency_formatter.dart';
 
 class BreakdownTable extends StatelessWidget {
   final List<ReportBreakdown> breakdown;
+  final String currencySymbol;
 
   const BreakdownTable({
     super.key,
     required this.breakdown,
+    this.currencySymbol = '\$',
   });
 
   @override
@@ -135,7 +138,7 @@ class BreakdownTable extends StatelessWidget {
                                 horizontal: 8,
                               ),
                               child: Text(
-                                '\$${item.totalExpenses.toStringAsFixed(2)}',
+                                CurrencyFormatter.format(item.totalExpenses, currencySymbol),
                                 style: const TextStyle(fontSize: 14),
                                 textAlign: TextAlign.right,
                               ),

--- a/frontend/lib/widgets/reports/comparison_breakdown_table.dart
+++ b/frontend/lib/widgets/reports/comparison_breakdown_table.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import '../../models/report_breakdown.dart';
+import '../../utils/currency_formatter.dart';
 
 class ComparisonBreakdownTable extends StatelessWidget {
   final List<ReportBreakdownWithComparison> breakdown;
   final bool showComparison;
+  final String currencySymbol;
 
   const ComparisonBreakdownTable({
     super.key,
     required this.breakdown,
     this.showComparison = true,
+    this.currencySymbol = '\$',
   });
 
   Widget _buildChangeCell(ChangeValue? change, bool isPositive) {
@@ -219,7 +222,7 @@ class ComparisonBreakdownTable extends StatelessWidget {
                                 horizontal: 8,
                               ),
                               child: Text(
-                                '\$${item.totalExpenses.toStringAsFixed(2)}',
+                                CurrencyFormatter.format(item.totalExpenses, currencySymbol),
                                 style: const TextStyle(fontSize: 14),
                                 textAlign: TextAlign.right,
                               ),

--- a/frontend/lib/widgets/reports/summary_cards.dart
+++ b/frontend/lib/widgets/reports/summary_cards.dart
@@ -1,15 +1,18 @@
 import 'package:flutter/material.dart';
+import '../../utils/currency_formatter.dart';
 
 class SummaryCards extends StatelessWidget {
   final int activitiesCount;
   final double expenses;
   final bool isReported;
+  final String currencySymbol;
 
   const SummaryCards({
     super.key,
     required this.activitiesCount,
     required this.expenses,
     required this.isReported,
+    this.currencySymbol = '\$',
   });
 
   @override
@@ -26,7 +29,7 @@ class SummaryCards extends StatelessWidget {
         Expanded(
           child: _SummaryCard(
             title: 'Gastos',
-            value: '\$${expenses.toStringAsFixed(2)}',
+            value: CurrencyFormatter.format(expenses, currencySymbol),
           ),
         ),
         const SizedBox(width: 16),

--- a/frontend/lib/widgets/reports/users_report_table.dart
+++ b/frontend/lib/widgets/reports/users_report_table.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/users_report.dart';
+import '../../utils/currency_formatter.dart';
 
 /// Paginated table showing users with their activity metrics
 class UsersReportTable extends StatefulWidget {
@@ -15,6 +16,7 @@ class UsersReportTable extends StatefulWidget {
     this.currentSortOrder,
     this.currentComplianceFilter,
     this.isLoading = false,
+    this.currencySymbol = '\$',
   });
 
   final UsersReportResponse response;
@@ -27,6 +29,7 @@ class UsersReportTable extends StatefulWidget {
   final String? currentSortOrder;
   final ComplianceFilter? currentComplianceFilter;
   final bool isLoading;
+  final String currencySymbol;
 
   @override
   State<UsersReportTable> createState() => _UsersReportTableState();
@@ -267,7 +270,7 @@ class _UsersReportTableState extends State<UsersReportTable> {
               ),
               DataCell(
                 Text(
-                  '\$${user.totalExpenses.toStringAsFixed(2)}',
+                  CurrencyFormatter.format(user.totalExpenses, widget.currencySymbol),
                   style: theme.textTheme.bodyMedium,
                 ),
               ),


### PR DESCRIPTION
## Summary

Adds support for dynamic currency symbol formatting throughout the application, allowing different Unions to display monetary values in their local currency.

- Add `currency_symbol` column to Entity (typically set at Union level)
- Add `getEffectiveCurrencySymbol()` method that traverses hierarchy to resolve currency
- Include currency symbol in user profile API response
- Add `CurrencyFormatter` utility class in Flutter frontend
- Add `currencySymbolProvider` for reactive currency symbol access
- Update all report widgets to use dynamic currency symbol

## Backend Changes

- `Entity.currency_symbol` - nullable field, defaults to `$` if not set
- `EntitiesService.getEffectiveCurrencySymbol(entityId)` - walks up hierarchy to find Union's currency
- `/users/me` endpoint returns `currency_symbol` in response

## Frontend Changes

- `CurrencyFormatter.format()` - consistent currency formatting utility
- `currencySymbolProvider` - Riverpod provider for current user's currency
- All report widgets updated to use provider instead of hardcoded `$`

## Test Plan

- [x] Currency symbol returned in user profile
- [x] Hierarchy resolution finds Union's currency setting
- [x] Default `$` returned when no currency set
- [x] Frontend displays correct currency symbol