### PR TITLE
feat: Prevent future dates in activity creation and updates

### DIFF
--- a/backend/src/activity/dto/activity-date.validation.spec.ts
+++ b/backend/src/activity/dto/activity-date.validation.spec.ts
@@ -1,0 +1,86 @@
+import { validate } from 'class-validator';
+import { CreateActivityDto } from './create-activity.dto';
+import { UpdateActivityDto } from './update-activity.dto';
+
+describe('Activity date validation', () => {
+  const fixedNow = new Date('2026-02-18T12:00:00.000Z');
+  const validActivityTypeId = '123e4567-e89b-12d3-a456-426614174000';
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(fixedNow);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const createDtoWithDate = (activityDate: string): CreateActivityDto =>
+    Object.assign(new CreateActivityDto(), {
+      activityTypeId: validActivityTypeId,
+      activityDate,
+      hasExpense: false,
+    });
+
+  const updateDtoWithDate = (activityDate: string): UpdateActivityDto =>
+    Object.assign(new UpdateActivityDto(), {
+      activityDate,
+    });
+
+  const dtoCases = [
+    {
+      name: 'CreateActivityDto',
+      build: createDtoWithDate,
+    },
+    {
+      name: 'UpdateActivityDto',
+      build: updateDtoWithDate,
+    },
+  ] as const;
+
+  it.each(dtoCases)('$name rejects future dates', async ({ build }) => {
+    const dto = build('2026-02-19');
+    const errors = await validate(dto);
+    const activityDateError = errors.find((error) => error.property === 'activityDate');
+
+    expect(activityDateError).toBeDefined();
+    expect(activityDateError?.constraints).toHaveProperty(
+      'isNotFutureActivityDate',
+      'Activity date cannot be in the future',
+    );
+  });
+
+  it.each(dtoCases)('$name accepts today', async ({ build }) => {
+    const dto = build('2026-02-18');
+    const errors = await validate(dto);
+
+    expect(errors.find((error) => error.property === 'activityDate')).toBeUndefined();
+  });
+
+  it.each(dtoCases)('$name accepts past dates', async ({ build }) => {
+    const dto = build('2026-02-17');
+    const errors = await validate(dto);
+
+    expect(errors.find((error) => error.property === 'activityDate')).toBeUndefined();
+  });
+
+  it.each(dtoCases)(
+    '$name rejects dates that become previous UTC date because local date is tomorrow',
+    async ({ build }) => {
+      const dto = build('2026-02-19T00:30:00+14:00');
+      const errors = await validate(dto);
+
+      expect(errors.find((error) => error.property === 'activityDate')).toBeDefined();
+    },
+  );
+
+  it.each(dtoCases)(
+    '$name accepts dates that become next UTC date because local date is still today',
+    async ({ build }) => {
+      const dto = build('2026-02-18T23:30:00-12:00');
+      const errors = await validate(dto);
+
+      expect(errors.find((error) => error.property === 'activityDate')).toBeUndefined();
+    },
+  );
+});

--- a/backend/src/activity/dto/create-activity.dto.ts
+++ b/backend/src/activity/dto/create-activity.dto.ts
@@ -12,6 +12,7 @@ import {
 } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotFutureActivityDate } from '../validators/is-not-future-activity-date.decorator';
 
 export class CreateActivityDto {
   @ApiProperty({
@@ -29,6 +30,9 @@ export class CreateActivityDto {
   })
   @Transform(({ obj }) => obj.activityDate ?? obj.activity_date)
   @IsDateString()
+  @IsNotFutureActivityDate({
+    message: 'Activity date cannot be in the future',
+  })
   @IsDefined()
   activityDate!: string;
 

--- a/backend/src/activity/dto/update-activity.dto.ts
+++ b/backend/src/activity/dto/update-activity.dto.ts
@@ -1,8 +1,9 @@
 import { PartialType } from '@nestjs/swagger';
 import { CreateActivityDto } from './create-activity.dto';
-import { IsOptional, IsUUID } from 'class-validator';
+import { IsDateString, IsOptional, IsUUID } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotFutureActivityDate } from '../validators/is-not-future-activity-date.decorator';
 
 export class UpdateActivityDto extends PartialType(CreateActivityDto) {
   @ApiPropertyOptional({ description: 'UUID of the activity type' })
@@ -14,6 +15,10 @@ export class UpdateActivityDto extends PartialType(CreateActivityDto) {
   @ApiPropertyOptional({ description: 'Date of the activity in ISO 8601 format' })
   @Transform(({ obj }) => obj.activityDate ?? obj.activity_date)
   @IsOptional()
+  @IsDateString()
+  @IsNotFutureActivityDate({
+    message: 'Activity date cannot be in the future',
+  })
   activityDate?: string;
 
   @ApiPropertyOptional({ description: 'Optional description of the activity' })

--- a/backend/src/activity/validators/is-not-future-activity-date.decorator.ts
+++ b/backend/src/activity/validators/is-not-future-activity-date.decorator.ts
@@ -1,0 +1,46 @@
+import { registerDecorator, ValidationArguments, ValidationOptions } from 'class-validator';
+
+const ISO_DATE_PART_REGEX = /^(\d{4}-\d{2}-\d{2})/;
+
+function toLocalIsoDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function extractIsoDatePart(value: string): string | null {
+  const match = ISO_DATE_PART_REGEX.exec(value);
+  return match ? match[1] : null;
+}
+
+export function IsNotFutureActivityDate(validationOptions?: ValidationOptions) {
+  return (object: object, propertyName: string): void => {
+    registerDecorator({
+      name: 'isNotFutureActivityDate',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown): boolean {
+          if (value === null || value === undefined) {
+            return true;
+          }
+          if (typeof value !== 'string') {
+            return false;
+          }
+
+          const datePart = extractIsoDatePart(value);
+          if (!datePart) {
+            return true;
+          }
+
+          return datePart <= toLocalIsoDate(new Date());
+        },
+        defaultMessage(args: ValidationArguments): string {
+          return `${args.property} cannot be in the future`;
+        },
+      },
+    });
+  };
+}


### PR DESCRIPTION
## Summary
Adds validation to prevent users from creating or updating activities with future dates. Activities can only be recorded for today or past dates.

## Changes
- Created custom `IsNotFutureActivityDate` validator decorator
- Applied validator to `CreateActivityDto.activityDate` field
- Applied validator to `UpdateActivityDto.activityDate` field
- Added comprehensive test suite with timezone edge case coverage

## Validation Logic
The validator:
- Extracts the date portion from ISO 8601 date strings (YYYY-MM-DD)
- Compares against today's date in local time
- Allows `null` or `undefined` values (handled by other validators)
- Returns user-friendly error message: "Activity date cannot be in the future"

## Test Coverage
Tests verify:
- Future dates are rejected
- Today's date is accepted
- Past dates are accepted
- Timezone edge cases handled correctly:
  - Dates that become previous UTC date because local date is tomorrow (rejected)
  - Dates that become next UTC date because local date is still today (accepted)