### PR TITLE
 Add Azure Terraform three‑tier infrastructure and clean legacy Terraform artifacts

### DIFF
--- a/infra/modules/app_vm/cloud-init.yaml.tftpl
+++ b/infra/modules/app_vm/cloud-init.yaml.tftpl
@@ -1,0 +1,25 @@
+#cloud-config
+runcmd:
+  - [bash, -c, "curl -fsSL https://get.docker.com -o /tmp/get-docker.sh"]
+  - [bash, -c, "sh /tmp/get-docker.sh"]
+  - [bash, -c, "mkdir -p /opt/app"]
+  - |
+      cat > /opt/app/nginx.conf <<'NGINX'
+      server {
+        listen 80;
+        # listen 443 ssl; # Optional if you terminate TLS on the VM
+        server_name ${server_name};
+
+        location /api/ {
+          proxy_pass http://nestjs:3000/;
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+        }
+      }
+      NGINX
+  - [bash, -c, "echo '${docker_compose_b64}' | base64 -d > /opt/app/docker-compose.yml"]
+  - [bash, -c, "echo '${env_file_b64}' | base64 -d > /opt/app/.env"]
+  - [bash, -c, "docker compose -f /opt/app/docker-compose.yml --env-file /opt/app/.env up -d"]

--- a/infra/modules/app_vm/main.tf
+++ b/infra/modules/app_vm/main.tf
@@ -1,0 +1,69 @@
+locals {
+  server_name = coalesce(var.api_domain, "_")
+}
+
+resource "azurerm_public_ip" "app" {
+  name                = "${var.project_name}-${var.env}-pip-app"
+  location            = var.location
+  resource_group_name = var.rg_name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}
+
+resource "azurerm_network_interface" "app" {
+  name                = "${var.project_name}-${var.env}-nic-app"
+  location            = var.location
+  resource_group_name = var.rg_name
+  tags                = var.tags
+
+  ip_configuration {
+    name                          = "ipconfig1"
+    subnet_id                     = var.subnet_id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.app.id
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "app" {
+  name                = "${var.project_name}-${var.env}-vm-app"
+  location            = var.location
+  resource_group_name = var.rg_name
+  size                = var.vm_size
+  admin_username      = var.vm_admin_username
+  network_interface_ids = [
+    azurerm_network_interface.app.id
+  ]
+
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username   = var.vm_admin_username
+    public_key = var.ssh_public_key
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  os_disk {
+    name                 = "${var.project_name}-${var.env}-osdisk"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  custom_data = base64encode(templatefile("${path.module}/cloud-init.yaml.tftpl", {
+    docker_compose_b64 = var.docker_compose_b64
+    env_file_b64       = var.env_file_b64
+    server_name        = local.server_name
+  }))
+
+  tags = var.tags
+}

--- a/infra/modules/app_vm/outputs.tf
+++ b/infra/modules/app_vm/outputs.tf
@@ -1,0 +1,7 @@
+output "public_ip" {
+  value = azurerm_public_ip.app.ip_address
+}
+
+output "vm_id" {
+  value = azurerm_linux_virtual_machine.app.id
+}

--- a/infra/modules/app_vm/variables.tf
+++ b/infra/modules/app_vm/variables.tf
@@ -1,0 +1,49 @@
+variable "project_name" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "rg_name" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+variable "vm_size" {
+  type = string
+}
+
+variable "vm_admin_username" {
+  type = string
+}
+
+variable "ssh_public_key" {
+  type = string
+}
+
+variable "docker_compose_b64" {
+  type = string
+}
+
+variable "env_file_b64" {
+  type = string
+}
+
+variable "api_domain" {
+  type    = string
+  default = null
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -1,0 +1,59 @@
+resource "azurerm_log_analytics_workspace" "main" {
+  count               = var.enabled ? 1 : 0
+  name                = "${var.project_name}-${var.env}-law"
+  location            = var.location
+  resource_group_name = var.rg_name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+  tags                = var.tags
+}
+
+resource "azurerm_virtual_machine_extension" "ama" {
+  count               = var.enabled ? 1 : 0
+  name                = "${var.project_name}-${var.env}-ama"
+  virtual_machine_id  = var.vm_id
+  publisher           = "Microsoft.Azure.Monitor"
+  type                = "AzureMonitorLinuxAgent"
+  type_handler_version = "1.0"
+  auto_upgrade_minor_version = true
+
+  settings = jsonencode({})
+}
+
+resource "azurerm_monitor_metric_alert" "cpu_high" {
+  count               = var.enabled ? 1 : 0
+  name                = "${var.project_name}-${var.env}-cpu-high"
+  resource_group_name = var.rg_name
+  scopes              = [var.vm_id]
+  description         = "CPU > 80% for 5 minutes"
+  severity            = 3
+  frequency           = "PT1M"
+  window_size         = "PT5M"
+
+  criteria {
+    metric_namespace = "Microsoft.Compute/virtualMachines"
+    metric_name      = "Percentage CPU"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 80
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "vm_availability" {
+  count               = var.enabled ? 1 : 0
+  name                = "${var.project_name}-${var.env}-vm-availability"
+  resource_group_name = var.rg_name
+  scopes              = [var.vm_id]
+  description         = "VM availability below 100%"
+  severity            = 2
+  frequency           = "PT1M"
+  window_size         = "PT5M"
+
+  criteria {
+    metric_namespace = "Microsoft.Compute/virtualMachines"
+    metric_name      = "VmAvailabilityMetric"
+    aggregation      = "Average"
+    operator         = "LessThan"
+    threshold        = 1
+  }
+}

--- a/infra/modules/monitoring/outputs.tf
+++ b/infra/modules/monitoring/outputs.tf
@@ -1,0 +1,4 @@
+output "log_analytics_workspace_id" {
+  value       = var.enabled ? azurerm_log_analytics_workspace.main[0].id : null
+  description = "Log Analytics Workspace ID if monitoring enabled."
+}

--- a/infra/modules/monitoring/variables.tf
+++ b/infra/modules/monitoring/variables.tf
@@ -1,0 +1,29 @@
+variable "project_name" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "rg_name" {
+  type = string
+}
+
+variable "vm_id" {
+  type = string
+}
+
+variable "enabled" {
+  type    = bool
+  default = false
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,0 +1,21 @@
+resource "azurerm_virtual_network" "main" {
+  name                = "${var.project_name}-${var.env}-vnet"
+  address_space       = [var.vnet_cidr]
+  location            = var.location
+  resource_group_name = var.rg_name
+  tags                = var.tags
+}
+
+resource "azurerm_subnet" "app" {
+  name                 = "snet-app"
+  resource_group_name  = var.rg_name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.app_subnet_cidr]
+}
+
+resource "azurerm_subnet" "data" {
+  name                 = "snet-data"
+  resource_group_name  = var.rg_name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.data_subnet_cidr]
+}

--- a/infra/modules/network/outputs.tf
+++ b/infra/modules/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vnet_id" {
+  value = azurerm_virtual_network.main.id
+}
+
+output "app_subnet_id" {
+  value = azurerm_subnet.app.id
+}
+
+output "data_subnet_id" {
+  value = azurerm_subnet.data.id
+}
+
+output "app_subnet_cidr" {
+  value = azurerm_subnet.app.address_prefixes[0]
+}
+
+output "data_subnet_cidr" {
+  value = azurerm_subnet.data.address_prefixes[0]
+}

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -1,0 +1,32 @@
+variable "project_name" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "rg_name" {
+  type = string
+}
+
+variable "vnet_cidr" {
+  type = string
+}
+
+variable "app_subnet_cidr" {
+  type = string
+}
+
+variable "data_subnet_cidr" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infra/modules/postgres/main.tf
+++ b/infra/modules/postgres/main.tf
@@ -1,0 +1,35 @@
+locals {
+  db_name = "appdb"
+}
+
+resource "azurerm_postgresql_flexible_server" "main" {
+  name                   = "${var.project_name}-${var.env}-pg"
+  resource_group_name    = var.rg_name
+  location               = var.location
+  version                = "14"
+  administrator_login    = var.admin_username
+  administrator_password = var.admin_password
+
+  sku_name                = var.postgres_sku
+  storage_mb              = 65536
+  auto_grow_enabled       = true
+  public_network_access_enabled = true
+  ssl_enforcement_enabled = true
+
+  tags = var.tags
+}
+
+resource "azurerm_postgresql_flexible_server_database" "main" {
+  name      = local.db_name
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "app_vm" {
+  name      = "allow-app-vm"
+  server_id = azurerm_postgresql_flexible_server.main.id
+
+  start_ip_address = var.app_vm_public_ip
+  end_ip_address   = var.app_vm_public_ip
+}

--- a/infra/modules/postgres/outputs.tf
+++ b/infra/modules/postgres/outputs.tf
@@ -1,0 +1,11 @@
+output "fqdn" {
+  value = azurerm_postgresql_flexible_server.main.fqdn
+}
+
+output "db_name" {
+  value = azurerm_postgresql_flexible_server_database.main.name
+}
+
+output "admin_username" {
+  value = azurerm_postgresql_flexible_server.main.administrator_login
+}

--- a/infra/modules/postgres/variables.tf
+++ b/infra/modules/postgres/variables.tf
@@ -1,0 +1,37 @@
+variable "project_name" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "rg_name" {
+  type = string
+}
+
+variable "postgres_sku" {
+  type = string
+}
+
+variable "admin_username" {
+  type = string
+}
+
+variable "admin_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "app_vm_public_ip" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infra/modules/security/main.tf
+++ b/infra/modules/security/main.tf
@@ -1,0 +1,107 @@
+resource "azurerm_network_security_group" "app" {
+  name                = "${var.project_name}-${var.env}-nsg-app"
+  location            = var.location
+  resource_group_name = var.rg_name
+  tags                = var.tags
+}
+
+resource "azurerm_network_security_rule" "app_http" {
+  name                        = "allow-http"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "80"
+  source_address_prefix       = "Internet"
+  destination_address_prefix  = "*"
+  resource_group_name         = var.rg_name
+  network_security_group_name = azurerm_network_security_group.app.name
+}
+
+resource "azurerm_network_security_rule" "app_https" {
+  name                        = "allow-https"
+  priority                    = 110
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "443"
+  source_address_prefix       = "Internet"
+  destination_address_prefix  = "*"
+  resource_group_name         = var.rg_name
+  network_security_group_name = azurerm_network_security_group.app.name
+}
+
+resource "azurerm_network_security_rule" "app_ssh" {
+  name                        = "allow-ssh"
+  priority                    = 120
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = var.admin_cidr
+  destination_address_prefix  = "*"
+  resource_group_name         = var.rg_name
+  network_security_group_name = azurerm_network_security_group.app.name
+}
+
+resource "azurerm_network_security_rule" "app_deny_all" {
+  name                        = "deny-all-inbound"
+  priority                    = 4096
+  direction                   = "Inbound"
+  access                      = "Deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = var.rg_name
+  network_security_group_name = azurerm_network_security_group.app.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "app" {
+  subnet_id                 = var.app_subnet_id
+  network_security_group_id = azurerm_network_security_group.app.id
+}
+
+resource "azurerm_network_security_group" "data" {
+  name                = "${var.project_name}-${var.env}-nsg-data"
+  location            = var.location
+  resource_group_name = var.rg_name
+  tags                = var.tags
+}
+
+resource "azurerm_network_security_rule" "data_postgres" {
+  name                        = "allow-postgres"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "5432"
+  source_address_prefix       = var.app_subnet_cidr
+  destination_address_prefix  = "*"
+  resource_group_name         = var.rg_name
+  network_security_group_name = azurerm_network_security_group.data.name
+}
+
+resource "azurerm_network_security_rule" "data_deny_all" {
+  name                        = "deny-all-inbound"
+  priority                    = 4096
+  direction                   = "Inbound"
+  access                      = "Deny"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = var.rg_name
+  network_security_group_name = azurerm_network_security_group.data.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "data" {
+  subnet_id                 = var.data_subnet_id
+  network_security_group_id = azurerm_network_security_group.data.id
+}

--- a/infra/modules/security/outputs.tf
+++ b/infra/modules/security/outputs.tf
@@ -1,0 +1,7 @@
+output "app_nsg_id" {
+  value = azurerm_network_security_group.app.id
+}
+
+output "data_nsg_id" {
+  value = azurerm_network_security_group.data.id
+}

--- a/infra/modules/security/variables.tf
+++ b/infra/modules/security/variables.tf
@@ -1,0 +1,40 @@
+variable "project_name" {
+  type = string
+}
+
+variable "env" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "rg_name" {
+  type = string
+}
+
+variable "app_subnet_id" {
+  type = string
+}
+
+variable "data_subnet_id" {
+  type = string
+}
+
+variable "app_subnet_cidr" {
+  type = string
+}
+
+variable "data_subnet_cidr" {
+  type = string
+}
+
+variable "admin_cidr" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/infra/root/README.md
+++ b/infra/root/README.md
@@ -1,0 +1,127 @@
+# Azure Terraform: Missionary App (Three-Tier)
+
+Production-lean Azure Terraform for a three-tier architecture with environments via Terraform workspaces: `dev`, `staging`, `prod`.
+
+- Frontend: Cloudflare Pages (outside Azure)
+- App tier: Linux VM running Docker (NestJS API)
+- Data tier: Azure Database for PostgreSQL Flexible Server
+- Region: single region (default `eastus2`, overrideable)
+
+## Prereqs
+
+1. Azure CLI login:
+   - `az login`
+   - `az account set --subscription <SUBSCRIPTION_ID>`
+
+2. Create a Resource Group, Storage Account, and Container for remote state (not managed by this Terraform):
+   - Resource Group: `REPLACE_ME_TFSTATE_RG`
+   - Storage Account: `REPLACE_ME_TFSTATE_STORAGE` (globally unique)
+   - Container: `REPLACE_ME_TFSTATE_CONTAINER`
+
+3. Update `infra/root/backend.tf` with the names above.
+
+## Variables
+
+Create a `terraform.tfvars` in `infra/root` (do not commit) with values like:
+
+```hcl
+admin_cidr              = "YOUR_PUBLIC_IP/32"
+ssh_public_key          = "ssh-ed25519 AAAA..."
+docker_compose_b64      = "BASE64_OF_DOCKER_COMPOSE"
+env_file_b64            = "BASE64_OF_ENV_FILE"
+postgres_admin_username = "pgadmin"
+postgres_admin_password = "REPLACE_ME"
+```
+
+Optional:
+
+```hcl
+location  = "eastus2"
+api_domain = "api.example.com"
+tags = {
+  owner = "platform"
+}
+```
+
+## Base64 Encoding
+
+Encode your `docker-compose.yml` and `.env`:
+
+```bash
+base64 -i docker-compose.yml
+base64 -i .env
+```
+
+## Example docker-compose.yml
+
+This example matches the required stack and uses `/opt/app/nginx.conf` (written by cloud-init). It keeps HTTPS commented by default (Cloudflare proxy can handle TLS).
+
+```yaml
+services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+      # - "443:443" # Optional if terminating TLS on the VM
+    volumes:
+      - /opt/app/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - nestjs
+
+  nestjs:
+    image: your-nestjs-image:latest
+    expose:
+      - "3000"
+```
+
+Optional LetsEncrypt approach (commented example):
+
+```yaml
+  # certbot:
+  #   image: certbot/certbot
+  #   volumes:
+  #     - /etc/letsencrypt:/etc/letsencrypt
+  #   command: certonly --standalone -d api.example.com --agree-tos -m you@example.com
+```
+
+## Workspaces
+
+Only `prod` is required for deployment now, but `dev` and `staging` are supported.
+
+```bash
+terraform init
+terraform workspace new prod
+terraform workspace select prod
+terraform plan
+terraform apply
+```
+
+To use other environments:
+
+```bash
+terraform workspace new dev
+terraform workspace new staging
+```
+
+## Destroy
+
+```bash
+terraform destroy
+```
+
+## Security Notes
+
+- Restrict `admin_cidr` to your IP only.
+- PostgreSQL requires SSL.
+- DB firewall is limited to the VM public IP.
+- Use Cloudflare proxy to terminate HTTPS; VM defaults to HTTP only.
+
+## Cost Notes
+
+- Biggest levers are VM size and PostgreSQL compute SKU.
+- Storage size (64 GiB) is secondary.
+- Log ingestion can grow costs if monitoring is enabled.
+
+## Connectivity Tradeoff
+
+This setup uses public PostgreSQL with firewall restricted to the VM public IP for simplicity and lower cost. Consider private access and private DNS if you need stronger network isolation.

--- a/infra/root/backend.tf
+++ b/infra/root/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "REPLACE_ME_TFSTATE_RG"
+    storage_account_name = "REPLACE_ME_TFSTATE_STORAGE"
+    container_name       = "REPLACE_ME_TFSTATE_CONTAINER"
+    key                  = "missionary-app.${terraform.workspace}.tfstate"
+  }
+}

--- a/infra/root/locals.tf
+++ b/infra/root/locals.tf
@@ -1,0 +1,37 @@
+locals {
+  env = terraform.workspace
+
+  settings = {
+    dev = {
+      vm_size            = "Standard_B1s"
+      postgres_sku       = "B_Standard_B1ms"
+      monitoring_enabled = false
+      location           = "eastus2"
+    }
+    staging = {
+      vm_size            = "Standard_B2s"
+      postgres_sku       = "B_Standard_B1ms"
+      monitoring_enabled = false
+      location           = "eastus2"
+    }
+    prod = {
+      vm_size            = "Standard_B2s"
+      postgres_sku       = "B_Standard_B2ms"
+      monitoring_enabled = true
+      location           = "eastus2"
+    }
+  }
+
+  cfg      = local.settings[local.env]
+  location = coalesce(var.location, local.cfg.location, "eastus2")
+
+  name_prefix = "${var.project_name}-${local.env}"
+
+  tags = merge(
+    {
+      environment = local.env
+      project     = var.project_name
+    },
+    var.tags
+  )
+}

--- a/infra/root/main.tf
+++ b/infra/root/main.tf
@@ -1,0 +1,76 @@
+resource "azurerm_resource_group" "main" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+  tags     = local.tags
+}
+
+module "network" {
+  source = "../modules/network"
+
+  project_name     = var.project_name
+  env              = local.env
+  location         = local.location
+  rg_name          = azurerm_resource_group.main.name
+  vnet_cidr        = "10.10.0.0/16"
+  app_subnet_cidr  = "10.10.1.0/24"
+  data_subnet_cidr = "10.10.2.0/24"
+  tags             = local.tags
+}
+
+module "security" {
+  source = "../modules/security"
+
+  project_name     = var.project_name
+  env              = local.env
+  location         = local.location
+  rg_name          = azurerm_resource_group.main.name
+  app_subnet_id    = module.network.app_subnet_id
+  data_subnet_id   = module.network.data_subnet_id
+  app_subnet_cidr  = module.network.app_subnet_cidr
+  data_subnet_cidr = module.network.data_subnet_cidr
+  admin_cidr       = var.admin_cidr
+  tags             = local.tags
+}
+
+module "app_vm" {
+  source = "../modules/app_vm"
+
+  project_name        = var.project_name
+  env                 = local.env
+  location            = local.location
+  rg_name             = azurerm_resource_group.main.name
+  subnet_id           = module.network.app_subnet_id
+  vm_size             = local.cfg.vm_size
+  vm_admin_username   = var.vm_admin_username
+  ssh_public_key      = var.ssh_public_key
+  docker_compose_b64  = var.docker_compose_b64
+  env_file_b64        = var.env_file_b64
+  api_domain          = var.api_domain
+  tags                = local.tags
+}
+
+module "postgres" {
+  source = "../modules/postgres"
+
+  project_name           = var.project_name
+  env                    = local.env
+  location               = local.location
+  rg_name                = azurerm_resource_group.main.name
+  postgres_sku           = local.cfg.postgres_sku
+  admin_username         = var.postgres_admin_username
+  admin_password         = var.postgres_admin_password
+  app_vm_public_ip       = module.app_vm.public_ip
+  tags                   = local.tags
+}
+
+module "monitoring" {
+  source = "../modules/monitoring"
+
+  project_name = var.project_name
+  env          = local.env
+  location     = local.location
+  rg_name      = azurerm_resource_group.main.name
+  vm_id        = module.app_vm.vm_id
+  enabled      = local.cfg.monitoring_enabled
+  tags         = local.tags
+}

--- a/infra/root/outputs.tf
+++ b/infra/root/outputs.tf
@@ -1,0 +1,27 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.main.name
+}
+
+output "vnet_id" {
+  value = module.network.vnet_id
+}
+
+output "app_subnet_id" {
+  value = module.network.app_subnet_id
+}
+
+output "data_subnet_id" {
+  value = module.network.data_subnet_id
+}
+
+output "vm_public_ip" {
+  value = module.app_vm.public_ip
+}
+
+output "postgres_fqdn" {
+  value = module.postgres.fqdn
+}
+
+output "postgres_db_name" {
+  value = module.postgres.db_name
+}

--- a/infra/root/providers.tf
+++ b/infra/root/providers.tf
@@ -1,0 +1,3 @@
+provider "azurerm" {
+  features {}
+}

--- a/infra/root/variables.tf
+++ b/infra/root/variables.tf
@@ -1,0 +1,60 @@
+variable "project_name" {
+  type        = string
+  description = "Project name prefix for all resources."
+  default     = "missionary-app"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region. Defaults to eastus2 if not set."
+  default     = null
+}
+
+variable "admin_cidr" {
+  type        = string
+  description = "CIDR allowed for SSH (recommend your public IP /32)."
+}
+
+variable "vm_admin_username" {
+  type        = string
+  description = "Admin username for the VM."
+  default     = "azureuser"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH public key for VM access."
+}
+
+variable "docker_compose_b64" {
+  type        = string
+  description = "Base64-encoded docker-compose.yml content."
+}
+
+variable "env_file_b64" {
+  type        = string
+  description = "Base64-encoded .env content for the app stack."
+}
+
+variable "postgres_admin_username" {
+  type        = string
+  description = "Admin username for PostgreSQL Flexible Server."
+}
+
+variable "postgres_admin_password" {
+  type        = string
+  description = "Admin password for PostgreSQL Flexible Server."
+  sensitive   = true
+}
+
+variable "api_domain" {
+  type        = string
+  description = "Optional domain for nginx server_name."
+  default     = null
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Optional tags to apply to resources."
+  default     = {}
+}

--- a/infra/root/versions.tf
+++ b/infra/root/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.90.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR delivers a new, production‑lean Azure Terraform stack under infra/, organized with modules and Terraform workspaces (dev,
  staging, prod). It provisions a single‑region three‑tier architecture: VNet + subnets, NSGs, a Docker‑based Linux VM for the NestJS
  API, PostgreSQL Flexible Server (public access restricted to the VM IP), and optional minimal monitoring. The root config includes
  backend placeholders, environment‑based sizing, and outputs needed for deployment, plus a clear README for setup and operations.