### PR TITLE
feat:  Add owner info to activities and PDF exports

### DIFF
--- a/frontend/lib/models/activity.dart
+++ b/frontend/lib/models/activity.dart
@@ -12,6 +12,8 @@ class Activity {
   final String status;
   final DateTime? createdAt;
   final DateTime? updatedAt;
+  final String? ownerUserId;
+  final String? ownerUsername;
 
   const Activity({
     this.id,
@@ -27,6 +29,8 @@ class Activity {
     this.status = 'active',
     this.createdAt,
     this.updatedAt,
+    this.ownerUserId,
+    this.ownerUsername,
   });
 
   factory Activity.fromApi(Map<String, dynamic> data) {
@@ -56,6 +60,8 @@ class Activity {
           data['createdAt'] != null ? DateTime.parse(data['createdAt']) : null,
       updatedAt:
           data['updatedAt'] != null ? DateTime.parse(data['updatedAt']) : null,
+      ownerUserId: data['ownerUserId'] as String?,
+      ownerUsername: data['ownerUsername'] as String?,
     );
   }
 }

--- a/frontend/lib/services/pdf_service.dart
+++ b/frontend/lib/services/pdf_service.dart
@@ -8,6 +8,7 @@ class PdfService {
   Future<Uint8List> generateActivitiesReport({
     required List<Activity> activities,
     required ActivitiesFilter filter,
+    String? requestorName,
   }) async {
     final pdf = pw.Document();
 
@@ -23,7 +24,7 @@ class PdfService {
       pw.MultiPage(
         pageFormat: PdfPageFormat.letter,
         margin: const pw.EdgeInsets.all(40),
-        header: (context) => _buildHeader(context, filter),
+        header: (context) => _buildHeader(context, filter, requestorName),
         footer: (context) => _buildFooter(context),
         build: (context) => [
           pw.SizedBox(height: 20),
@@ -56,7 +57,11 @@ class PdfService {
     return pdf.save();
   }
 
-  pw.Widget _buildHeader(pw.Context context, ActivitiesFilter filter) {
+  pw.Widget _buildHeader(
+    pw.Context context,
+    ActivitiesFilter filter,
+    String? requestorName,
+  ) {
     return pw.Column(
       crossAxisAlignment: pw.CrossAxisAlignment.start,
       children: [
@@ -85,6 +90,14 @@ class PdfService {
             'Periodo: ${_formatDate(filter.startDate)} - ${_formatDate(filter.endDate)}',
             style: const pw.TextStyle(
               fontSize: 12,
+              color: PdfColors.grey700,
+            ),
+          ),
+        if (requestorName != null && requestorName.isNotEmpty)
+          pw.Text(
+            'Solicitado por: $requestorName',
+            style: const pw.TextStyle(
+              fontSize: 11,
               color: PdfColors.grey700,
             ),
           ),
@@ -174,10 +187,11 @@ class PdfService {
     return pw.Table(
       border: pw.TableBorder.all(color: PdfColors.grey400),
       columnWidths: {
-        0: const pw.FlexColumnWidth(1.5),
-        1: const pw.FlexColumnWidth(2),
-        2: const pw.FlexColumnWidth(3),
-        3: const pw.FlexColumnWidth(1.5),
+        0: const pw.FlexColumnWidth(1.3),
+        1: const pw.FlexColumnWidth(1.8),
+        2: const pw.FlexColumnWidth(2),
+        3: const pw.FlexColumnWidth(3),
+        4: const pw.FlexColumnWidth(1.5),
       },
       children: [
         // Header row
@@ -188,6 +202,7 @@ class PdfService {
           children: [
             _buildTableCell('Fecha', isHeader: true),
             _buildTableCell('Tipo', isHeader: true),
+            _buildTableCell('Propietario', isHeader: true),
             _buildTableCell('Descripcion', isHeader: true),
             _buildTableCell('Gasto', isHeader: true),
           ],
@@ -197,6 +212,9 @@ class PdfService {
               children: [
                 _buildTableCell(_formatDate(a.date)),
                 _buildTableCell(a.category),
+                _buildTableCell(a.ownerUsername?.isNotEmpty == true
+                    ? a.ownerUsername!
+                    : '-'),
                 _buildTableCell(
                   a.description.length > 60
                       ? '${a.description.substring(0, 60)}...'

--- a/frontend/lib/widgets/common/pdf_export_button.dart
+++ b/frontend/lib/widgets/common/pdf_export_button.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:printing/printing.dart';
 import '../../models/activity.dart';
 import '../../models/activities_filter.dart';
+import '../../providers/auth.dart';
 import '../../services/pdf_service.dart';
 
-class PdfExportButton extends StatefulWidget {
+class PdfExportButton extends ConsumerStatefulWidget {
   final List<Activity> activities;
   final ActivitiesFilter filter;
 
@@ -15,11 +17,21 @@ class PdfExportButton extends StatefulWidget {
   });
 
   @override
-  State<PdfExportButton> createState() => _PdfExportButtonState();
+  ConsumerState<PdfExportButton> createState() => _PdfExportButtonState();
 }
 
-class _PdfExportButtonState extends State<PdfExportButton> {
+class _PdfExportButtonState extends ConsumerState<PdfExportButton> {
   bool _isGenerating = false;
+
+  String? _resolveRequestorName(Map<String, dynamic>? user) {
+    if (user == null) return null;
+    return user['full_name'] as String? ??
+        user['first_name'] as String? ??
+        user['name'] as String? ??
+        user['nickname'] as String? ??
+        user['username'] as String? ??
+        user['email'] as String?;
+  }
 
   Future<void> _generatePdf() async {
     if (widget.activities.isEmpty) {
@@ -38,9 +50,12 @@ class _PdfExportButtonState extends State<PdfExportButton> {
 
     try {
       final pdfService = PdfService();
+      final authState = ref.read(authNotifierProvider);
+      final requestorName = _resolveRequestorName(authState.user);
       final pdfBytes = await pdfService.generateActivitiesReport(
         activities: widget.activities,
         filter: widget.filter,
+        requestorName: requestorName,
       );
 
       await Printing.sharePdf(

--- a/frontend/test/models/activity_test.dart
+++ b/frontend/test/models/activity_test.dart
@@ -11,6 +11,8 @@ void main() {
           'activityTypeName': 'Meeting',
           'description': 'Team standup',
           'expenseAmount': '150.50',
+          'ownerUserId': 'user-987',
+          'ownerUsername': 'maria.gomez',
         };
 
         final activity = Activity.fromApi(apiData);
@@ -20,6 +22,8 @@ void main() {
         expect(activity.category, 'Meeting');
         expect(activity.description, 'Team standup');
         expect(activity.expense, 150.50);
+        expect(activity.ownerUserId, 'user-987');
+        expect(activity.ownerUsername, 'maria.gomez');
       });
 
       test('should handle null id', () {


### PR DESCRIPTION
Description
  This PR fixes missing owner details in activity PDF exports by adding owner fields to the Activity model and rendering them in the PDF table. It also
  adds the report requestor name to the PDF header when available.

  What changed

  - Added ownerUserId and ownerUsername to Activity and parse them from the API response.
  - Added a Propietario column to the activities PDF table, showing the username or - if missing.
  - Included “Solicitado por” in the PDF header using the current authenticated user.
  - Updated activity model tests to cover owner fields.

  Testing

  - flutter test test/models/activity_test.dart

Closes #161