### PR TITLE
fix: Correct activity filter date range calculations and add test coverage

### DIFF
--- a/backend/src/activity/tests/activities.service.filters.spec.ts
+++ b/backend/src/activity/tests/activities.service.filters.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Repository } from 'typeorm';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ActivitiesService } from '../activities.service';
+import { Activity } from '../activity.entity';
+import { ActivityType } from '../../activities-type/activity-type.entity';
+import { ReportingPeriod } from '../../reporting-periods/reporting-period.entity';
+import { UserRoleAssignment } from '../../roles/user-role-assignment.entity';
+import { ActivityStatus } from '../activity-status.enum';
+
+describe('ActivitiesService - Filters', () => {
+  let service: ActivitiesService;
+  let activityRepo: jest.Mocked<Repository<Activity>>;
+  let qb: any;
+
+  beforeEach(async () => {
+    qb = {
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+
+    const mockActivityRepo = {
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ActivitiesService,
+        {
+          provide: getRepositoryToken(Activity),
+          useValue: mockActivityRepo,
+        },
+        {
+          provide: getRepositoryToken(ActivityType),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(ReportingPeriod),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(UserRoleAssignment),
+          useValue: {},
+        },
+      ],
+    }).compile();
+
+    service = module.get<ActivitiesService>(ActivitiesService);
+    activityRepo = module.get(getRepositoryToken(Activity));
+  });
+
+  it('applies base user and status filters', async () => {
+    await service.findMine('user-id', 1, 20);
+
+    expect(activityRepo.createQueryBuilder).toHaveBeenCalledWith('activity');
+    expect(qb.where).toHaveBeenCalledWith('activity.userId = :userId', { userId: 'user-id' });
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.status = :status', {
+      status: ActivityStatus.ACTIVE,
+    });
+  });
+
+  it('applies date range filters when provided', async () => {
+    await service.findMine('user-id', 1, 20, {
+      startDate: '2024-03-01',
+      endDate: '2024-03-31',
+    });
+
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.activityDate >= :startDate', {
+      startDate: '2024-03-01',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.activityDate <= :endDate', {
+      endDate: '2024-03-31',
+    });
+  });
+
+  it('combines activity type and expense filters', async () => {
+    await service.findMine('user-id', 1, 20, {
+      activityTypeId: 'type-id',
+      hasExpense: true,
+    });
+
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.activityTypeId = :activityTypeId', {
+      activityTypeId: 'type-id',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.hasExpense = :hasExpense', {
+      hasExpense: true,
+    });
+  });
+
+  it('includes hasExpense=false filters', async () => {
+    await service.findMine('user-id', 1, 20, {
+      hasExpense: false,
+    });
+
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.hasExpense = :hasExpense', {
+      hasExpense: false,
+    });
+  });
+
+  it('combines all filters without conflicts', async () => {
+    await service.findMine('user-id', 2, 10, {
+      startDate: '2024-01-01',
+      endDate: '2024-03-15',
+      activityTypeId: 'type-id',
+      hasExpense: true,
+    });
+
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.activityDate >= :startDate', {
+      startDate: '2024-01-01',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.activityDate <= :endDate', {
+      endDate: '2024-03-15',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.activityTypeId = :activityTypeId', {
+      activityTypeId: 'type-id',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('activity.hasExpense = :hasExpense', {
+      hasExpense: true,
+    });
+  });
+});

--- a/backend/src/test/activities-filters.e2e-spec.ts
+++ b/backend/src/test/activities-filters.e2e-spec.ts
@@ -1,0 +1,232 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import request from 'supertest';
+import { AppModule } from '../app.module';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Activity } from '../activity/activity.entity';
+import { ActivityStatus } from '../activity/activity-status.enum';
+import { ActivityType, GrowthDirection } from '../activities-type/activity-type.entity';
+import { Entity as OrgEntity, EntityType } from '../entities/entity.entity';
+import { Role } from '../roles/role.entity';
+import { User } from '../users/user.entity';
+import { IdpIdentity } from '../idp-identities/idp-identity.entity';
+
+describe('Activities Filters (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let activityRepo: Repository<Activity>;
+  let activityTypeRepo: Repository<ActivityType>;
+  let entityRepo: Repository<OrgEntity>;
+  let roleRepo: Repository<Role>;
+  let userRepo: Repository<User>;
+  let idpRepo: Repository<IdpIdentity>;
+
+  const activityIds: string[] = [];
+  const activityTypeIds: string[] = [];
+  const entityIds: string[] = [];
+  const roleIds: string[] = [];
+  const userIds: string[] = [];
+  const idpIds: string[] = [];
+  const subject = `test-sub-${Date.now()}`;
+  const issuer = 'test-issuer';
+  let type1Id: string;
+  let type2Id: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context: any) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = { sub: subject, iss: issuer };
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    dataSource = moduleFixture.get(DataSource);
+    activityRepo = moduleFixture.get(getRepositoryToken(Activity));
+    activityTypeRepo = moduleFixture.get(getRepositoryToken(ActivityType));
+    entityRepo = moduleFixture.get(getRepositoryToken(OrgEntity));
+    roleRepo = moduleFixture.get(getRepositoryToken(Role));
+    userRepo = moduleFixture.get(getRepositoryToken(User));
+    idpRepo = moduleFixture.get(getRepositoryToken(IdpIdentity));
+
+    const entity = await entityRepo.save({
+      name: `Filters Entity ${Date.now()}`,
+      type: EntityType.FIELD,
+      is_active: true,
+      term_length_years: 5,
+    });
+    entityIds.push(entity.id);
+
+    const role = await roleRepo.save({
+      name: `Filters Role ${Date.now()}`,
+    });
+    roleIds.push(role.id);
+
+    const user = await userRepo.save({
+      username: `filters_user_${Date.now()}`,
+      email: `filters_${Date.now()}@example.com`,
+      role,
+      entity,
+      role_id: role.id,
+      entity_id: entity.id,
+    });
+    userIds.push(user.id);
+
+    const idp = await idpRepo.save({
+      user,
+      user_id: user.id,
+      provider: 'test',
+      issuer,
+      subject,
+      audience: null,
+      email: user.email,
+      email_verified: true,
+      name: user.username,
+      last_seen_at: new Date(),
+    });
+    idpIds.push(idp.id);
+
+    const type1 = await activityTypeRepo.save({
+      name: `Type One ${Date.now()}`,
+      description: 'Type one for filter tests',
+      growth_direction: GrowthDirection.POSITIVE,
+      allowed_roles: [],
+    });
+    type1Id = type1.id;
+    activityTypeIds.push(type1.id);
+
+    const type2 = await activityTypeRepo.save({
+      name: `Type Two ${Date.now()}`,
+      description: 'Type two for filter tests',
+      growth_direction: GrowthDirection.POSITIVE,
+      allowed_roles: [],
+    });
+    type2Id = type2.id;
+    activityTypeIds.push(type2.id);
+
+    const activities = [
+      {
+        activityTypeId: type1.id,
+        activityDate: '2024-03-10',
+        hasExpense: true,
+        expenseAmount: '10.00',
+      },
+      {
+        activityTypeId: type1.id,
+        activityDate: '2024-03-05',
+        hasExpense: false,
+        expenseAmount: null,
+      },
+      {
+        activityTypeId: type2.id,
+        activityDate: '2024-02-20',
+        hasExpense: true,
+        expenseAmount: '25.00',
+      },
+      {
+        activityTypeId: type2.id,
+        activityDate: '2024-01-15',
+        hasExpense: false,
+        expenseAmount: null,
+      },
+      {
+        activityTypeId: type2.id,
+        activityDate: '2023-12-31',
+        hasExpense: true,
+        expenseAmount: '5.00',
+      },
+    ];
+
+    for (const activity of activities) {
+      const created = await activityRepo.save({
+        ...activity,
+        description: 'Seeded activity',
+        reportingPeriodId: null,
+        userId: user.id,
+        createdBy: user.id,
+        updatedBy: user.id,
+        status: ActivityStatus.ACTIVE,
+      });
+      activityIds.push(created.id);
+    }
+  });
+
+  afterAll(async () => {
+    await activityRepo.delete(activityIds);
+    await idpRepo.delete(idpIds);
+    await userRepo.delete(userIds);
+    await activityTypeRepo.delete(activityTypeIds);
+    await roleRepo.delete(roleIds);
+    await entityRepo.delete(entityIds);
+    await app.close();
+  });
+
+  it('filters by date range only', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/activities')
+      .query({ startDate: '2024-03-01', endDate: '2024-03-31', limit: 50 })
+      .expect(200);
+
+    const dates = response.body.items.map((item: any) => item.activityDate);
+    expect(dates).toEqual(expect.arrayContaining(['2024-03-10', '2024-03-05']));
+    expect(dates).not.toContain('2024-02-20');
+    expect(dates).not.toContain('2024-01-15');
+  });
+
+  it('combines date, type, and expense filters', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/activities')
+      .query({
+        startDate: '2024-01-01',
+        endDate: '2024-03-31',
+        activityTypeId: type2Id,
+        hasExpense: 'true',
+        limit: 50,
+      })
+      .expect(200);
+
+    const items = response.body.items;
+    expect(items).toHaveLength(1);
+    expect(items[0].activityDate).toBe('2024-02-20');
+    expect(items[0].hasExpense).toBe(true);
+  });
+
+  it('supports hasExpense=false filters', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/activities')
+      .query({ hasExpense: 'false', limit: 50 })
+      .expect(200);
+
+    const dates = response.body.items.map((item: any) => item.activityDate);
+    expect(dates).toEqual(expect.arrayContaining(['2024-03-05', '2024-01-15']));
+    expect(dates).not.toContain('2024-03-10');
+    expect(dates).not.toContain('2024-02-20');
+  });
+
+  it('combines activity type and date range without conflicts', async () => {
+    const response = await request(app.getHttpServer())
+      .get('/activities')
+      .query({
+        startDate: '2024-03-01',
+        endDate: '2024-03-31',
+        activityTypeId: type1Id,
+        limit: 50,
+      })
+      .expect(200);
+
+    const dates = response.body.items.map((item: any) => item.activityDate);
+    expect(dates).toEqual(expect.arrayContaining(['2024-03-10', '2024-03-05']));
+    expect(dates).not.toContain('2024-02-20');
+    expect(dates).not.toContain('2024-01-15');
+  });
+});

--- a/frontend/lib/models/activities_filter.dart
+++ b/frontend/lib/models/activities_filter.dart
@@ -77,36 +77,41 @@ extension TimePresetExtension on TimePreset {
     }
   }
 
-  DateTimeRange getRange() {
-    final now = DateTime.now();
+  DateTimeRange getRange({DateTime? now}) {
+    final current = now ?? DateTime.now();
+    final today = DateTime(current.year, current.month, current.day);
     switch (this) {
       case TimePreset.last7Days:
+        final end = today;
+        final start = end.subtract(const Duration(days: 6));
         return DateTimeRange(
-          start: now.subtract(const Duration(days: 7)),
-          end: now,
+          start: start,
+          end: end,
         );
       case TimePreset.thisMonth:
         return DateTimeRange(
-          start: DateTime(now.year, now.month, 1),
-          end: DateTime(now.year, now.month + 1, 0),
+          start: DateTime(current.year, current.month, 1),
+          end: today,
         );
       case TimePreset.lastMonth:
         return DateTimeRange(
-          start: DateTime(now.year, now.month - 1, 1),
-          end: DateTime(now.year, now.month, 0),
+          start: DateTime(current.year, current.month - 1, 1),
+          end: DateTime(current.year, current.month, 0),
         );
       case TimePreset.last3Months:
+        final end = today;
+        final start = DateTime(current.year, current.month - 2, 1);
         return DateTimeRange(
-          start: DateTime(now.year, now.month - 2, 1),
-          end: now,
+          start: start,
+          end: end,
         );
       case TimePreset.thisYear:
         return DateTimeRange(
-          start: DateTime(now.year, 1, 1),
-          end: DateTime(now.year, 12, 31),
+          start: DateTime(current.year, 1, 1),
+          end: today,
         );
       case TimePreset.custom:
-        return DateTimeRange(start: now, end: now);
+        return DateTimeRange(start: today, end: today);
     }
   }
 }

--- a/frontend/test/models/activities_filter_test.dart
+++ b/frontend/test/models/activities_filter_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/models/activities_filter.dart';
+
+void main() {
+  group('TimePreset.getRange', () {
+    final reference = DateTime(2024, 3, 15, 10, 30);
+
+    test('last7Days includes today and previous 6 days', () {
+      final range = TimePreset.last7Days.getRange(now: reference);
+      expect(range.start, DateTime(2024, 3, 9));
+      expect(range.end, DateTime(2024, 3, 15));
+    });
+
+    test('thisMonth starts at first day and ends today', () {
+      final range = TimePreset.thisMonth.getRange(now: reference);
+      expect(range.start, DateTime(2024, 3, 1));
+      expect(range.end, DateTime(2024, 3, 15));
+    });
+
+    test('lastMonth covers the full previous calendar month', () {
+      final range = TimePreset.lastMonth.getRange(now: reference);
+      expect(range.start, DateTime(2024, 2, 1));
+      expect(range.end, DateTime(2024, 2, 29));
+    });
+
+    test('last3Months includes current and two previous months', () {
+      final range = TimePreset.last3Months.getRange(now: reference);
+      expect(range.start, DateTime(2024, 1, 1));
+      expect(range.end, DateTime(2024, 3, 15));
+    });
+
+    test('thisYear starts on Jan 1 and ends today', () {
+      final range = TimePreset.thisYear.getRange(now: reference);
+      expect(range.start, DateTime(2024, 1, 1));
+      expect(range.end, DateTime(2024, 3, 15));
+    });
+
+    test('custom defaults to today', () {
+      final range = TimePreset.custom.getRange(now: reference);
+      expect(range.start, DateTime(2024, 3, 15));
+      expect(range.end, DateTime(2024, 3, 15));
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Activity filters were returning incorrect results for certain filter combinations due to inaccurate date range calculations in the frontend.

## Changes
- **Fixed date range calculations** for all time presets in `activities_filter.dart`:
  - "Last 7 days" now correctly includes today + 6 previous days (was including 8 days)
  - "This month" ends on today instead of end of month
  - "This year" ends on today instead of December 31st
  - All date ranges normalized to midnight to avoid time-of-day issues

- **Added comprehensive test coverage**:
  - Unit tests for frontend date preset calculations
  - Unit tests for backend service filter logic
  - E2E tests verifying all filter combinations work correctly

## Testing
-  Date range filters return accurate results
-  Multiple filters combine without conflicts
-  Expense filter handles both `true` and `false` values
-  All filter combinations tested end-to-end