### PR TITLE
refactor: Replace string-based repository access with typed ReportingPeriodException entity

### DIFF
--- a/backend/src/activity/activities.module.ts
+++ b/backend/src/activity/activities.module.ts
@@ -8,6 +8,7 @@ import { IdpIdentity } from '../idp-identities/idp-identity.entity';
 import { User } from '../users/user.entity';
 import { ActivityType } from '../activities-type/activity-type.entity';
 import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
+import { ReportingPeriodException } from '../reporting-periods/reporting-period-exception.entity';
 import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 import { ReportingPeriodsModule } from '../reporting-periods/reporting-periods.module';
 
@@ -19,6 +20,7 @@ import { ReportingPeriodsModule } from '../reporting-periods/reporting-periods.m
       IdpIdentity,
       User,
       ReportingPeriod,
+      ReportingPeriodException,
       UserRoleAssignment,
     ]),
     ReportingPeriodsModule,

--- a/backend/src/activity/activities.service.spec.ts
+++ b/backend/src/activity/activities.service.spec.ts
@@ -8,6 +8,7 @@ import { Activity } from './activity.entity';
 import { ActivityType } from '../activities-type/activity-type.entity';
 import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
+import { ReportingPeriodException } from '../reporting-periods/reporting-period-exception.entity';
 
 import { CreateActivityDto } from './dto/create-activity.dto';
 
@@ -57,6 +58,10 @@ describe('ActivitiesService', () => {
         {
           provide: getRepositoryToken(ReportingPeriod),
           useValue: mockReportingPeriodRepo,
+        },
+        {
+          provide: getRepositoryToken(ReportingPeriodException),
+          useValue: {},
         },
       ],
     }).compile();

--- a/backend/src/activity/activities.service.ts
+++ b/backend/src/activity/activities.service.ts
@@ -15,6 +15,7 @@ import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
 import { ReportingPeriodStatus } from '../reporting-periods/reporting-period-status.enum';
 import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 import { formatDateToString } from '../common/date.utils';
+import { ReportingPeriodException } from '../reporting-periods/reporting-period-exception.entity';
 
 @Injectable()
 export class ActivitiesService {
@@ -23,6 +24,8 @@ export class ActivitiesService {
     @InjectRepository(ActivityType) private readonly typesRepo: Repository<ActivityType>,
     @InjectRepository(ReportingPeriod)
     private readonly reportingPeriodsRepo: Repository<ReportingPeriod>,
+    @InjectRepository(ReportingPeriodException)
+    private readonly exceptionsRepo: Repository<ReportingPeriodException>,
     @InjectRepository(UserRoleAssignment)
     private readonly uraRepo: Repository<UserRoleAssignment>,
   ) {}
@@ -52,18 +55,16 @@ export class ActivitiesService {
         where: { id: activity.reportingPeriodId },
       });
       if (reportingPeriod && reportingPeriod.status === ReportingPeriodStatus.LOCKED) {
-        const hasException = await this.reportingPeriodsRepo.manager
-          .getRepository('reporting_period_exception')
-          .findOne({
-            where: {
-              userId,
-              reportingPeriodId: activity.reportingPeriodId,
-            },
-          });
+        const hasException = await this.exceptionsRepo.findOne({
+          where: {
+            userId,
+            reportingPeriodId: activity.reportingPeriodId,
+          },
+        });
 
         if (hasException) {
           const activityDate = activity.activityDate;
-          const { startDate, endDate } = hasException as any;
+          const { startDate, endDate } = hasException;
           if (activityDate >= startDate && activityDate <= endDate) {
             return;
           }
@@ -116,18 +117,16 @@ export class ActivitiesService {
 
     const reportingPeriod = await this.findReportingPeriodForDate(dto.activityDate);
     if (reportingPeriod && reportingPeriod.status === ReportingPeriodStatus.LOCKED) {
-      const hasException = await this.reportingPeriodsRepo.manager
-        .getRepository('reporting_period_exception')
-        .findOne({
-          where: {
-            userId: actorUserId,
-            reportingPeriodId: reportingPeriod.id,
-          },
-        });
+      const hasException = await this.exceptionsRepo.findOne({
+        where: {
+          userId: actorUserId,
+          reportingPeriodId: reportingPeriod.id,
+        },
+      });
 
       if (hasException) {
         const activityDate = dto.activityDate;
-        const { startDate, endDate } = hasException as any;
+        const { startDate, endDate } = hasException;
         if (!(activityDate >= startDate && activityDate <= endDate)) {
           throw new ForbiddenException('Cannot create activity in a locked reporting period');
         }
@@ -245,18 +244,16 @@ export class ActivitiesService {
     if (dto.activityDate && dto.activityDate !== a.activityDate) {
       const newReportingPeriod = await this.findReportingPeriodForDate(dto.activityDate);
       if (newReportingPeriod && newReportingPeriod.status === ReportingPeriodStatus.LOCKED) {
-        const hasException = await this.reportingPeriodsRepo.manager
-          .getRepository('reporting_period_exception')
-          .findOne({
-            where: {
-              userId,
-              reportingPeriodId: newReportingPeriod.id,
-            },
-          });
+        const hasException = await this.exceptionsRepo.findOne({
+          where: {
+            userId,
+            reportingPeriodId: newReportingPeriod.id,
+          },
+        });
 
         if (hasException) {
           const activityDate = dto.activityDate;
-          const { startDate, endDate } = hasException as any;
+          const { startDate, endDate } = hasException;
           if (!(activityDate >= startDate && activityDate <= endDate)) {
             throw new ForbiddenException('Cannot move activity to a locked reporting period');
           }

--- a/backend/src/activity/tests/activities.service.exceptions.spec.ts
+++ b/backend/src/activity/tests/activities.service.exceptions.spec.ts
@@ -11,6 +11,7 @@ import { ActivityStatus } from '../activity-status.enum';
 import { ReportingPeriodStatus } from '../../reporting-periods/reporting-period-status.enum';
 import { CreateActivityDto } from '../dto/create-activity.dto';
 import { UpdateActivityDto } from '../dto/update-activity.dto';
+import { ReportingPeriodException } from '../../reporting-periods/reporting-period-exception.entity';
 
 describe('ActivitiesService - Exception Handling', () => {
   let service: ActivitiesService;
@@ -18,7 +19,7 @@ describe('ActivitiesService - Exception Handling', () => {
   let activityTypeRepo: jest.Mocked<Repository<ActivityType>>;
   let reportingPeriodRepo: jest.Mocked<Repository<ReportingPeriod>>;
   let userRoleAssignmentRepo: jest.Mocked<Repository<UserRoleAssignment>>;
-  let mockExceptionRepo: any;
+  let exceptionRepo: jest.Mocked<Repository<ReportingPeriodException>>;
 
   const mockActivity: Activity = {
     id: 'activity-id',
@@ -74,10 +75,6 @@ describe('ActivitiesService - Exception Handling', () => {
   };
 
   beforeEach(async () => {
-    mockExceptionRepo = {
-      findOne: jest.fn(),
-    };
-
     const mockActivityRepo = {
       create: jest.fn(),
       save: jest.fn(),
@@ -93,14 +90,15 @@ describe('ActivitiesService - Exception Handling', () => {
     const mockReportingPeriodRepo = {
       findOne: jest.fn(),
       createQueryBuilder: jest.fn(),
-      manager: {
-        getRepository: jest.fn().mockReturnValue(mockExceptionRepo),
-      },
     };
 
     const mockUserRoleAssignmentRepo = {
       findOne: jest.fn(),
       find: jest.fn(),
+    };
+
+    const mockExceptionRepo = {
+      findOne: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -122,6 +120,10 @@ describe('ActivitiesService - Exception Handling', () => {
           provide: getRepositoryToken(UserRoleAssignment),
           useValue: mockUserRoleAssignmentRepo,
         },
+        {
+          provide: getRepositoryToken(ReportingPeriodException),
+          useValue: mockExceptionRepo,
+        },
       ],
     }).compile();
 
@@ -130,6 +132,7 @@ describe('ActivitiesService - Exception Handling', () => {
     activityTypeRepo = module.get(getRepositoryToken(ActivityType));
     reportingPeriodRepo = module.get(getRepositoryToken(ReportingPeriod));
     userRoleAssignmentRepo = module.get(getRepositoryToken(UserRoleAssignment));
+    exceptionRepo = module.get(getRepositoryToken(ReportingPeriodException));
   });
 
   describe('create with exception', () => {
@@ -149,7 +152,7 @@ describe('ActivitiesService - Exception Handling', () => {
         getOne: jest.fn().mockResolvedValue(mockLockedPeriod),
       } as any);
 
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
 
       activityRepo.create.mockReturnValue(mockActivity);
       activityRepo.save.mockResolvedValue(mockActivity);
@@ -158,7 +161,7 @@ describe('ActivitiesService - Exception Handling', () => {
 
       expect(result).toEqual(mockActivity);
       expect(activityRepo.save).toHaveBeenCalled();
-      expect(mockExceptionRepo.findOne).toHaveBeenCalledWith({
+      expect(exceptionRepo.findOne).toHaveBeenCalledWith({
         where: {
           userId: 'user-id',
           reportingPeriodId: 'locked-period-id',
@@ -182,7 +185,7 @@ describe('ActivitiesService - Exception Handling', () => {
         getOne: jest.fn().mockResolvedValue(mockLockedPeriod),
       } as any);
 
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
 
       await expect(service.create(createDto, 'user-id')).rejects.toThrow(
         new ForbiddenException('Cannot create activity in a locked reporting period'),
@@ -207,7 +210,7 @@ describe('ActivitiesService - Exception Handling', () => {
         getOne: jest.fn().mockResolvedValue(mockLockedPeriod),
       } as any);
 
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
       activityRepo.create.mockReturnValue(mockActivity);
       activityRepo.save.mockResolvedValue(mockActivity);
 
@@ -230,7 +233,7 @@ describe('ActivitiesService - Exception Handling', () => {
         getOne: jest.fn().mockResolvedValue(mockLockedPeriod),
       } as any);
 
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
       activityRepo.create.mockReturnValue(mockActivity);
       activityRepo.save.mockResolvedValue(mockActivity);
 
@@ -247,7 +250,7 @@ describe('ActivitiesService - Exception Handling', () => {
       const activityInRange = { ...mockActivity, activityDate: '2024-01-03' };
       activityRepo.findOne.mockResolvedValue(activityInRange);
       reportingPeriodRepo.findOne.mockResolvedValue(mockLockedPeriod);
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
       activityRepo.save.mockResolvedValue({ ...activityInRange, description: 'Updated' });
 
       const result = await service.updateMine('activity-id', updateDto, 'user-id');
@@ -264,7 +267,7 @@ describe('ActivitiesService - Exception Handling', () => {
       const activityOutsideRange = { ...mockActivity, activityDate: '2024-01-10' };
       activityRepo.findOne.mockResolvedValue(activityOutsideRange);
       reportingPeriodRepo.findOne.mockResolvedValue(mockLockedPeriod);
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
 
       await expect(service.updateMine('activity-id', updateDto, 'user-id')).rejects.toThrow(
         new ForbiddenException('This activity is locked because its reporting period has ended'),
@@ -283,7 +286,7 @@ describe('ActivitiesService - Exception Handling', () => {
         getOne: jest.fn().mockResolvedValue(mockLockedPeriod),
       } as any);
 
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
       activityRepo.save.mockResolvedValue({ ...mockActivity, activityDate: '2024-01-04' });
 
       const result = await service.updateMine('activity-id', updateDto, 'user-id');
@@ -304,7 +307,7 @@ describe('ActivitiesService - Exception Handling', () => {
         getOne: jest.fn().mockResolvedValue(mockLockedPeriod),
       } as any);
 
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
 
       await expect(service.updateMine('activity-id', updateDto, 'user-id')).rejects.toThrow(
         new ForbiddenException('Cannot move activity to a locked reporting period'),
@@ -317,7 +320,7 @@ describe('ActivitiesService - Exception Handling', () => {
       const activityInRange = { ...mockActivity, activityDate: '2024-01-03' };
       activityRepo.findOne.mockResolvedValue(activityInRange);
       reportingPeriodRepo.findOne.mockResolvedValue(mockLockedPeriod);
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
       activityRepo.save.mockResolvedValue({ ...activityInRange, status: ActivityStatus.ARCHIVED });
 
       await service.archiveMine('activity-id', 'user-id');
@@ -329,7 +332,7 @@ describe('ActivitiesService - Exception Handling', () => {
       const activityOutsideRange = { ...mockActivity, activityDate: '2024-01-10' };
       activityRepo.findOne.mockResolvedValue(activityOutsideRange);
       reportingPeriodRepo.findOne.mockResolvedValue(mockLockedPeriod);
-      mockExceptionRepo.findOne.mockResolvedValue(mockException);
+      exceptionRepo.findOne.mockResolvedValue(mockException);
 
       await expect(service.archiveMine('activity-id', 'user-id')).rejects.toThrow(
         new ForbiddenException('This activity is locked because its reporting period has ended'),

--- a/backend/src/activity/tests/activities.service.exceptions.spec.ts
+++ b/backend/src/activity/tests/activities.service.exceptions.spec.ts
@@ -63,16 +63,19 @@ describe('ActivitiesService - Exception Handling', () => {
     updatedBy: 'admin-id',
   } as ReportingPeriod;
 
-  const mockException = {
+  const mockException: ReportingPeriodException = {
     id: 'exception-id',
     userId: 'user-id',
+    user: {} as any,
     reportingPeriodId: 'locked-period-id',
+    reportingPeriod: {} as any,
     startDate: '2024-01-01',
     endDate: '2024-01-05',
     reason: 'Late submission approved',
     grantedBy: 'admin-id',
+    grantedByUser: {} as any,
     grantedAt: new Date(),
-  };
+  } as ReportingPeriodException;
 
   beforeEach(async () => {
     const mockActivityRepo = {

--- a/backend/src/activity/tests/activities.service.filters.spec.ts
+++ b/backend/src/activity/tests/activities.service.filters.spec.ts
@@ -7,6 +7,7 @@ import { ActivityType } from '../../activities-type/activity-type.entity';
 import { ReportingPeriod } from '../../reporting-periods/reporting-period.entity';
 import { UserRoleAssignment } from '../../roles/user-role-assignment.entity';
 import { ActivityStatus } from '../activity-status.enum';
+import { ReportingPeriodException } from '../../reporting-periods/reporting-period-exception.entity';
 
 describe('ActivitiesService - Filters', () => {
   let service: ActivitiesService;
@@ -45,6 +46,10 @@ describe('ActivitiesService - Filters', () => {
         },
         {
           provide: getRepositoryToken(UserRoleAssignment),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(ReportingPeriodException),
           useValue: {},
         },
       ],

--- a/backend/src/activity/tests/activities.service.lifecycle-locking.spec.ts
+++ b/backend/src/activity/tests/activities.service.lifecycle-locking.spec.ts
@@ -11,6 +11,7 @@ import { ActivityStatus } from '../activity-status.enum';
 import { ReportingPeriodStatus } from '../../reporting-periods/reporting-period-status.enum';
 import { CreateActivityDto } from '../dto/create-activity.dto';
 import { UpdateActivityDto } from '../dto/update-activity.dto';
+import { ReportingPeriodException } from '../../reporting-periods/reporting-period-exception.entity';
 
 describe('ActivitiesService - Lifecycle Locking', () => {
   let service: ActivitiesService;
@@ -18,6 +19,7 @@ describe('ActivitiesService - Lifecycle Locking', () => {
   let activityTypeRepo: jest.Mocked<Repository<ActivityType>>;
   let reportingPeriodRepo: jest.Mocked<Repository<ReportingPeriod>>;
   let userRoleAssignmentRepo: jest.Mocked<Repository<UserRoleAssignment>>;
+  let exceptionRepo: jest.Mocked<Repository<ReportingPeriodException>>;
 
   const mockActivity: Activity = {
     id: 'activity-id',
@@ -81,21 +83,18 @@ describe('ActivitiesService - Lifecycle Locking', () => {
       findOne: jest.fn(),
     };
 
-    const mockExceptionRepo = {
-      findOne: jest.fn(),
-    };
-
     const mockReportingPeriodRepo = {
       findOne: jest.fn(),
       createQueryBuilder: jest.fn(),
-      manager: {
-        getRepository: jest.fn().mockReturnValue(mockExceptionRepo),
-      },
     };
 
     const mockUserRoleAssignmentRepo = {
       findOne: jest.fn(),
       find: jest.fn(),
+    };
+
+    const mockExceptionRepo = {
+      findOne: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -117,6 +116,10 @@ describe('ActivitiesService - Lifecycle Locking', () => {
           provide: getRepositoryToken(UserRoleAssignment),
           useValue: mockUserRoleAssignmentRepo,
         },
+        {
+          provide: getRepositoryToken(ReportingPeriodException),
+          useValue: mockExceptionRepo,
+        },
       ],
     }).compile();
 
@@ -125,6 +128,7 @@ describe('ActivitiesService - Lifecycle Locking', () => {
     activityTypeRepo = module.get(getRepositoryToken(ActivityType));
     reportingPeriodRepo = module.get(getRepositoryToken(ReportingPeriod));
     userRoleAssignmentRepo = module.get(getRepositoryToken(UserRoleAssignment));
+    exceptionRepo = module.get(getRepositoryToken(ReportingPeriodException));
   });
 
   describe('create', () => {
@@ -177,8 +181,7 @@ describe('ActivitiesService - Lifecycle Locking', () => {
         getOne: jest.fn().mockResolvedValue(mockLockedPeriod),
       } as any);
 
-      const mockExceptionRepo = (reportingPeriodRepo.manager as any).getRepository();
-      mockExceptionRepo.findOne.mockResolvedValue(null);
+      exceptionRepo.findOne.mockResolvedValue(null);
 
       await expect(service.create(createDto, 'user-id')).rejects.toThrow(
         new ForbiddenException('Cannot create activity in a locked reporting period'),
@@ -232,8 +235,7 @@ describe('ActivitiesService - Lifecycle Locking', () => {
       activityRepo.findOne.mockResolvedValue(activityInLockedPeriod);
       reportingPeriodRepo.findOne.mockResolvedValue(mockLockedPeriod);
 
-      const mockExceptionRepo = (reportingPeriodRepo.manager as any).getRepository();
-      mockExceptionRepo.findOne.mockResolvedValue(null);
+      exceptionRepo.findOne.mockResolvedValue(null);
 
       await expect(service.updateMine('activity-id', updateDto, 'user-id')).rejects.toThrow(
         new ForbiddenException('This activity is locked because its reporting period has ended'),
@@ -252,8 +254,7 @@ describe('ActivitiesService - Lifecycle Locking', () => {
         getOne: jest.fn().mockResolvedValue(mockLockedPeriod), // New period is locked
       } as any);
 
-      const mockExceptionRepo = (reportingPeriodRepo.manager as any).getRepository();
-      mockExceptionRepo.findOne.mockResolvedValue(null);
+      exceptionRepo.findOne.mockResolvedValue(null);
 
       await expect(service.updateMine('activity-id', updateDto, 'user-id')).rejects.toThrow(
         new ForbiddenException('Cannot move activity to a locked reporting period'),
@@ -312,8 +313,7 @@ describe('ActivitiesService - Lifecycle Locking', () => {
       activityRepo.findOne.mockResolvedValue(activityInLockedPeriod);
       reportingPeriodRepo.findOne.mockResolvedValue(mockLockedPeriod);
 
-      const mockExceptionRepo = (reportingPeriodRepo.manager as any).getRepository();
-      mockExceptionRepo.findOne.mockResolvedValue(null);
+      exceptionRepo.findOne.mockResolvedValue(null);
 
       await expect(service.archiveMine('activity-id', 'user-id')).rejects.toThrow(
         new ForbiddenException('This activity is locked because its reporting period has ended'),


### PR DESCRIPTION
## Overview
Refactors exception handling in `ActivitiesService` to use proper dependency injection of the `ReportingPeriodException` repository instead of string-based repository access via the entity manager.

## Problem
Previously, the service accessed the reporting period exceptions using:
```typescript
this.reportingPeriodsRepo.manager.getRepository('reporting_period_exception')