### PR TITLE
feat: Show locked dates in activity calendar

### DIFF
--- a/backend/src/reporting-periods/reporting-periods.controller.ts
+++ b/backend/src/reporting-periods/reporting-periods.controller.ts
@@ -42,7 +42,11 @@ export class ReportingPeriodsController {
   @Post('admin')
   @Roles('admin')
   @ApiOperation({ summary: 'Create a new reporting period (Admin only)' })
-  @ApiResponse({ status: 201, description: 'Reporting period created', type: ReportingPeriodResponseDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Reporting period created',
+    type: ReportingPeriodResponseDto,
+  })
   async create(
     @Req() req: Request,
     @Body() dto: CreateReportingPeriodDto,
@@ -56,7 +60,11 @@ export class ReportingPeriodsController {
 
   @Get()
   @ApiOperation({ summary: 'List all reporting periods' })
-  @ApiResponse({ status: 200, description: 'List of reporting periods', type: [ReportingPeriodResponseDto] })
+  @ApiResponse({
+    status: 200,
+    description: 'List of reporting periods',
+    type: [ReportingPeriodResponseDto],
+  })
   @ApiQuery({ name: 'entityId', required: false, description: 'Filter by entity UUID' })
   async findAll(@Query('entityId') entityId?: string): Promise<ReportingPeriodResponseDto[]> {
     const periods = await this.reportingPeriodsService.findAll(entityId);
@@ -65,7 +73,11 @@ export class ReportingPeriodsController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get a single reporting period by ID' })
-  @ApiResponse({ status: 200, description: 'Reporting period details', type: ReportingPeriodResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Reporting period details',
+    type: ReportingPeriodResponseDto,
+  })
   async findOne(@Param('id', new ParseUUIDPipe()) id: string): Promise<ReportingPeriodResponseDto> {
     const period = await this.reportingPeriodsService.findOne(id);
     return ReportingPeriodResponseDto.fromEntity(period);
@@ -74,7 +86,11 @@ export class ReportingPeriodsController {
   @Patch(':id')
   @Roles('admin')
   @ApiOperation({ summary: 'Update a reporting period (Admin only)' })
-  @ApiResponse({ status: 200, description: 'Reporting period updated', type: ReportingPeriodResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Reporting period updated',
+    type: ReportingPeriodResponseDto,
+  })
   async update(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -90,7 +106,11 @@ export class ReportingPeriodsController {
   @Patch(':id/lock')
   @Roles('admin')
   @ApiOperation({ summary: 'Lock a reporting period (Admin only)' })
-  @ApiResponse({ status: 200, description: 'Reporting period locked', type: ReportingPeriodResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Reporting period locked',
+    type: ReportingPeriodResponseDto,
+  })
   async lock(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -105,7 +125,11 @@ export class ReportingPeriodsController {
   @Patch(':id/unlock')
   @Roles('admin')
   @ApiOperation({ summary: 'Unlock a reporting period (Admin only)' })
-  @ApiResponse({ status: 200, description: 'Reporting period unlocked', type: ReportingPeriodResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Reporting period unlocked',
+    type: ReportingPeriodResponseDto,
+  })
   async unlock(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -120,7 +144,11 @@ export class ReportingPeriodsController {
   @Patch(':id/close')
   @Roles('admin')
   @ApiOperation({ summary: 'Close a reporting period (Admin only)' })
-  @ApiResponse({ status: 200, description: 'Reporting period closed', type: ReportingPeriodResponseDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Reporting period closed',
+    type: ReportingPeriodResponseDto,
+  })
   async close(
     @Req() req: Request,
     @Param('id', new ParseUUIDPipe()) id: string,
@@ -135,7 +163,11 @@ export class ReportingPeriodsController {
   @Post(':periodId/exceptions')
   @Roles('admin')
   @ApiOperation({ summary: 'Create or update an exception for a user (Admin only)' })
-  @ApiResponse({ status: 201, description: 'Exception created/updated', type: ExceptionResponseDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Exception created/updated',
+    type: ExceptionResponseDto,
+  })
   async createException(
     @Req() req: Request,
     @Param('periodId', new ParseUUIDPipe()) periodId: string,
@@ -177,6 +209,38 @@ export class ReportingPeriodsController {
     return exceptions.map((ex) =>
       ExceptionResponseDto.fromEntity(ex, ex.user.username, ex.user.email),
     );
+  }
+
+  @Get('locked-dates/ranges')
+  @ApiOperation({ summary: 'Get locked date ranges for the current user' })
+  @ApiResponse({ 
+    status: 200, 
+    description: 'List of locked date ranges (dates where user cannot create activities)',
+    schema: {
+      type: 'object',
+      properties: {
+        lockedRanges: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              startDate: { type: 'string', format: 'date', example: '2024-01-01' },
+              endDate: { type: 'string', format: 'date', example: '2024-01-31' },
+              periodName: { type: 'string', example: 'January 2024' },
+            },
+          },
+        },
+      },
+    },
+  })
+  async getLockedDateRanges(@Req() req: Request): Promise<{
+    lockedRanges: Array<{ startDate: string; endDate: string; periodName: string }>;
+  }> {
+    const { sub, iss } = (req.user as any) ?? {};
+    const user = await this.identity.resolveUserBySubAndIssuer(sub, iss);
+
+    const lockedRanges = await this.reportingPeriodsService.getLockedDateRangesForUser(user.id);
+    return { lockedRanges };
   }
 
   @Delete(':id')

--- a/backend/src/reporting-periods/reporting-periods.service.ts
+++ b/backend/src/reporting-periods/reporting-periods.service.ts
@@ -405,6 +405,53 @@ export class ReportingPeriodsService {
     return activityDate >= exception.startDate && activityDate <= exception.endDate;
   }
 
+  async getLockedDateRangesForUser(
+    userId: string,
+  ): Promise<Array<{ startDate: string; endDate: string; periodName: string }>> {
+    const lockedPeriods = await this.repo.find({
+      where: { status: ReportingPeriodStatus.LOCKED },
+      order: { startDate: 'ASC' },
+    });
+
+    const userExceptions = await this.exceptionsRepo.find({
+      where: { userId },
+    });
+
+    const lockedRanges: Array<{ startDate: string; endDate: string; periodName: string }> = [];
+
+    for (const period of lockedPeriods) {
+      const exception = userExceptions.find((ex) => ex.reportingPeriodId === period.id);
+
+      if (exception) {
+        if (period.startDate < exception.startDate) {
+          const dayBefore = this.subtractDays(new Date(exception.startDate), 1);
+          lockedRanges.push({
+            startDate: period.startDate,
+            endDate: this.formatDate(dayBefore),
+            periodName: period.name,
+          });
+        }
+
+        if (exception.endDate < period.endDate) {
+          const dayAfter = this.addDays(new Date(exception.endDate), 1);
+          lockedRanges.push({
+            startDate: this.formatDate(dayAfter),
+            endDate: period.endDate,
+            periodName: period.name,
+          });
+        }
+      } else {
+        lockedRanges.push({
+          startDate: period.startDate,
+          endDate: period.endDate,
+          periodName: period.name,
+        });
+      }
+    }
+
+    return lockedRanges;
+  }
+
   private formatDate(date: Date): string {
     return date.toISOString().split('T')[0];
   }
@@ -412,6 +459,12 @@ export class ReportingPeriodsService {
   private addDays(date: Date, days: number): Date {
     const result = new Date(date);
     result.setDate(result.getDate() + days);
+    return result;
+  }
+
+  private subtractDays(date: Date, days: number): Date {
+    const result = new Date(date);
+    result.setDate(result.getDate() - days);
     return result;
   }
 }

--- a/frontend/lib/services/reporting_periods.dart
+++ b/frontend/lib/services/reporting_periods.dart
@@ -1,0 +1,82 @@
+import '../config/api_config.dart';
+import '../core/api_client.dart';
+
+class ReportingPeriodsService {
+  ReportingPeriodsService({
+    required this.apiClient,
+  });
+
+  final ApiClient apiClient;
+
+  factory ReportingPeriodsService.localhost(AccessTokenProvider getAccessToken) {
+    final apiClient = ApiClient(
+      baseUrl: ApiConfig.baseUrl,
+      getAccessToken: getAccessToken,
+    );
+    return ReportingPeriodsService(apiClient: apiClient);
+  }
+
+  Future<List<LockedDateRange>> getLockedDateRanges() async {
+    print('[ReportingPeriodsService] Fetching locked date ranges...');
+    try {
+      final data = await apiClient.get('reporting-periods/locked-dates/ranges');
+      print('[ReportingPeriodsService] API response: $data');
+      final ranges = data['lockedRanges'] as List<dynamic>;
+      print('[ReportingPeriodsService] Parsed ${ranges.length} locked ranges');
+      return ranges
+          .map((range) => LockedDateRange.fromJson(range as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      print('[ReportingPeriodsService] Error fetching locked ranges: $e');
+      rethrow;
+    }
+  }
+
+  Future<bool> isDateLocked(DateTime date) async {
+    final ranges = await getLockedDateRanges();
+    final dateStr = _formatDate(date);
+
+    for (final range in ranges) {
+      if (dateStr.compareTo(range.startDate) >= 0 &&
+          dateStr.compareTo(range.endDate) <= 0) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+  }
+}
+
+class LockedDateRange {
+  final String startDate;
+  final String endDate;
+  final String periodName;
+
+  LockedDateRange({
+    required this.startDate,
+    required this.endDate,
+    required this.periodName,
+  });
+
+  factory LockedDateRange.fromJson(Map<String, dynamic> json) {
+    return LockedDateRange(
+      startDate: json['startDate'] as String,
+      endDate: json['endDate'] as String,
+      periodName: json['periodName'] as String,
+    );
+  }
+
+  bool containsDate(String dateStr) {
+    return dateStr.compareTo(startDate) >= 0 && dateStr.compareTo(endDate) <= 0;
+  }
+
+  bool containsDateTime(DateTime date) {
+    final dateStr =
+        '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+    return containsDate(dateStr);
+  }
+}

--- a/frontend/lib/services/reporting_periods.dart
+++ b/frontend/lib/services/reporting_periods.dart
@@ -8,7 +8,8 @@ class ReportingPeriodsService {
 
   final ApiClient apiClient;
 
-  factory ReportingPeriodsService.localhost(AccessTokenProvider getAccessToken) {
+  factory ReportingPeriodsService.localhost(
+      AccessTokenProvider getAccessToken) {
     final apiClient = ApiClient(
       baseUrl: ApiConfig.baseUrl,
       getAccessToken: getAccessToken,
@@ -21,7 +22,8 @@ class ReportingPeriodsService {
       final data = await apiClient.get('reporting-periods/locked-dates/ranges');
       final ranges = data['lockedRanges'] as List<dynamic>;
       return ranges
-          .map((range) => LockedDateRange.fromJson(range as Map<String, dynamic>))
+          .map((range) =>
+              LockedDateRange.fromJson(range as Map<String, dynamic>))
           .toList();
     } catch (e) {
       rethrow;

--- a/frontend/lib/services/reporting_periods.dart
+++ b/frontend/lib/services/reporting_periods.dart
@@ -17,17 +17,13 @@ class ReportingPeriodsService {
   }
 
   Future<List<LockedDateRange>> getLockedDateRanges() async {
-    print('[ReportingPeriodsService] Fetching locked date ranges...');
     try {
       final data = await apiClient.get('reporting-periods/locked-dates/ranges');
-      print('[ReportingPeriodsService] API response: $data');
       final ranges = data['lockedRanges'] as List<dynamic>;
-      print('[ReportingPeriodsService] Parsed ${ranges.length} locked ranges');
       return ranges
           .map((range) => LockedDateRange.fromJson(range as Map<String, dynamic>))
           .toList();
     } catch (e) {
-      print('[ReportingPeriodsService] Error fetching locked ranges: $e');
       rethrow;
     }
   }

--- a/frontend/lib/widgets/dialogs/activity_form_dialog.dart
+++ b/frontend/lib/widgets/dialogs/activity_form_dialog.dart
@@ -7,6 +7,7 @@ import '../dialogs/calendar_dialog.dart';
 import '../../models/activity_type.dart';
 import '../../models/user_role_assignment.dart';
 import '../../services/activity_type.dart';
+import '../../services/reporting_periods.dart';
 import '../../core/validators.dart';
 import '../../core/api_client.dart';
 
@@ -16,7 +17,6 @@ class ActivityFormDialog extends StatefulWidget {
   final VoidCallback? onRequireLogin;
   final String typesPath;
 
-  /// If provided, the dialog will be in edit mode
   final Map<String, dynamic>? existingActivity;
 
   const ActivityFormDialog({
@@ -36,6 +36,7 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
   final _formKey = GlobalKey<FormState>();
 
   late final ActivityTypeService _typeService;
+  late final ReportingPeriodsService _reportingPeriodsService;
   late Future<List<UserRoleAssignment>> _rolesFuture;
   late Future<List<ActivityType>> _typesFuture;
 
@@ -71,24 +72,23 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
       apiClient: apiClient,
       path: widget.typesPath,
     );
+    _reportingPeriodsService = ReportingPeriodsService(
+      apiClient: apiClient,
+    );
 
     _rolesFuture = _typeService.fetchUserRoles();
     _typesFuture = _typeService.fetchAll();
 
-    // Pre-populate fields if editing
     if (isEditMode) {
       final activity = widget.existingActivity!;
 
-      // Parse date
       final dateStr = activity['activityDate'] as String?;
       if (dateStr != null) {
         _selectedDate = DateTime.tryParse(dateStr) ?? DateTime.now();
       }
 
-      // Description
       _descCtrl.text = activity['description'] as String? ?? '';
 
-      // Expense fields
       _hasExpense = activity['hasExpense'] as bool? ?? false;
       final amount = activity['expenseAmount'];
       if (amount != null) {
@@ -98,7 +98,6 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
 
     _dateCtrl.text = DateFormat.yMMMMd('es').format(_selectedDate);
     _typesFuture = _typeService.fetchAll().then((types) {
-      // If editing, pre-select the activity type
       if (isEditMode && types.isNotEmpty) {
         final typeId = widget.existingActivity?['activityTypeId'] as String?;
         if (typeId != null) {
@@ -127,6 +126,7 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
         initialDate: _selectedDate,
         firstDate: DateTime(2000),
         lastDate: DateTime(2100),
+        reportingPeriodsService: _reportingPeriodsService,
       ),
     );
     if (picked != null) {

--- a/frontend/lib/widgets/dialogs/calendar_dialog.dart
+++ b/frontend/lib/widgets/dialogs/calendar_dialog.dart
@@ -59,11 +59,11 @@ class _CalendarDialogState extends State<CalendarDialog> {
     if (_isLoading) {
       return false;
     }
-    
+
     if (_errorMessage != null) {
       return true;
     }
-    
+
     for (final range in _lockedRanges) {
       if (range.containsDateTime(date)) {
         return false;
@@ -157,7 +157,7 @@ class _CalendarDialogState extends State<CalendarDialog> {
                     padding: const EdgeInsets.symmetric(horizontal: 12),
                     alignment: Alignment.centerLeft,
                     child: Text(
-                      _isLoading 
+                      _isLoading
                           ? 'Cargando restricciones...'
                           : _errorMessage != null
                               ? 'Sin restricciones'
@@ -187,7 +187,9 @@ class _CalendarDialogState extends State<CalendarDialog> {
                     border: Border.all(color: Theme.of(context).dividerColor),
                   ),
                   child: Icon(
-                    _lockedRanges.isNotEmpty ? Icons.lock_outline : Icons.filter_list,
+                    _lockedRanges.isNotEmpty
+                        ? Icons.lock_outline
+                        : Icons.filter_list,
                     color: _lockedRanges.isNotEmpty
                         ? Theme.of(context).colorScheme.error
                         : Theme.of(context).colorScheme.primary,
@@ -211,8 +213,7 @@ class _CalendarDialogState extends State<CalendarDialog> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     Icon(Icons.error_outline,
-                        size: 48,
-                        color: Theme.of(context).colorScheme.error),
+                        size: 48, color: Theme.of(context).colorScheme.error),
                     const SizedBox(height: 16),
                     Text(
                       _errorMessage!,
@@ -250,7 +251,10 @@ class _CalendarDialogState extends State<CalendarDialog> {
                   color: Theme.of(context).colorScheme.errorContainer,
                   borderRadius: BorderRadius.circular(8),
                   border: Border.all(
-                    color: Theme.of(context).colorScheme.error.withValues(alpha: 0.3),
+                    color: Theme.of(context)
+                        .colorScheme
+                        .error
+                        .withValues(alpha: 0.3),
                   ),
                 ),
                 padding: const EdgeInsets.all(12),
@@ -277,15 +281,18 @@ class _CalendarDialogState extends State<CalendarDialog> {
                     ),
                     const SizedBox(height: 8),
                     ..._lockedRanges.map((range) {
-                      final start = DateFormat('d MMM', 'es_ES').format(DateTime.parse(range.startDate));
-                      final end = DateFormat('d MMM yyyy', 'es_ES').format(DateTime.parse(range.endDate));
+                      final start = DateFormat('d MMM', 'es_ES')
+                          .format(DateTime.parse(range.startDate));
+                      final end = DateFormat('d MMM yyyy', 'es_ES')
+                          .format(DateTime.parse(range.endDate));
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 4),
                         child: Text(
                           '• $start - $end: ${range.periodName}',
                           style: TextStyle(
                             fontSize: 11,
-                            color: Theme.of(context).colorScheme.onErrorContainer,
+                            color:
+                                Theme.of(context).colorScheme.onErrorContainer,
                           ),
                         ),
                       );

--- a/frontend/lib/widgets/dialogs/calendar_dialog.dart
+++ b/frontend/lib/widgets/dialogs/calendar_dialog.dart
@@ -43,13 +43,8 @@ class _CalendarDialogState extends State<CalendarDialog> {
           _lockedRanges = ranges;
           _isLoading = false;
         });
-        print('Loaded ${ranges.length} locked date ranges:');
-        for (final range in ranges) {
-          print('  - ${range.startDate} to ${range.endDate}: ${range.periodName}');
-        }
       }
     } catch (e) {
-      print('Error loading locked date ranges: $e');
       if (mounted) {
         setState(() {
           _errorMessage = 'Error al cargar restricciones de fechas';
@@ -71,8 +66,6 @@ class _CalendarDialogState extends State<CalendarDialog> {
     
     for (final range in _lockedRanges) {
       if (range.containsDateTime(date)) {
-        final dateStr = '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
-        print('Date $dateStr is locked by range: ${range.startDate} to ${range.endDate}');
         return false;
       }
     }
@@ -296,7 +289,7 @@ class _CalendarDialogState extends State<CalendarDialog> {
                           ),
                         ),
                       );
-                    }).toList(),
+                    }),
                   ],
                 ),
               ),

--- a/frontend/lib/widgets/dialogs/calendar_dialog.dart
+++ b/frontend/lib/widgets/dialogs/calendar_dialog.dart
@@ -250,6 +250,58 @@ class _CalendarDialogState extends State<CalendarDialog> {
                 ),
               ),
             const SizedBox(height: 12),
+            if (_lockedRanges.isNotEmpty) ...[
+              Container(
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.errorContainer,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: Theme.of(context).colorScheme.error.withValues(alpha: 0.3),
+                  ),
+                ),
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.lock_outline,
+                          size: 16,
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Períodos bloqueados:',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            color: Theme.of(context).colorScheme.error,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    ..._lockedRanges.map((range) {
+                      final start = DateFormat('d MMM', 'es_ES').format(DateTime.parse(range.startDate));
+                      final end = DateFormat('d MMM yyyy', 'es_ES').format(DateTime.parse(range.endDate));
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Text(
+                          '• $start - $end: ${range.periodName}',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: Theme.of(context).colorScheme.onErrorContainer,
+                          ),
+                        ),
+                      );
+                    }).toList(),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
             Container(
               width: double.infinity,
               decoration: BoxDecoration(

--- a/frontend/lib/widgets/dialogs/calendar_dialog.dart
+++ b/frontend/lib/widgets/dialogs/calendar_dialog.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import '../../services/reporting_periods.dart';
 
 class CalendarDialog extends StatefulWidget {
   final DateTime initialDate;
   final DateTime firstDate;
   final DateTime lastDate;
+  final ReportingPeriodsService reportingPeriodsService;
 
   const CalendarDialog({
     super.key,
     required this.initialDate,
     required this.firstDate,
     required this.lastDate,
+    required this.reportingPeriodsService,
   });
 
   @override
@@ -20,12 +23,60 @@ class CalendarDialog extends StatefulWidget {
 class _CalendarDialogState extends State<CalendarDialog> {
   late DateTime _focusedMonth;
   DateTime? _selected;
+  List<LockedDateRange> _lockedRanges = [];
+  bool _isLoading = true;
+  String? _errorMessage;
 
   @override
   void initState() {
     super.initState();
     _focusedMonth = DateTime(widget.initialDate.year, widget.initialDate.month);
     _selected = widget.initialDate;
+    _loadLockedDateRanges();
+  }
+
+  Future<void> _loadLockedDateRanges() async {
+    try {
+      final ranges = await widget.reportingPeriodsService.getLockedDateRanges();
+      if (mounted) {
+        setState(() {
+          _lockedRanges = ranges;
+          _isLoading = false;
+        });
+        print('Loaded ${ranges.length} locked date ranges:');
+        for (final range in ranges) {
+          print('  - ${range.startDate} to ${range.endDate}: ${range.periodName}');
+        }
+      }
+    } catch (e) {
+      print('Error loading locked date ranges: $e');
+      if (mounted) {
+        setState(() {
+          _errorMessage = 'Error al cargar restricciones de fechas';
+          _isLoading = false;
+          _lockedRanges = [];
+        });
+      }
+    }
+  }
+
+  bool _isDateSelectable(DateTime date) {
+    if (_isLoading) {
+      return false;
+    }
+    
+    if (_errorMessage != null) {
+      return true;
+    }
+    
+    for (final range in _lockedRanges) {
+      if (range.containsDateTime(date)) {
+        final dateStr = '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+        print('Date $dateStr is locked by range: ${range.startDate} to ${range.endDate}');
+        return false;
+      }
+    }
+    return true;
   }
 
   void _prevMonth() {
@@ -113,13 +164,20 @@ class _CalendarDialogState extends State<CalendarDialog> {
                     padding: const EdgeInsets.symmetric(horizontal: 12),
                     alignment: Alignment.centerLeft,
                     child: Text(
-                      'Rango de fechas',
+                      _isLoading 
+                          ? 'Cargando restricciones...'
+                          : _errorMessage != null
+                              ? 'Sin restricciones'
+                              : _lockedRanges.isEmpty
+                                  ? 'Todas las fechas disponibles'
+                                  : '${_lockedRanges.length} período(s) bloqueado(s)',
                       style: TextStyle(
                         color: Theme.of(context)
                             .textTheme
                             .bodySmall
                             ?.color
                             ?.withValues(alpha: 0.7),
+                        fontSize: 12,
                       ),
                     ),
                   ),
@@ -129,32 +187,68 @@ class _CalendarDialogState extends State<CalendarDialog> {
                   width: 44,
                   height: 44,
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.surface,
+                    color: _lockedRanges.isNotEmpty
+                        ? Theme.of(context).colorScheme.errorContainer
+                        : Theme.of(context).colorScheme.surface,
                     borderRadius: BorderRadius.circular(8),
                     border: Border.all(color: Theme.of(context).dividerColor),
                   ),
-                  child: Icon(Icons.filter_list,
-                      color: Theme.of(context).colorScheme.primary),
+                  child: Icon(
+                    _lockedRanges.isNotEmpty ? Icons.lock_outline : Icons.filter_list,
+                    color: _lockedRanges.isNotEmpty
+                        ? Theme.of(context).colorScheme.error
+                        : Theme.of(context).colorScheme.primary,
+                  ),
                 ),
               ],
             ),
             const SizedBox(height: 12),
-            Container(
-              width: double.infinity,
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface,
-                borderRadius: BorderRadius.circular(8),
+            if (_isLoading)
+              Container(
+                height: 340,
+                alignment: Alignment.center,
+                child: const CircularProgressIndicator(),
+              )
+            else if (_errorMessage != null)
+              Container(
+                height: 340,
+                alignment: Alignment.center,
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.error_outline,
+                        size: 48,
+                        color: Theme.of(context).colorScheme.error),
+                    const SizedBox(height: 16),
+                    Text(
+                      _errorMessage!,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            else
+              Container(
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surface,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                child: CalendarDatePicker(
+                  initialDate: _selected ?? widget.initialDate,
+                  firstDate: widget.firstDate,
+                  lastDate: widget.lastDate,
+                  currentDate: DateTime.now(),
+                  onDateChanged: (d) => setState(() => _selected = d),
+                  initialCalendarMode: DatePickerMode.day,
+                  selectableDayPredicate: _isDateSelectable,
+                ),
               ),
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
-              child: CalendarDatePicker(
-                initialDate: _selected ?? widget.initialDate,
-                firstDate: widget.firstDate,
-                lastDate: widget.lastDate,
-                currentDate: DateTime.now(),
-                onDateChanged: (d) => setState(() => _selected = d),
-                initialCalendarMode: DatePickerMode.day,
-              ),
-            ),
             const SizedBox(height: 12),
             Container(
               width: double.infinity,

--- a/frontend/lib/widgets/dialogs/create_activity_dialog.dart
+++ b/frontend/lib/widgets/dialogs/create_activity_dialog.dart
@@ -7,6 +7,7 @@ import '../dialogs/calendar_dialog.dart';
 import '../../models/activity_type.dart';
 import '../../models/user_role_assignment.dart';
 import '../../services/activity_type.dart';
+import '../../services/reporting_periods.dart';
 import '../../core/validators.dart';
 import '../../core/api_client.dart';
 
@@ -33,6 +34,7 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
   final _formKey = GlobalKey<FormState>();
 
   late final ActivityTypeService _typeService;
+  late final ReportingPeriodsService _reportingPeriodsService;
   late Future<List<UserRoleAssignment>> _rolesFuture;
   late Future<List<ActivityType>> _typesFuture;
 
@@ -64,6 +66,9 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
       apiClient: apiClient,
       path: widget.typesPath,
     );
+    _reportingPeriodsService = ReportingPeriodsService(
+      apiClient: apiClient,
+    );
     _dateCtrl.text = DateFormat.yMMMMd('es').format(_selectedDate);
     _rolesFuture = _typeService.fetchUserRoles();
     _typesFuture = _typeService.fetchAll();
@@ -84,6 +89,7 @@ class _CreateActivityDialogState extends State<CreateActivityDialog> {
         initialDate: _selectedDate,
         firstDate: DateTime(2000),
         lastDate: DateTime(2100),
+        reportingPeriodsService: _reportingPeriodsService,
       ),
     );
     if (picked != null) {


### PR DESCRIPTION
## What Changed
The activity calendar now shows which dates are locked and cannot be selected.

## Why
Users were selecting dates in locked reporting periods and getting errors after submission. Now they can see which dates are blocked before trying to submit.

## How It Works
- Backend: New API endpoint returns locked date ranges for the user
- Frontend: Calendar grays out locked dates and shows which periods are blocked
- Users cannot click on locked dates

## Files Changed
**Backend:**
- `reporting-periods.controller.ts` - New endpoint
- `reporting-periods.service.ts` - Logic to get locked ranges

**Frontend:**
- `services/reporting_periods.dart` - Service to fetch locked dates (new file)
- `widgets/dialogs/calendar_dialog.dart` - Show locked dates
- `widgets/dialogs/create_activity_dialog.dart` - Updated
- `widgets/dialogs/activity_form_dialog.dart` - Updated

Closes #157