### PR TITLE
feat: Make reporting period duration configurable per entity

### DIFF
--- a/backend/migrations/AddReportingPeriodDaysToEntities.ts
+++ b/backend/migrations/AddReportingPeriodDaysToEntities.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddReportingPeriodDaysToEntities1739923200000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('entities');
+    const reportingPeriodDaysColumn = table?.findColumnByName('reporting_period_days');
+
+    if (!reportingPeriodDaysColumn) {
+      await queryRunner.addColumn(
+        'entities',
+        new TableColumn({
+          name: 'reporting_period_days',
+          type: 'int',
+          isNullable: true,
+          comment:
+            'Custom reporting period duration in days. If null, uses environment variable or default (14).',
+        }),
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('entities', 'reporting_period_days');
+  }
+}

--- a/backend/migrations/EnableTrigramSearchActivities.ts
+++ b/backend/migrations/EnableTrigramSearchActivities.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class EnableTrigramSearchActivities implements MigrationInterface {
+export class EnableTrigramSearchActivities1736200000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
     await queryRunner.query(

--- a/backend/src/entities/entity.entity.ts
+++ b/backend/src/entities/entity.entity.ts
@@ -50,6 +50,9 @@ export class Entity {
   @Column({ type: 'int', default: 5, name: 'term_length_years' })
   term_length_years!: number;
 
+  @Column({ type: 'int', nullable: true, name: 'reporting_period_days' })
+  reporting_period_days?: number;
+
   @Column({ type: 'uuid', nullable: true })
   parent_id?: string | null;
 

--- a/backend/src/reporting-periods/reporting-periods.service.ts
+++ b/backend/src/reporting-periods/reporting-periods.service.ts
@@ -13,6 +13,7 @@ import { CreateReportingPeriodDto } from './dto/create-reporting-period.dto';
 import { UpdateReportingPeriodDto } from './dto/update-reporting-period.dto';
 import { CreateExceptionDto } from './dto/create-exception.dto';
 import { ReportingPeriodStatus } from './reporting-period-status.enum';
+import { Entity } from '../entities/entity.entity';
 
 @Injectable()
 export class ReportingPeriodsService {
@@ -23,7 +24,28 @@ export class ReportingPeriodsService {
     private readonly repo: Repository<ReportingPeriod>,
     @InjectRepository(ReportingPeriodException)
     private readonly exceptionsRepo: Repository<ReportingPeriodException>,
+    @InjectRepository(Entity)
+    private readonly entityRepo: Repository<Entity>,
   ) {}
+
+  private async getReportingPeriodDays(entityId: string): Promise<number> {
+    const entity = await this.entityRepo.findOne({
+      where: { id: entityId },
+      select: ['reporting_period_days'],
+    });
+    if (entity?.reporting_period_days != null) {
+      return entity.reporting_period_days;
+    }
+    const envDays = process.env.REPORTING_PERIOD_DAYS;
+    if (envDays) {
+      const parsed = parseInt(envDays, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+
+    return 14;
+  }
 
   async create(dto: CreateReportingPeriodDto, actorUserId: string): Promise<ReportingPeriod> {
     if (dto.startDate >= dto.endDate) {
@@ -91,7 +113,8 @@ export class ReportingPeriodsService {
 
       const today = new Date();
       const startDate = this.formatDate(today);
-      const endDate = this.formatDate(this.addDays(today, 14));
+      const periodDays = await this.getReportingPeriodDays(entityId);
+      const endDate = this.formatDate(this.addDays(today, periodDays));
 
       const period = this.repo.create({
         entityId,
@@ -126,7 +149,8 @@ export class ReportingPeriodsService {
     }
 
     const startDate = this.formatDate(this.addDays(new Date(previousPeriod.endDate), 1));
-    const endDate = this.formatDate(this.addDays(new Date(startDate), 14));
+    const periodDays = await this.getReportingPeriodDays(entityId);
+    const endDate = this.formatDate(this.addDays(new Date(startDate), periodDays));
 
     const period = this.repo.create({
       entityId,

--- a/backend/src/reporting-periods/tests/reporting-period-exceptions.spec.ts
+++ b/backend/src/reporting-periods/tests/reporting-period-exceptions.spec.ts
@@ -7,11 +7,13 @@ import { ReportingPeriod } from '../reporting-period.entity';
 import { ReportingPeriodException } from '../reporting-period-exception.entity';
 import { ReportingPeriodStatus } from '../reporting-period-status.enum';
 import { CreateExceptionDto } from '../dto/create-exception.dto';
+import { Entity } from '../../entities/entity.entity';
 
 describe('ReportingPeriodsService - Exceptions', () => {
   let service: ReportingPeriodsService;
   let periodRepo: jest.Mocked<Repository<ReportingPeriod>>;
   let exceptionRepo: jest.Mocked<Repository<ReportingPeriodException>>;
+  let entityRepo: jest.Mocked<Repository<Entity>>;
 
   const mockPeriod: ReportingPeriod = {
     id: 'period-id',
@@ -60,6 +62,10 @@ describe('ReportingPeriodsService - Exceptions', () => {
       remove: jest.fn(),
     };
 
+    const mockEntityRepo = {
+      findOne: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReportingPeriodsService,
@@ -71,12 +77,17 @@ describe('ReportingPeriodsService - Exceptions', () => {
           provide: getRepositoryToken(ReportingPeriodException),
           useValue: mockExceptionRepo,
         },
+        {
+          provide: getRepositoryToken(Entity),
+          useValue: mockEntityRepo,
+        },
       ],
     }).compile();
 
     service = module.get<ReportingPeriodsService>(ReportingPeriodsService);
     periodRepo = module.get(getRepositoryToken(ReportingPeriod));
     exceptionRepo = module.get(getRepositoryToken(ReportingPeriodException));
+    entityRepo = module.get(getRepositoryToken(Entity));
   });
 
   describe('createOrUpdateException', () => {

--- a/backend/src/reporting-periods/tests/reporting-periods-lifecycle.spec.ts
+++ b/backend/src/reporting-periods/tests/reporting-periods-lifecycle.spec.ts
@@ -6,6 +6,7 @@ import { ReportingPeriod } from '../reporting-period.entity';
 import { ReportingPeriodException } from '../reporting-period-exception.entity';
 import { ReportingPeriodStatus } from '../reporting-period-status.enum';
 import { ConflictException } from '@nestjs/common';
+import { Entity } from '../../entities/entity.entity';
 
 describe('ReportingPeriodsService - Lifecycle Management', () => {
   let service: ReportingPeriodsService;
@@ -25,6 +26,10 @@ describe('ReportingPeriodsService - Lifecycle Management', () => {
     find: jest.fn(),
     findOne: jest.fn(),
     remove: jest.fn(),
+  };
+
+  const mockEntityRepository = {
+    findOne: jest.fn(),
   };
 
   const mockQueryBuilder = {
@@ -52,6 +57,10 @@ describe('ReportingPeriodsService - Lifecycle Management', () => {
         {
           provide: getRepositoryToken(ReportingPeriodException),
           useValue: mockExceptionsRepository,
+        },
+        {
+          provide: getRepositoryToken(Entity),
+          useValue: mockEntityRepository,
         },
       ],
     }).compile();

--- a/backend/src/reporting-periods/tests/reporting-periods.service.spec.ts
+++ b/backend/src/reporting-periods/tests/reporting-periods.service.spec.ts
@@ -8,11 +8,13 @@ import { ReportingPeriodException } from '../reporting-period-exception.entity';
 import { ReportingPeriodStatus } from '../reporting-period-status.enum';
 import { CreateReportingPeriodDto } from '../dto/create-reporting-period.dto';
 import { UpdateReportingPeriodDto } from '../dto/update-reporting-period.dto';
+import { Entity } from '../../entities/entity.entity';
 
 describe('ReportingPeriodsService', () => {
   let service: ReportingPeriodsService;
   let repo: jest.Mocked<Repository<ReportingPeriod>>;
   let exceptionsRepo: jest.Mocked<Repository<ReportingPeriodException>>;
+  let entityRepo: jest.Mocked<Repository<Entity>>;
 
   const mockReportingPeriod: ReportingPeriod = {
     id: 'period-id',
@@ -51,6 +53,10 @@ describe('ReportingPeriodsService', () => {
       remove: jest.fn(),
     };
 
+    const mockEntityRepo = {
+      findOne: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReportingPeriodsService,
@@ -62,12 +68,17 @@ describe('ReportingPeriodsService', () => {
           provide: getRepositoryToken(ReportingPeriodException),
           useValue: mockExceptionsRepo,
         },
+        {
+          provide: getRepositoryToken(Entity),
+          useValue: mockEntityRepo,
+        },
       ],
     }).compile();
 
     service = module.get<ReportingPeriodsService>(ReportingPeriodsService);
     repo = module.get(getRepositoryToken(ReportingPeriod));
     exceptionsRepo = module.get(getRepositoryToken(ReportingPeriodException));
+    entityRepo = module.get(getRepositoryToken(Entity));
   });
 
   describe('create', () => {


### PR DESCRIPTION
## Summary
Replaces hardcoded 14-day reporting period duration with a flexible configuration system that supports entity-level customization, environment variable defaults, and backward compatibility.

## Changes
- Added `reporting_period_days` column to `entities` table (nullable integer)
- Updated `Entity` model with new `reporting_period_days` field
- Implemented 3-tier configuration lookup in `ReportingPeriodsService`:
  1. Entity-specific setting (`entities.reporting_period_days`)
  2. Environment variable (`REPORTING_PERIOD_DAYS`)
  3. Default value (14 days)
- Removed hardcoded 14-day periods from `createFirstPeriodForEntity()` and `createNextPeriod()` methods
- Fixed migration class name for `EnableTrigramSearchActivities` to include timestamp

## Configuration Options

### Per-Entity Configuration (Highest Priority)
```sql
UPDATE entities SET reporting_period_days = 7 WHERE id = 'entity-id';