### PR TITLE
feat: Add pagination support to list endpoints across all modules

### DIFF
--- a/backend/scripts/honduras-structure.seed.ts
+++ b/backend/scripts/honduras-structure.seed.ts
@@ -31,9 +31,9 @@ async function run() {
     } catch (e: any) {
       const msg = String(e?.message ?? '');
       if (msg.toLowerCase().includes('already exists') || e?.status === 409) {
-        const { data } = await entitiesService.findAll();
-        const found = data.find(
-          (x) => x.type === params.type && x.name.toLowerCase() === params.name.toLowerCase(),
+        const existing = await entitiesService.findAllByType(params.type);
+        const found = existing.find(
+          (x) => x.name.toLowerCase() === params.name.toLowerCase(),
         );
         if (found) return found;
       }

--- a/backend/scripts/honduras-structure.seed.ts
+++ b/backend/scripts/honduras-structure.seed.ts
@@ -31,8 +31,8 @@ async function run() {
     } catch (e: any) {
       const msg = String(e?.message ?? '');
       if (msg.toLowerCase().includes('already exists') || e?.status === 409) {
-        const all = await entitiesService.findAll();
-        const found = all.find(
+        const { data } = await entitiesService.findAll();
+        const found = data.find(
           (x) => x.type === params.type && x.name.toLowerCase() === params.name.toLowerCase(),
         );
         if (found) return found;

--- a/backend/src/activities-type/activity-types.controller.spec.ts
+++ b/backend/src/activities-type/activity-types.controller.spec.ts
@@ -110,13 +110,17 @@ describe('ActivityTypesController', () => {
 
   describe('list', () => {
     it('should return all activity types', async () => {
-      service.findAll.mockResolvedValue(mockActivityTypes as ActivityType[]);
+      const payload = {
+        data: mockActivityTypes,
+        pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+      };
+      service.findAll.mockResolvedValue(payload as any);
 
       const result = await controller.list();
 
       expect(service.findAll).toHaveBeenCalled();
       expect(service.findAllByUserRole).not.toHaveBeenCalled();
-      expect(result).toEqual(mockActivityTypes);
+      expect(result).toEqual(payload);
     });
   });
 

--- a/backend/src/activities-type/activity-types.controller.spec.ts
+++ b/backend/src/activities-type/activity-types.controller.spec.ts
@@ -116,7 +116,7 @@ describe('ActivityTypesController', () => {
       };
       service.findAll.mockResolvedValue(payload as any);
 
-      const result = await controller.list();
+      const result = await controller.list({} as any);
 
       expect(service.findAll).toHaveBeenCalled();
       expect(service.findAllByUserRole).not.toHaveBeenCalled();

--- a/backend/src/activities-type/activity-types.controller.ts
+++ b/backend/src/activities-type/activity-types.controller.ts
@@ -34,7 +34,7 @@ export class ActivityTypesController {
   @Get()
   @ApiOperation({ summary: 'List all activity types' })
   @ApiResponse({ status: 200, description: 'List of all activity types' })
-  async list(@Query() query: PaginationQueryDto = new PaginationQueryDto()) {
+  async list(@Query() query: PaginationQueryDto) {
     return this.service.findAll(query);
   }
 

--- a/backend/src/activities-type/activity-types.controller.ts
+++ b/backend/src/activities-type/activity-types.controller.ts
@@ -9,6 +9,7 @@ import {
   Put,
   UseGuards,
   Req,
+  Query,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { ActivityTypesService } from './activity-types.service';
@@ -20,6 +21,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { IdentityResolutionService } from '../auth/identity-resolution.service';
 import { Request } from 'express';
 import { JwtValidatedUser } from '../auth/jwt.strategy';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 @ApiTags('Activity Types')
 @Controller('activity-types')
@@ -32,8 +34,8 @@ export class ActivityTypesController {
   @Get()
   @ApiOperation({ summary: 'List all activity types' })
   @ApiResponse({ status: 200, description: 'List of all activity types' })
-  async list() {
-    return this.service.findAll();
+  async list(@Query() query: PaginationQueryDto = new PaginationQueryDto()) {
+    return this.service.findAll(query);
   }
 
   @Get('authorized')

--- a/backend/src/activities-type/activity-types.service.ts
+++ b/backend/src/activities-type/activity-types.service.ts
@@ -10,6 +10,8 @@ import {
   ACTIVITY_TYPE_USAGE_POLICY,
   ActivityTypeUsagePolicy,
 } from './usage/activity-type-usage.policy';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class ActivityTypesService {
@@ -52,8 +54,19 @@ export class ActivityTypesService {
     return this.repo.save(entity);
   }
 
-  async findAll(): Promise<ActivityType[]> {
-    return this.repo.find();
+  async findAll(
+    query?: PaginationQueryDto,
+  ): Promise<{
+    data: ActivityType[];
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }> {
+    const { page, limit, skip, take } = normalizePagination(query);
+    const [data, total] = await this.repo.findAndCount({
+      order: { name: 'ASC' },
+      skip,
+      take,
+    });
+    return { data, pagination: buildPagination(page, limit, total) };
   }
 
   async findAllByUserRole(userRoleId: string): Promise<ActivityType[]> {

--- a/backend/src/activities-type/activity-types.service.ts
+++ b/backend/src/activities-type/activity-types.service.ts
@@ -11,7 +11,7 @@ import {
   ActivityTypeUsagePolicy,
 } from './usage/activity-type-usage.policy';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
-import { buildPagination, normalizePagination } from '../common/pagination';
+import { PaginatedResult, buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class ActivityTypesService {
@@ -54,17 +54,12 @@ export class ActivityTypesService {
     return this.repo.save(entity);
   }
 
-  async findAll(
-    query?: PaginationQueryDto,
-  ): Promise<{
-    data: ActivityType[];
-    pagination: { page: number; limit: number; total: number; totalPages: number };
-  }> {
-    const { page, limit, skip, take } = normalizePagination(query);
+  async findAll(query?: PaginationQueryDto): Promise<PaginatedResult<ActivityType>> {
+    const { page, limit, skip } = normalizePagination(query);
     const [data, total] = await this.repo.findAndCount({
       order: { name: 'ASC' },
       skip,
-      take,
+      take: limit,
     });
     return { data, pagination: buildPagination(page, limit, total) };
   }

--- a/backend/src/activity/activities.controller.ts
+++ b/backend/src/activity/activities.controller.ts
@@ -22,6 +22,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { IdentityResolutionService } from '../auth/identity-resolution.service';
 import { ActivityResponseDto } from './dto/activity-response.dto';
 import { ReportingPeriodsService } from '../reporting-periods/reporting-periods.service';
+import { buildPagination } from '../common/pagination';
 import { Request } from 'express';
 import { Repository, In } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -191,10 +192,8 @@ export class ActivitiesController {
     );
 
     return {
-      page,
-      limit,
-      total,
-      items: itemsWithLocked,
+      data: itemsWithLocked,
+      pagination: buildPagination(page, limit, total),
     };
   }
 

--- a/backend/src/activity/activities.service.ts
+++ b/backend/src/activity/activities.service.ts
@@ -15,6 +15,7 @@ import { ReportingPeriod } from '../reporting-periods/reporting-period.entity';
 import { ReportingPeriodStatus } from '../reporting-periods/reporting-period-status.enum';
 import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 import { formatDateToString } from '../common/date.utils';
+import { normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class ActivitiesService {
@@ -164,8 +165,7 @@ export class ActivitiesService {
       search?: string;
     },
   ): Promise<[Activity[], number]> {
-    const take = Math.min(Math.max(limit, 1), 100);
-    const skip = Math.max(page - 1, 0) * take;
+    const { skip, limit: take } = normalizePagination({ page, limit });
 
     const qb = this.repo
       .createQueryBuilder('activity')

--- a/backend/src/activity/tests/activity-locked-indicator.spec.ts
+++ b/backend/src/activity/tests/activity-locked-indicator.spec.ts
@@ -329,10 +329,10 @@ describe('ActivitiesController - Locked Indicator', () => {
 
       const result = await controller.findMine(mockRequest, 1, 20);
 
-      expect(result.items).toHaveLength(3);
-      expect(result.items[0].locked).toBe(false); // Jan 5 - has exception
-      expect(result.items[1].locked).toBe(false); // Jan 10 - has exception
-      expect(result.items[2].locked).toBe(true); // Jan 15 - no exception
+      expect(result.data).toHaveLength(3);
+      expect(result.data[0].locked).toBe(false); // Jan 5 - has exception
+      expect(result.data[1].locked).toBe(false); // Jan 10 - has exception
+      expect(result.data[2].locked).toBe(true); // Jan 15 - no exception
       expect(reportingPeriodsService.hasUserExceptionForDate).toHaveBeenCalledTimes(3);
     });
 
@@ -352,9 +352,9 @@ describe('ActivitiesController - Locked Indicator', () => {
 
       const result = await controller.findMine(mockRequest, 1, 20);
 
-      expect(result.items).toHaveLength(2);
-      expect(result.items[0].locked).toBe(false);
-      expect(result.items[1].locked).toBe(false);
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].locked).toBe(false);
+      expect(result.data[1].locked).toBe(false);
       expect(reportingPeriodsService.hasUserExceptionForDate).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/common/dto/pagination-query.dto.ts
+++ b/backend/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,20 @@
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class PaginationQueryDto {
+  @ApiPropertyOptional({ description: 'Page number', default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/backend/src/common/pagination.spec.ts
+++ b/backend/src/common/pagination.spec.ts
@@ -1,0 +1,60 @@
+import { normalizePagination, buildPagination, DEFAULT_PAGE, DEFAULT_LIMIT, MAX_LIMIT } from './pagination';
+
+describe('normalizePagination', () => {
+  it('returns defaults when called with no arguments', () => {
+    expect(normalizePagination()).toEqual({ page: 1, limit: 20, skip: 0 });
+  });
+
+  it('returns defaults when called with empty object', () => {
+    expect(normalizePagination({})).toEqual({ page: 1, limit: 20, skip: 0 });
+  });
+
+  it('calculates skip from page and limit', () => {
+    expect(normalizePagination({ page: 3, limit: 10 })).toEqual({ page: 3, limit: 10, skip: 20 });
+  });
+
+  it('clamps page to minimum of 1', () => {
+    const result = normalizePagination({ page: 0 });
+    expect(result.page).toBe(DEFAULT_PAGE);
+    expect(result.skip).toBe(0);
+  });
+
+  it('clamps negative page to 1', () => {
+    expect(normalizePagination({ page: -5 }).page).toBe(1);
+  });
+
+  it('clamps limit to minimum of 1', () => {
+    expect(normalizePagination({ limit: 0 }).limit).toBe(1);
+  });
+
+  it('clamps limit to MAX_LIMIT', () => {
+    expect(normalizePagination({ limit: 200 }).limit).toBe(MAX_LIMIT);
+  });
+
+  it('allows limit at exactly MAX_LIMIT', () => {
+    expect(normalizePagination({ limit: MAX_LIMIT }).limit).toBe(MAX_LIMIT);
+  });
+});
+
+describe('buildPagination', () => {
+  it('calculates totalPages correctly', () => {
+    expect(buildPagination(1, 20, 50)).toEqual({
+      page: 1,
+      limit: 20,
+      total: 50,
+      totalPages: 3,
+    });
+  });
+
+  it('returns totalPages of 0 when total is 0', () => {
+    expect(buildPagination(1, 20, 0).totalPages).toBe(0);
+  });
+
+  it('returns totalPages of 1 when total equals limit', () => {
+    expect(buildPagination(1, 20, 20).totalPages).toBe(1);
+  });
+
+  it('rounds up partial pages', () => {
+    expect(buildPagination(1, 20, 21).totalPages).toBe(2);
+  });
+});

--- a/backend/src/common/pagination.ts
+++ b/backend/src/common/pagination.ts
@@ -2,16 +2,27 @@ export const DEFAULT_PAGE = 1;
 export const DEFAULT_LIMIT = 20;
 export const MAX_LIMIT = 100;
 
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  pagination: PaginationMeta;
+}
+
 export function normalizePagination(query?: { page?: number; limit?: number }) {
   const page = Math.max(DEFAULT_PAGE, query?.page ?? DEFAULT_PAGE);
   const limit = Math.min(Math.max(query?.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
   const skip = (page - 1) * limit;
-  const take = limit;
 
-  return { page, limit, skip, take };
+  return { page, limit, skip };
 }
 
-export function buildPagination(page: number, limit: number, total: number) {
+export function buildPagination(page: number, limit: number, total: number): PaginationMeta {
   return {
     page,
     limit,

--- a/backend/src/common/pagination.ts
+++ b/backend/src/common/pagination.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 100;
+
+export function normalizePagination(query?: { page?: number; limit?: number }) {
+  const page = Math.max(DEFAULT_PAGE, query?.page ?? DEFAULT_PAGE);
+  const limit = Math.min(Math.max(query?.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+  const skip = (page - 1) * limit;
+  const take = limit;
+
+  return { page, limit, skip, take };
+}
+
+export function buildPagination(page: number, limit: number, total: number) {
+  return {
+    page,
+    limit,
+    total,
+    totalPages: Math.ceil(total / limit),
+  };
+}

--- a/backend/src/entities/entities.controller.ts
+++ b/backend/src/entities/entities.controller.ts
@@ -69,7 +69,7 @@ export class EntitiesController {
   @Get()
   @ApiOperation({ summary: 'List all entities' })
   @ApiResponse({ status: 200, description: 'List of all entities' })
-  async findAll(@Query() query: PaginationQueryDto = new PaginationQueryDto()) {
+  async findAll(@Query() query: PaginationQueryDto) {
     return this.entitiesService.findAll(query);
   }
 

--- a/backend/src/entities/entities.controller.ts
+++ b/backend/src/entities/entities.controller.ts
@@ -14,7 +14,14 @@ import {
   UseGuards,
   Query,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery, ApiParam } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+  ApiParam,
+} from '@nestjs/swagger';
 import { Request } from 'express';
 import { AuthGuard } from '@nestjs/passport';
 import { PoliciesGuard } from '../casl/policies.guard';
@@ -24,6 +31,7 @@ import { EntitiesService } from './entities.service';
 import { CreateEntityDto } from './dto/create-entity.dto';
 import { UpdateEntityDto } from './dto/update-entity.dto';
 import { EntityType, Entity } from './entity.entity';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 @ApiTags('Entities')
 @ApiBearerAuth('JWT-auth')
@@ -61,8 +69,8 @@ export class EntitiesController {
   @Get()
   @ApiOperation({ summary: 'List all entities' })
   @ApiResponse({ status: 200, description: 'List of all entities' })
-  async findAll() {
-    return this.entitiesService.findAll();
+  async findAll(@Query() query: PaginationQueryDto = new PaginationQueryDto()) {
+    return this.entitiesService.findAll(query);
   }
 
   @Get(':id')

--- a/backend/src/entities/entities.service.ts
+++ b/backend/src/entities/entities.service.ts
@@ -18,7 +18,7 @@ import { HierarchyValidationService } from './hierarchy-validation.service';
 import { EntityTreeNode } from './dto/entity-tree.dto';
 import { ReportingPeriodsService } from '../reporting-periods/reporting-periods.service';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
-import { buildPagination, normalizePagination } from '../common/pagination';
+import { PaginatedResult, buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class EntitiesService {
@@ -75,15 +75,12 @@ export class EntitiesService {
     return saved;
   }
 
-  async findAll(query?: PaginationQueryDto): Promise<{
-    data: Entity[];
-    pagination: { page: number; limit: number; total: number; totalPages: number };
-  }> {
-    const { page, limit, skip, take } = normalizePagination(query);
+  async findAll(query?: PaginationQueryDto): Promise<PaginatedResult<Entity>> {
+    const { page, limit, skip } = normalizePagination(query);
     const [data, total] = await this.repo.findAndCount({
       order: { name: 'ASC' },
       skip,
-      take,
+      take: limit,
     });
     return { data, pagination: buildPagination(page, limit, total) };
   }

--- a/backend/src/entities/entities.service.ts
+++ b/backend/src/entities/entities.service.ts
@@ -17,6 +17,8 @@ import { UpdateEntityDto } from './dto/update-entity.dto';
 import { HierarchyValidationService } from './hierarchy-validation.service';
 import { EntityTreeNode } from './dto/entity-tree.dto';
 import { ReportingPeriodsService } from '../reporting-periods/reporting-periods.service';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class EntitiesService {
@@ -73,8 +75,17 @@ export class EntitiesService {
     return saved;
   }
 
-  async findAll(): Promise<Entity[]> {
-    return this.repo.find({ order: { name: 'ASC' } });
+  async findAll(query?: PaginationQueryDto): Promise<{
+    data: Entity[];
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }> {
+    const { page, limit, skip, take } = normalizePagination(query);
+    const [data, total] = await this.repo.findAndCount({
+      order: { name: 'ASC' },
+      skip,
+      take,
+    });
+    return { data, pagination: buildPagination(page, limit, total) };
   }
 
   async findOne(id: string): Promise<Entity> {

--- a/backend/src/entities/tests/activity-types.controller.spec.ts
+++ b/backend/src/entities/tests/activity-types.controller.spec.ts
@@ -49,11 +49,17 @@ describe('ActivityTypesController', () => {
   });
 
   it('GET /activity-types calls service.findAll', async () => {
-    serviceMock.findAll.mockResolvedValueOnce(['x']);
+    serviceMock.findAll.mockResolvedValueOnce({
+      data: ['x'],
+      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    });
     const controller = app.get(ActivityTypesController);
     const result = await controller.list();
     expect(serviceMock.findAll).toHaveBeenCalled();
-    expect(result).toEqual(['x']);
+    expect(result).toEqual({
+      data: ['x'],
+      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    });
   });
 
   it('GET /activity-types/:id calls service.findOne', async () => {

--- a/backend/src/entities/tests/activity-types.controller.spec.ts
+++ b/backend/src/entities/tests/activity-types.controller.spec.ts
@@ -54,7 +54,7 @@ describe('ActivityTypesController', () => {
       pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
     });
     const controller = app.get(ActivityTypesController);
-    const result = await controller.list();
+    const result = await controller.list({} as any);
     expect(serviceMock.findAll).toHaveBeenCalled();
     expect(result).toEqual({
       data: ['x'],

--- a/backend/src/entities/tests/activity-types.service.spec.ts
+++ b/backend/src/entities/tests/activity-types.service.spec.ts
@@ -16,6 +16,7 @@ class UsagePolicyStub {
 function createMockRepo<T extends ObjectLiteral>() {
   return {
     find: jest.fn<Promise<T[]>, any>(),
+    findAndCount: jest.fn<Promise<[T[], number]>, any>(),
     findOne: jest.fn<Promise<T | null>, any>(),
     findBy: jest.fn<Promise<T[]>, any>(),
     save: jest.fn<Promise<T>, any>(),
@@ -91,6 +92,22 @@ describe('ActivityTypesService', () => {
     usagePolicy.isInUse.mockResolvedValue(false);
   });
 
+  describe('findAll', () => {
+    it('returns paginated activity types with defaults', async () => {
+      activityTypeRepo.findAndCount.mockResolvedValue([[atype], 1]);
+      const result = await service.findAll();
+      expect(activityTypeRepo.findAndCount).toHaveBeenCalledWith({
+        order: { name: 'ASC' },
+        skip: 0,
+        take: 20,
+      });
+      expect(result).toEqual({
+        data: [atype],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      });
+    });
+  });
+
   describe('create', () => {
     it('creates an activity type when name is unique and roles exist', async () => {
       activityTypeRepo.findOne.mockResolvedValue(null);
@@ -137,15 +154,6 @@ describe('ActivityTypesService', () => {
         role_ids: [roleMissionary.id, rolePastor.id],
       };
       await expect(service.create(dto as any)).rejects.toBeInstanceOf(BadRequestException);
-    });
-  });
-
-  describe('findAll', () => {
-    it('returns all activity types', async () => {
-      activityTypeRepo.find.mockResolvedValue([atype]);
-      const result = await service.findAll();
-      expect(activityTypeRepo.find).toHaveBeenCalled();
-      expect(result).toEqual([atype]);
     });
   });
 

--- a/backend/src/entities/tests/entities.controller.spec.ts
+++ b/backend/src/entities/tests/entities.controller.spec.ts
@@ -130,7 +130,7 @@ describe('EntitiesController', () => {
         pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
       };
       service.findAll.mockResolvedValue(payload as any);
-      await expect(controller.findAll()).resolves.toEqual(payload);
+      await expect(controller.findAll({} as any)).resolves.toEqual(payload);
     });
   });
 

--- a/backend/src/entities/tests/entities.controller.spec.ts
+++ b/backend/src/entities/tests/entities.controller.spec.ts
@@ -125,8 +125,12 @@ describe('EntitiesController', () => {
 
   describe('findAll', () => {
     it('returns all entities', async () => {
-      service.findAll.mockResolvedValue([mockEntity]);
-      await expect(controller.findAll()).resolves.toEqual([mockEntity]);
+      const payload = {
+        data: [mockEntity],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      };
+      service.findAll.mockResolvedValue(payload as any);
+      await expect(controller.findAll()).resolves.toEqual(payload);
     });
   });
 

--- a/backend/src/entities/tests/entities.service.spec.ts
+++ b/backend/src/entities/tests/entities.service.spec.ts
@@ -16,6 +16,7 @@ function createRepoMock<T extends ObjectLiteral>(): MockRepo<T> {
     create: jest.fn(),
     save: jest.fn(),
     find: jest.fn(),
+    findAndCount: jest.fn(),
     findOne: jest.fn(),
     delete: jest.fn(),
     update: jest.fn(),
@@ -117,9 +118,17 @@ describe('EntitiesService', () => {
   });
 
   describe('findAll', () => {
-    it('returns all entities', async () => {
-      repo.find?.mockResolvedValue([baseEntity]);
-      await expect(service.findAll()).resolves.toEqual([baseEntity]);
+    it('returns paginated entities with defaults', async () => {
+      repo.findAndCount?.mockResolvedValue([[baseEntity], 1]);
+      await expect(service.findAll()).resolves.toEqual({
+        data: [baseEntity],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      });
+      expect(repo.findAndCount).toHaveBeenCalledWith({
+        order: { name: 'ASC' },
+        skip: 0,
+        take: 20,
+      });
     });
   });
 

--- a/backend/src/entities/tests/roles.controller.spec.ts
+++ b/backend/src/entities/tests/roles.controller.spec.ts
@@ -73,7 +73,7 @@ describe('RolesController', () => {
     };
     rolesService.findAll.mockResolvedValue(payload as any);
 
-    const res = await controller.findAll();
+    const res = await controller.findAll({} as any);
     expect(rolesService.findAll).toHaveBeenCalled();
     expect(res).toEqual(payload);
   });

--- a/backend/src/entities/tests/roles.controller.spec.ts
+++ b/backend/src/entities/tests/roles.controller.spec.ts
@@ -67,12 +67,15 @@ describe('RolesController', () => {
   });
 
   it('findAll -> should return list', async () => {
-    const list = [{ id: 'uuid-1', name: 'PASTOR' }];
-    rolesService.findAll.mockResolvedValue(list as any);
+    const payload = {
+      data: [{ id: 'uuid-1', name: 'PASTOR' }],
+      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    };
+    rolesService.findAll.mockResolvedValue(payload as any);
 
     const res = await controller.findAll();
     expect(rolesService.findAll).toHaveBeenCalled();
-    expect(res).toEqual(list);
+    expect(res).toEqual(payload);
   });
 
   it('getRoleById -> should return one', async () => {

--- a/backend/src/entities/tests/roles.service.spec.ts
+++ b/backend/src/entities/tests/roles.service.spec.ts
@@ -12,6 +12,7 @@ const createMockRepo = (): MockRepo<Role> => ({
   create: jest.fn(),
   save: jest.fn(),
   find: jest.fn(),
+  findAndCount: jest.fn(),
   findOne: jest.fn(),
   delete: jest.fn(),
 });
@@ -79,10 +80,13 @@ describe('RolesService', () => {
 
   describe('findAll', () => {
     it('returns roles list', async () => {
-      repo.find?.mockResolvedValue([role]);
+      repo.findAndCount?.mockResolvedValue([[role], 1]);
       const result = await service.findAll();
-      expect(repo.find).toHaveBeenCalledWith({ order: { name: 'ASC' } });
-      expect(result).toEqual([role]);
+      expect(repo.findAndCount).toHaveBeenCalledWith({ order: { name: 'ASC' }, skip: 0, take: 20 });
+      expect(result).toEqual({
+        data: [role],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      });
     });
   });
 

--- a/backend/src/entities/tests/users.service.spec.ts
+++ b/backend/src/entities/tests/users.service.spec.ts
@@ -24,6 +24,7 @@ function createMockRepo<T extends ObjectLiteral>(): MockRepo<T> {
     create: jest.fn(),
     save: jest.fn(),
     count: jest.fn(),
+    findAndCount: jest.fn(),
     delete: jest.fn(),
   };
 }
@@ -81,6 +82,24 @@ describe('UsersService (create & update)', () => {
     service = module.get<UsersService>(UsersService);
 
     jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('returns paginated users with defaults', async () => {
+      usersRepo.findAndCount?.mockResolvedValue([[baseUser], 1]);
+
+      const result = await service.findAll();
+
+      expect(usersRepo.findAndCount).toHaveBeenCalledWith({
+        order: { username: 'ASC' },
+        skip: 0,
+        take: 20,
+      });
+      expect(result).toEqual({
+        data: [baseUser],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      });
+    });
   });
 
   describe('create', () => {

--- a/backend/src/reporting-periods/dto/list-reporting-periods.dto.ts
+++ b/backend/src/reporting-periods/dto/list-reporting-periods.dto.ts
@@ -1,0 +1,10 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsUUID } from 'class-validator';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+
+export class ListReportingPeriodsQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by entity UUID' })
+  @IsOptional()
+  @IsUUID()
+  entityId?: string;
+}

--- a/backend/src/reporting-periods/reporting-periods.controller.ts
+++ b/backend/src/reporting-periods/reporting-periods.controller.ts
@@ -11,7 +11,7 @@ import {
   ParseUUIDPipe,
   Query,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { ReportingPeriodsService } from './reporting-periods.service';
 import { CreateReportingPeriodDto } from './dto/create-reporting-period.dto';
 import { UpdateReportingPeriodDto } from './dto/update-reporting-period.dto';
@@ -19,6 +19,7 @@ import { CreateExceptionDto } from './dto/create-exception.dto';
 import { ReportingPeriodResponseDto } from './dto/reporting-period-response.dto';
 import { ExceptionResponseDto } from './dto/exception-response.dto';
 import { ListReportingPeriodsQueryDto } from './dto/list-reporting-periods.dto';
+import { PaginationMeta } from '../common/pagination';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -65,12 +66,11 @@ export class ReportingPeriodsController {
     status: 200,
     description: 'List of reporting periods',
   })
-  @ApiQuery({ name: 'entityId', required: false, description: 'Filter by entity UUID' })
   async findAll(
-    @Query() query: ListReportingPeriodsQueryDto = new ListReportingPeriodsQueryDto(),
+    @Query() query: ListReportingPeriodsQueryDto,
   ): Promise<{
     data: ReportingPeriodResponseDto[];
-    pagination: { page: number; limit: number; total: number; totalPages: number };
+    pagination: PaginationMeta;
   }> {
     const result = await this.reportingPeriodsService.findAll(query);
     return {

--- a/backend/src/reporting-periods/reporting-periods.controller.ts
+++ b/backend/src/reporting-periods/reporting-periods.controller.ts
@@ -18,6 +18,7 @@ import { UpdateReportingPeriodDto } from './dto/update-reporting-period.dto';
 import { CreateExceptionDto } from './dto/create-exception.dto';
 import { ReportingPeriodResponseDto } from './dto/reporting-period-response.dto';
 import { ExceptionResponseDto } from './dto/exception-response.dto';
+import { ListReportingPeriodsQueryDto } from './dto/list-reporting-periods.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
@@ -63,12 +64,19 @@ export class ReportingPeriodsController {
   @ApiResponse({
     status: 200,
     description: 'List of reporting periods',
-    type: [ReportingPeriodResponseDto],
   })
   @ApiQuery({ name: 'entityId', required: false, description: 'Filter by entity UUID' })
-  async findAll(@Query('entityId') entityId?: string): Promise<ReportingPeriodResponseDto[]> {
-    const periods = await this.reportingPeriodsService.findAll(entityId);
-    return periods.map((period) => ReportingPeriodResponseDto.fromEntity(period));
+  async findAll(
+    @Query() query: ListReportingPeriodsQueryDto = new ListReportingPeriodsQueryDto(),
+  ): Promise<{
+    data: ReportingPeriodResponseDto[];
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }> {
+    const result = await this.reportingPeriodsService.findAll(query);
+    return {
+      data: result.data.map((period) => ReportingPeriodResponseDto.fromEntity(period)),
+      pagination: result.pagination,
+    };
   }
 
   @Get(':id')

--- a/backend/src/reporting-periods/reporting-periods.service.ts
+++ b/backend/src/reporting-periods/reporting-periods.service.ts
@@ -14,7 +14,7 @@ import { UpdateReportingPeriodDto } from './dto/update-reporting-period.dto';
 import { CreateExceptionDto } from './dto/create-exception.dto';
 import { ReportingPeriodStatus } from './reporting-period-status.enum';
 import { ListReportingPeriodsQueryDto } from './dto/list-reporting-periods.dto';
-import { buildPagination, normalizePagination } from '../common/pagination';
+import { PaginatedResult, buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class ReportingPeriodsService {
@@ -192,12 +192,7 @@ export class ReportingPeriodsService {
       .getMany();
   }
 
-  async findAll(
-    query?: ListReportingPeriodsQueryDto,
-  ): Promise<{
-    data: ReportingPeriod[];
-    pagination: { page: number; limit: number; total: number; totalPages: number };
-  }> {
+  async findAll(query?: ListReportingPeriodsQueryDto): Promise<PaginatedResult<ReportingPeriod>> {
     const queryBuilder = this.repo
       .createQueryBuilder('period')
       .leftJoinAndSelect('period.entity', 'entity')
@@ -207,8 +202,8 @@ export class ReportingPeriodsService {
       queryBuilder.andWhere('period.entity_id = :entityId', { entityId: query.entityId });
     }
 
-    const { page, limit, skip, take } = normalizePagination(query);
-    const [data, total] = await queryBuilder.skip(skip).take(take).getManyAndCount();
+    const { page, limit, skip } = normalizePagination(query);
+    const [data, total] = await queryBuilder.skip(skip).take(limit).getManyAndCount();
     return { data, pagination: buildPagination(page, limit, total) };
   }
 

--- a/backend/src/reporting-periods/reporting-periods.service.ts
+++ b/backend/src/reporting-periods/reporting-periods.service.ts
@@ -13,6 +13,8 @@ import { CreateReportingPeriodDto } from './dto/create-reporting-period.dto';
 import { UpdateReportingPeriodDto } from './dto/update-reporting-period.dto';
 import { CreateExceptionDto } from './dto/create-exception.dto';
 import { ReportingPeriodStatus } from './reporting-period-status.enum';
+import { ListReportingPeriodsQueryDto } from './dto/list-reporting-periods.dto';
+import { buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class ReportingPeriodsService {
@@ -190,17 +192,24 @@ export class ReportingPeriodsService {
       .getMany();
   }
 
-  async findAll(entityId?: string): Promise<ReportingPeriod[]> {
-    const query = this.repo
+  async findAll(
+    query?: ListReportingPeriodsQueryDto,
+  ): Promise<{
+    data: ReportingPeriod[];
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }> {
+    const queryBuilder = this.repo
       .createQueryBuilder('period')
       .leftJoinAndSelect('period.entity', 'entity')
       .orderBy('period.start_date', 'DESC');
 
-    if (entityId) {
-      query.andWhere('period.entity_id = :entityId', { entityId });
+    if (query?.entityId) {
+      queryBuilder.andWhere('period.entity_id = :entityId', { entityId: query.entityId });
     }
 
-    return query.getMany();
+    const { page, limit, skip, take } = normalizePagination(query);
+    const [data, total] = await queryBuilder.skip(skip).take(take).getManyAndCount();
+    return { data, pagination: buildPagination(page, limit, total) };
   }
 
   async findOne(id: string): Promise<ReportingPeriod> {

--- a/backend/src/reporting-periods/tests/reporting-periods-lifecycle.spec.ts
+++ b/backend/src/reporting-periods/tests/reporting-periods-lifecycle.spec.ts
@@ -33,8 +33,11 @@ describe('ReportingPeriodsService - Lifecycle Management', () => {
     orderBy: jest.fn().mockReturnThis(),
     leftJoinAndSelect: jest.fn().mockReturnThis(),
     leftJoin: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
     getOne: jest.fn(),
     getMany: jest.fn(),
+    getManyAndCount: jest.fn(),
     getCount: jest.fn(),
     update: jest.fn().mockReturnThis(),
     set: jest.fn().mockReturnThis(),
@@ -249,13 +252,17 @@ describe('ReportingPeriodsService - Lifecycle Management', () => {
 
     it('should find all periods with entity filter', async () => {
       mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
-      mockQueryBuilder.getMany.mockResolvedValue([{ id: '1' }]);
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([[{ id: '1' }], 1]);
+      mockQueryBuilder.skip.mockReturnThis();
+      mockQueryBuilder.take.mockReturnThis();
 
-      await service.findAll('entity-1');
+      await service.findAll({ entityId: 'entity-1' } as any);
 
       expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('period.entity_id = :entityId', {
         entityId: 'entity-1',
       });
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(0);
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(20);
     });
   });
 

--- a/backend/src/roles/roles.controller.ts
+++ b/backend/src/roles/roles.controller.ts
@@ -26,6 +26,7 @@ import { BulkAssignRoleDto } from './dto/bulk-assign-role.dto';
 import { GetUserEntitiesByRoleDto } from './dto/get-user-entities-by-role.dto';
 import { UpdateAssignmentDto } from './dto/update-assignment.dto';
 import { AssignmentResponseDto } from './dto/assignment-response.dto';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 @ApiTags('Roles')
 @ApiBearerAuth('JWT-auth')
@@ -94,8 +95,8 @@ export class RolesController {
 
   @Get()
   @Roles('admin')
-  findAll() {
-    return this.rolesService.findAll();
+  findAll(@Query() query: PaginationQueryDto = new PaginationQueryDto()) {
+    return this.rolesService.findAll(query);
   }
 
   @Get('id/:id')

--- a/backend/src/roles/roles.controller.ts
+++ b/backend/src/roles/roles.controller.ts
@@ -95,7 +95,7 @@ export class RolesController {
 
   @Get()
   @Roles('admin')
-  findAll(@Query() query: PaginationQueryDto = new PaginationQueryDto()) {
+  findAll(@Query() query: PaginationQueryDto) {
     return this.rolesService.findAll(query);
   }
 

--- a/backend/src/roles/roles.service.ts
+++ b/backend/src/roles/roles.service.ts
@@ -10,7 +10,7 @@ import { Role } from './role.entity';
 import { CreateRoleDto } from './dto/create-role.dto';
 import { UpdateRoleDto } from './dto/update-role.dto';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
-import { buildPagination, normalizePagination } from '../common/pagination';
+import { PaginatedResult, buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class RolesService {
@@ -43,15 +43,12 @@ export class RolesService {
     return this.rolesRepo.save(role);
   }
 
-  async findAll(query?: PaginationQueryDto): Promise<{
-    data: Role[];
-    pagination: { page: number; limit: number; total: number; totalPages: number };
-  }> {
-    const { page, limit, skip, take } = normalizePagination(query);
+  async findAll(query?: PaginationQueryDto): Promise<PaginatedResult<Role>> {
+    const { page, limit, skip } = normalizePagination(query);
     const [data, total] = await this.rolesRepo.findAndCount({
       order: { name: 'ASC' },
       skip,
-      take,
+      take: limit,
     });
     return { data, pagination: buildPagination(page, limit, total) };
   }

--- a/backend/src/roles/roles.service.ts
+++ b/backend/src/roles/roles.service.ts
@@ -9,6 +9,8 @@ import { Raw, Repository } from 'typeorm';
 import { Role } from './role.entity';
 import { CreateRoleDto } from './dto/create-role.dto';
 import { UpdateRoleDto } from './dto/update-role.dto';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class RolesService {
@@ -41,8 +43,17 @@ export class RolesService {
     return this.rolesRepo.save(role);
   }
 
-  findAll(): Promise<Role[]> {
-    return this.rolesRepo.find({ order: { name: 'ASC' } });
+  async findAll(query?: PaginationQueryDto): Promise<{
+    data: Role[];
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }> {
+    const { page, limit, skip, take } = normalizePagination(query);
+    const [data, total] = await this.rolesRepo.findAndCount({
+      order: { name: 'ASC' },
+      skip,
+      take,
+    });
+    return { data, pagination: buildPagination(page, limit, total) };
   }
 
   async findOne(id: string): Promise<Role> {

--- a/backend/src/users/admin-users.controller.spec.ts
+++ b/backend/src/users/admin-users.controller.spec.ts
@@ -87,12 +87,15 @@ describe('AdminUsersController', () => {
 
   describe('list', () => {
     it('returns all users', async () => {
-      const users = [userMock];
-      service.findAll.mockResolvedValue(users as User[]);
+      const payload = {
+        data: [userMock],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      };
+      service.findAll.mockResolvedValue(payload as any);
 
       const result = await controller.list();
       expect(service.findAll).toHaveBeenCalled();
-      expect(result).toEqual(users);
+      expect(result).toEqual(payload);
     });
   });
 

--- a/backend/src/users/admin-users.controller.spec.ts
+++ b/backend/src/users/admin-users.controller.spec.ts
@@ -93,7 +93,7 @@ describe('AdminUsersController', () => {
       };
       service.findAll.mockResolvedValue(payload as any);
 
-      const result = await controller.list();
+      const result = await controller.list({} as any);
       expect(service.findAll).toHaveBeenCalled();
       expect(result).toEqual(payload);
     });

--- a/backend/src/users/admin-users.controller.ts
+++ b/backend/src/users/admin-users.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, Post, Get, Patch, Param, Body, UseGuards, ParseUUIDPipe } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Param,
+  Body,
+  UseGuards,
+  ParseUUIDPipe,
+  Query,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
@@ -6,6 +16,7 @@ import { UpdateUserDto } from './dto/update-user.dto';
 import { AuthGuard } from '@nestjs/passport';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
 
 @ApiTags('Admin Users')
 @ApiBearerAuth('JWT-auth')
@@ -30,8 +41,8 @@ export class AdminUsersController {
   @ApiResponse({ status: 200, description: 'List of all users' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
-  async list() {
-    return this.usersService.findAll();
+  async list(@Query() query: PaginationQueryDto = new PaginationQueryDto()) {
+    return this.usersService.findAll(query);
   }
 
   @Get(':id')

--- a/backend/src/users/admin-users.controller.ts
+++ b/backend/src/users/admin-users.controller.ts
@@ -41,7 +41,7 @@ export class AdminUsersController {
   @ApiResponse({ status: 200, description: 'List of all users' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 403, description: 'Forbidden - requires admin role' })
-  async list(@Query() query: PaginationQueryDto = new PaginationQueryDto()) {
+  async list(@Query() query: PaginationQueryDto) {
     return this.usersService.findAll(query);
   }
 

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -16,7 +16,7 @@ import { EntitiesService } from '../entities/entities.service';
 import { RolesService } from '../roles/roles.service';
 import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
-import { buildPagination, normalizePagination } from '../common/pagination';
+import { PaginatedResult, buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class UsersService {
@@ -72,15 +72,12 @@ export class UsersService {
     return this.usersRepo.save(user);
   }
 
-  async findAll(query?: PaginationQueryDto): Promise<{
-    data: User[];
-    pagination: { page: number; limit: number; total: number; totalPages: number };
-  }> {
-    const { page, limit, skip, take } = normalizePagination(query);
+  async findAll(query?: PaginationQueryDto): Promise<PaginatedResult<User>> {
+    const { page, limit, skip } = normalizePagination(query);
     const [data, total] = await this.usersRepo.findAndCount({
       order: { username: 'ASC' },
       skip,
-      take,
+      take: limit,
     });
     return { data, pagination: buildPagination(page, limit, total) };
   }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -15,6 +15,8 @@ import { UserStatus } from './user-status.enum';
 import { EntitiesService } from '../entities/entities.service';
 import { RolesService } from '../roles/roles.service';
 import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { buildPagination, normalizePagination } from '../common/pagination';
 
 @Injectable()
 export class UsersService {
@@ -70,8 +72,17 @@ export class UsersService {
     return this.usersRepo.save(user);
   }
 
-  async findAll(): Promise<User[]> {
-    return this.usersRepo.find();
+  async findAll(query?: PaginationQueryDto): Promise<{
+    data: User[];
+    pagination: { page: number; limit: number; total: number; totalPages: number };
+  }> {
+    const { page, limit, skip, take } = normalizePagination(query);
+    const [data, total] = await this.usersRepo.findAndCount({
+      order: { username: 'ASC' },
+      skip,
+      take,
+    });
+    return { data, pagination: buildPagination(page, limit, total) };
   }
 
   async findOne(id: string): Promise<User> {

--- a/e2e/step-definitions/api/activities.steps.ts
+++ b/e2e/step-definitions/api/activities.steps.ts
@@ -38,13 +38,14 @@ async function ensureUserCanSubmitActivities(world: CustomWorld): Promise<string
 
   // Get all activity types
   const typesResponse = await world.apiClient.get(ENDPOINTS.ACTIVITY_TYPES);
-  if (typesResponse.data.length === 0) {
+  const activityTypesList = typesResponse.data?.data || typesResponse.data;
+  if (activityTypesList.length === 0) {
     throw new Error('No activity types found in database');
   }
 
   // Find an activity type that requires a role we can assign via the API
   // (roles like 'president' are not in the RoleEnum and will fail validation)
-  const validActivityType = typesResponse.data.find((at: any) => {
+  const validActivityType = activityTypesList.find((at: any) => {
     if (!at.allowed_roles || at.allowed_roles.length === 0) {
       return true; // No restrictions
     }
@@ -105,7 +106,8 @@ Given('I have an authorized activity type', async function (this: CustomWorld) {
 
   // Get the name
   const typesResponse = await this.apiClient.get(ENDPOINTS.ACTIVITY_TYPES);
-  const activityType = typesResponse.data.find((t: any) => t.id === activityTypeId);
+  const activityTypesList = typesResponse.data?.data || typesResponse.data;
+  const activityType = activityTypesList.find((t: any) => t.id === activityTypeId);
   this.context.activityTypeName = activityType?.name || 'Unknown';
 });
 
@@ -256,7 +258,7 @@ Then('the activity should not be in the list', async function (this: CustomWorld
   const response = await this.apiClient.get(ENDPOINTS.ACTIVITIES);
   expect(response.status).toBe(200);
 
-  const items = response.data.items || response.data;
+  const items = response.data?.data || response.data;
   const found = items.find((item: any) => item.id === notedId);
 
   expect(found).toBeUndefined();

--- a/e2e/step-definitions/api/common.steps.ts
+++ b/e2e/step-definitions/api/common.steps.ts
@@ -76,14 +76,18 @@ Then('the response should have property {string} with value {string}', function 
 
 Then('the response should be an array', function (this: CustomWorld) {
   const data = this.context.lastResponse?.data;
-  expect(Array.isArray(data)).toBe(true);
+  // Support both plain arrays and paginated responses ({ data: [...], pagination: {...} })
+  const items = Array.isArray(data) ? data : data?.data;
+  expect(Array.isArray(items)).toBe(true);
 });
 
 Then('each item should have property {string}', function (this: CustomWorld, propertyName: string) {
   const data = this.context.lastResponse?.data;
-  expect(Array.isArray(data)).toBe(true);
+  // Support both plain arrays and paginated responses ({ data: [...], pagination: {...} })
+  const items = Array.isArray(data) ? data : data?.data;
+  expect(Array.isArray(items)).toBe(true);
 
-  for (const item of data) {
+  for (const item of items) {
     expect(item).toHaveProperty(propertyName);
   }
 });

--- a/e2e/step-definitions/journeys/admin/entity-hierarchy-management.steps.ts
+++ b/e2e/step-definitions/journeys/admin/entity-hierarchy-management.steps.ts
@@ -7,16 +7,18 @@ import { ENDPOINTS } from '../../../support/api/api-client';
 
 async function findEntityByName(world: CustomWorld, name: string): Promise<any | null> {
   const response = await world.apiClient.get(ENDPOINTS.ENTITIES);
-  if (response.status === 200 && Array.isArray(response.data)) {
-    return response.data.find((e: any) => e.name.includes(name)) || null;
+  const entities = response.data?.data || response.data;
+  if (response.status === 200 && Array.isArray(entities)) {
+    return entities.find((e: any) => e.name.includes(name)) || null;
   }
   return null;
 }
 
 async function findEntityByType(world: CustomWorld, type: string): Promise<any | null> {
   const response = await world.apiClient.get(ENDPOINTS.ENTITIES);
-  if (response.status === 200 && Array.isArray(response.data)) {
-    return response.data.find((e: any) => e.type === type.toUpperCase()) || null;
+  const entities = response.data?.data || response.data;
+  if (response.status === 200 && Array.isArray(entities)) {
+    return entities.find((e: any) => e.type === type.toUpperCase()) || null;
   }
   return null;
 }
@@ -237,8 +239,9 @@ When('I deactivate the entity', async function (this: CustomWorld) {
 
 When('I list all Unions', async function (this: CustomWorld) {
   const response = await this.apiClient.get(ENDPOINTS.ENTITIES);
-  if (response.status === 200 && Array.isArray(response.data)) {
-    this.context.filteredEntities = response.data.filter((e: any) => e.type === 'UNION');
+  const entitiesList = response.data?.data || response.data;
+  if (response.status === 200 && Array.isArray(entitiesList)) {
+    this.context.filteredEntities = entitiesList.filter((e: any) => e.type === 'UNION');
   }
   this.context.lastResponse = response;
 });
@@ -247,8 +250,9 @@ When('I list all Unions', async function (this: CustomWorld) {
 
 Then('I should see the complete hierarchy tree', function (this: CustomWorld) {
   expect(this.context.lastResponse?.status).toBe(200);
-  expect(Array.isArray(this.context.lastResponse?.data)).toBe(true);
-  expect(this.context.lastResponse?.data.length).toBeGreaterThan(0);
+  const entitiesList = this.context.lastResponse?.data?.data || this.context.lastResponse?.data;
+  expect(Array.isArray(entitiesList)).toBe(true);
+  expect(entitiesList.length).toBeGreaterThan(0);
 });
 
 Then('each level should show its child entities', async function (this: CustomWorld) {
@@ -333,7 +337,8 @@ Then('it should not appear in active entity lists', async function (this: Custom
   const response = await this.apiClient.get(ENDPOINTS.ENTITIES);
 
   if (response.status === 200) {
-    const activeEntities = response.data.filter((e: any) => e.is_active === true);
+    const entitiesList = response.data?.data || response.data;
+    const activeEntities = entitiesList.filter((e: any) => e.is_active === true);
     const found = activeEntities.some((e: any) => e.id === entityId);
     // Depending on API behavior, may or may not filter inactive by default
     // Just verify the entity was deactivated

--- a/e2e/step-definitions/journeys/admin/late-submissions.steps.ts
+++ b/e2e/step-definitions/journeys/admin/late-submissions.steps.ts
@@ -13,9 +13,10 @@ async function ensureLockedPeriod(world: CustomWorld): Promise<void> {
     `${ENDPOINTS.REPORTING_PERIODS}?entityId=${entityId}`,
   );
 
-  if (listResponse.status === 200 && Array.isArray(listResponse.data)) {
+  const listData = listResponse.data?.data || listResponse.data;
+  if (listResponse.status === 200 && Array.isArray(listData)) {
     // Look for an existing locked period
-    const lockedPeriod = listResponse.data.find((p: any) => p.status === 'locked');
+    const lockedPeriod = listData.find((p: any) => p.status === 'locked');
     if (lockedPeriod) {
       world.context.createdReportingPeriodId = lockedPeriod.id;
       world.context.createdPeriodStartDate = lockedPeriod.startDate;
@@ -24,7 +25,7 @@ async function ensureLockedPeriod(world: CustomWorld): Promise<void> {
     }
 
     // Look for an active period we can lock
-    const activePeriod = listResponse.data.find((p: any) => p.status === 'active');
+    const activePeriod = listData.find((p: any) => p.status === 'active');
     if (activePeriod) {
       await world.apiClient.patch(`${ENDPOINTS.REPORTING_PERIODS}/${activePeriod.id}/lock`);
       world.context.createdReportingPeriodId = activePeriod.id;
@@ -62,11 +63,12 @@ async function ensureLockedPeriod(world: CustomWorld): Promise<void> {
 
 async function ensureTeamMember(world: CustomWorld): Promise<void> {
   const response = await world.apiClient.get(ENDPOINTS.ADMIN_USERS);
-  if (response.status === 200 && Array.isArray(response.data) && response.data.length > 0) {
+  const usersList = response.data?.data || response.data;
+  if (response.status === 200 && Array.isArray(usersList) && usersList.length > 0) {
     const meResponse = await world.apiClient.get(ENDPOINTS.ME);
     const currentUserId = meResponse.data.id;
-    const teamMember = response.data.find((u: any) => u.id !== currentUserId);
-    world.context.teamMemberId = teamMember ? teamMember.id : response.data[0].id;
+    const teamMember = usersList.find((u: any) => u.id !== currentUserId);
+    world.context.teamMemberId = teamMember ? teamMember.id : usersList[0].id;
     world.context.teamMemberName = 'Carlos';
   }
 }

--- a/e2e/step-definitions/journeys/admin/multi-entity-role-management.steps.ts
+++ b/e2e/step-definitions/journeys/admin/multi-entity-role-management.steps.ts
@@ -7,16 +7,18 @@ import { ENDPOINTS } from '../../../support/api/api-client';
 
 async function findEntityByName(world: CustomWorld, name: string): Promise<any | null> {
   const response = await world.apiClient.get(ENDPOINTS.ENTITIES);
-  if (response.status === 200 && Array.isArray(response.data)) {
-    return response.data.find((e: any) => e.name.includes(name)) || null;
+  const entities = response.data?.data || response.data;
+  if (response.status === 200 && Array.isArray(entities)) {
+    return entities.find((e: any) => e.name.includes(name)) || null;
   }
   return null;
 }
 
 async function findEntityByType(world: CustomWorld, type: string): Promise<any | null> {
   const response = await world.apiClient.get(ENDPOINTS.ENTITIES);
-  if (response.status === 200 && Array.isArray(response.data)) {
-    return response.data.find((e: any) => e.type === type.toUpperCase()) || null;
+  const entities = response.data?.data || response.data;
+  if (response.status === 200 && Array.isArray(entities)) {
+    return entities.find((e: any) => e.type === type.toUpperCase()) || null;
   }
   return null;
 }
@@ -98,10 +100,11 @@ async function ensureUserExists(world: CustomWorld, name: string): Promise<strin
 
   // Get a role for the user
   const rolesResponse = await world.apiClient.get(ENDPOINTS.ROLES);
-  if (rolesResponse.status !== 200 || !Array.isArray(rolesResponse.data) || rolesResponse.data.length === 0) {
+  const rolesList = rolesResponse.data?.data || rolesResponse.data;
+  if (rolesResponse.status !== 200 || !Array.isArray(rolesList) || rolesList.length === 0) {
     throw new Error('No roles available');
   }
-  const roleId = rolesResponse.data[0].id;
+  const roleId = rolesList[0].id;
 
   const timestamp = Date.now();
   const payload = {

--- a/e2e/step-definitions/journeys/admin/offboarding-team-member.steps.ts
+++ b/e2e/step-definitions/journeys/admin/offboarding-team-member.steps.ts
@@ -12,10 +12,11 @@ async function ensureUserWithStatus(
 ): Promise<string> {
   // Get a role for the user
   const rolesResponse = await world.apiClient.get(ENDPOINTS.ROLES);
-  if (rolesResponse.status !== 200 || !Array.isArray(rolesResponse.data) || rolesResponse.data.length === 0) {
+  const rolesList = rolesResponse.data?.data || rolesResponse.data;
+  if (rolesResponse.status !== 200 || !Array.isArray(rolesList) || rolesList.length === 0) {
     throw new Error('No roles available');
   }
-  const roleId = rolesResponse.data[0].id;
+  const roleId = rolesList[0].id;
 
   const timestamp = Date.now();
   const payload = {
@@ -158,7 +159,12 @@ When("I archive Pedro's account", async function (this: CustomWorld) {
 
 When('I review the list of inactive users', async function (this: CustomWorld) {
   // Get all users and filter by those with no recent activity
-  this.context.lastResponse = await this.apiClient.get(ENDPOINTS.ADMIN_USERS);
+  const rawResponse = await this.apiClient.get(ENDPOINTS.ADMIN_USERS);
+  // Normalize to always expose a flat array in lastResponse.data for assertion steps
+  this.context.lastResponse = {
+    ...rawResponse,
+    data: rawResponse.data?.data || rawResponse.data,
+  };
 });
 
 // --- Assertion Steps ---
@@ -181,7 +187,8 @@ Then('Maria should appear in the suspended users list', async function (this: Cu
   expect(response.status).toBe(200);
 
   const userId = this.context.currentTestUserId;
-  const user = response.data.find((u: any) => u.id === userId);
+  const usersList = response.data?.data || response.data;
+  const user = usersList.find((u: any) => u.id === userId);
   expect(user).toBeTruthy();
   expect(user.status).toBe('suspended');
 });

--- a/e2e/step-definitions/journeys/admin/onboarding.steps.ts
+++ b/e2e/step-definitions/journeys/admin/onboarding.steps.ts
@@ -17,10 +17,11 @@ When(
   'I create an account for {string} with email {string}',
   async function (this: CustomWorld, fullName: string, email: string) {
     const roleResponse = await this.apiClient.get(ENDPOINTS.ROLES);
-    if (roleResponse.status !== 200 || !Array.isArray(roleResponse.data) || roleResponse.data.length === 0) {
+    const rolesList = roleResponse.data?.data || roleResponse.data;
+    if (roleResponse.status !== 200 || !Array.isArray(rolesList) || rolesList.length === 0) {
       throw new Error('No roles available in the system');
     }
-    const roleId = roleResponse.data[0].id;
+    const roleId = rolesList[0].id;
 
     const timestamp = Date.now();
     const uniqueEmail = email.replace('@', `-${timestamp}@`);

--- a/e2e/step-definitions/journeys/admin/organization-setup.steps.ts
+++ b/e2e/step-definitions/journeys/admin/organization-setup.steps.ts
@@ -15,8 +15,9 @@ Given('the organization has existing roles and activity types', async function (
   expect(typesResponse.status).toBe(200);
 
   // Store a role ID for later use
-  if (Array.isArray(rolesResponse.data) && rolesResponse.data.length > 0) {
-    this.context.roleId = rolesResponse.data[0].id;
+  const rolesList = rolesResponse.data?.data || rolesResponse.data;
+  if (Array.isArray(rolesList) && rolesList.length > 0) {
+    this.context.roleId = rolesList[0].id;
   }
 });
 
@@ -80,8 +81,9 @@ When('I create a {string} activity type', async function (this: CustomWorld, typ
   // Ensure we have a role ID for the activity type
   if (!this.context.roleId) {
     const rolesResponse = await this.apiClient.get(ENDPOINTS.ROLES);
-    if (rolesResponse.status === 200 && Array.isArray(rolesResponse.data) && rolesResponse.data.length > 0) {
-      this.context.roleId = rolesResponse.data[0].id;
+    const rolesList = rolesResponse.data?.data || rolesResponse.data;
+    if (rolesResponse.status === 200 && Array.isArray(rolesList) && rolesList.length > 0) {
+      this.context.roleId = rolesList[0].id;
     }
   }
 
@@ -138,7 +140,7 @@ Then('all three roles should be available for assignment', function (this: Custo
 Then('I can assign team members to these roles', async function (this: CustomWorld) {
   const rolesResponse = await this.apiClient.get(ENDPOINTS.ROLES);
   expect(rolesResponse.status).toBe(200);
-  expect(Array.isArray(rolesResponse.data)).toBe(true);
+  expect(Array.isArray(rolesResponse.data?.data || rolesResponse.data)).toBe(true);
 });
 
 Then('team members can log these types of activities', function (this: CustomWorld) {
@@ -149,7 +151,7 @@ Then('team members can log these types of activities', function (this: CustomWor
 Then('activities will be categorized appropriately', async function (this: CustomWorld) {
   const typesResponse = await this.apiClient.get(ENDPOINTS.ACTIVITY_TYPES);
   expect(typesResponse.status).toBe(200);
-  expect(Array.isArray(typesResponse.data)).toBe(true);
+  expect(Array.isArray(typesResponse.data?.data || typesResponse.data)).toBe(true);
 });
 
 Then('the changes should be reflected immediately', function (this: CustomWorld) {

--- a/e2e/step-definitions/journeys/leader/hierarchical-reports.steps.ts
+++ b/e2e/step-definitions/journeys/leader/hierarchical-reports.steps.ts
@@ -7,8 +7,9 @@ import { ENDPOINTS } from '../../../support/api/api-client';
 
 async function findEntityByType(world: CustomWorld, type: string): Promise<any | null> {
   const response = await world.apiClient.get(ENDPOINTS.ENTITIES);
-  if (response.status === 200 && Array.isArray(response.data)) {
-    return response.data.find((e: any) => e.type === type.toUpperCase()) || null;
+  const entities = response.data?.data || response.data;
+  if (response.status === 200 && Array.isArray(entities)) {
+    return entities.find((e: any) => e.type === type.toUpperCase()) || null;
   }
   return null;
 }
@@ -42,8 +43,9 @@ async function ensureEntityExists(
   parentId?: string,
 ): Promise<string> {
   const response = await world.apiClient.get(ENDPOINTS.ENTITIES);
-  if (response.status === 200 && Array.isArray(response.data)) {
-    const existing = response.data.find((e: any) => e.name.includes(name) && e.type === type.toUpperCase());
+  const entities = response.data?.data || response.data;
+  if (response.status === 200 && Array.isArray(entities)) {
+    const existing = entities.find((e: any) => e.name.includes(name) && e.type === type.toUpperCase());
     if (existing) {
       return existing.id;
     }
@@ -101,16 +103,18 @@ async function ensureTestHierarchy(world: CustomWorld): Promise<void> {
 
 async function ensureActivityType(world: CustomWorld, typeName: string): Promise<string> {
   const response = await world.apiClient.get(ENDPOINTS.ACTIVITY_TYPES);
+  const activityTypesList = response.data?.data || response.data;
 
-  if (response.status === 200 && Array.isArray(response.data)) {
-    const existing = response.data.find((t: any) => t.name.includes(typeName));
+  if (response.status === 200 && Array.isArray(activityTypesList)) {
+    const existing = activityTypesList.find((t: any) => t.name.includes(typeName));
     if (existing) {
       return existing.id;
     }
   }
 
   const rolesResponse = await world.apiClient.get(ENDPOINTS.ROLES);
-  const roleId = rolesResponse.data?.[0]?.id;
+  const rolesList = rolesResponse.data?.data || rolesResponse.data;
+  const roleId = rolesList?.[0]?.id;
 
   const timestamp = Date.now();
   const createResponse = await world.apiClient.post(ENDPOINTS.ACTIVITY_TYPES, {
@@ -135,16 +139,17 @@ async function ensureActiveReportingPeriod(world: CustomWorld): Promise<boolean>
 
   // Check if there's already an active period for user's entity
   const periodsResponse = await world.apiClient.get(`${ENDPOINTS.REPORTING_PERIODS}?entityId=${entityId}`);
-  if (periodsResponse.status === 200 && Array.isArray(periodsResponse.data)) {
-    const activePeriod = periodsResponse.data.find((p: any) => p.status === 'active');
+  const periodsList = periodsResponse.data?.data || periodsResponse.data;
+  if (periodsResponse.status === 200 && Array.isArray(periodsList)) {
+    const activePeriod = periodsList.find((p: any) => p.status === 'active');
     if (activePeriod) {
       world.context.activeReportingPeriodId = activePeriod.id;
       return true;
     }
 
     // Try any period if no active one exists
-    if (periodsResponse.data.length > 0) {
-      world.context.activeReportingPeriodId = periodsResponse.data[0].id;
+    if (periodsList.length > 0) {
+      world.context.activeReportingPeriodId = periodsList[0].id;
       return true;
     }
   }

--- a/e2e/step-definitions/journeys/missionary/daily-activity-logging.steps.ts
+++ b/e2e/step-definitions/journeys/missionary/daily-activity-logging.steps.ts
@@ -8,9 +8,10 @@ import { getTestUser } from '../../../support/auth/test-users';
 
 async function ensureActivityType(world: CustomWorld, typeName: string): Promise<string> {
   const response = await world.apiClient.get(ENDPOINTS.ACTIVITY_TYPES);
+  const activityTypesList = response.data?.data || response.data;
 
-  if (response.status === 200 && Array.isArray(response.data)) {
-    const existing = response.data.find((t: any) => t.name.includes(typeName));
+  if (response.status === 200 && Array.isArray(activityTypesList)) {
+    const existing = activityTypesList.find((t: any) => t.name.includes(typeName));
     if (existing) {
       return existing.id;
     }
@@ -18,7 +19,8 @@ async function ensureActivityType(world: CustomWorld, typeName: string): Promise
 
   // Get a role for the activity type
   const rolesResponse = await world.apiClient.get(ENDPOINTS.ROLES);
-  const roleId = rolesResponse.data?.[0]?.id;
+  const rolesList = rolesResponse.data?.data || rolesResponse.data;
+  const roleId = rolesList?.[0]?.id;
 
   const timestamp = Date.now();
   const createResponse = await world.apiClient.post(ENDPOINTS.ACTIVITY_TYPES, {
@@ -41,9 +43,10 @@ async function ensureActivePeriod(world: CustomWorld): Promise<string> {
     `${ENDPOINTS.REPORTING_PERIODS}?entityId=${entityId}`,
   );
 
-  if (listResponse.status === 200 && Array.isArray(listResponse.data)) {
+  const periodsList = listResponse.data?.data || listResponse.data;
+  if (listResponse.status === 200 && Array.isArray(periodsList)) {
     // Look for an existing active period
-    const activePeriod = listResponse.data.find((p: any) => p.status === 'active');
+    const activePeriod = periodsList.find((p: any) => p.status === 'active');
     if (activePeriod) {
       world.context.activePeriodId = activePeriod.id;
       world.context.activePeriodStartDate = activePeriod.startDate;
@@ -52,7 +55,7 @@ async function ensureActivePeriod(world: CustomWorld): Promise<string> {
     }
 
     // Unlock a locked period if one exists
-    const lockedPeriod = listResponse.data.find((p: any) => p.status === 'locked');
+    const lockedPeriod = periodsList.find((p: any) => p.status === 'locked');
     if (lockedPeriod) {
       await world.apiClient.patch(`${ENDPOINTS.REPORTING_PERIODS}/${lockedPeriod.id}/unlock`);
       world.context.activePeriodId = lockedPeriod.id;
@@ -223,10 +226,7 @@ When('I delete the activity', async function (this: CustomWorld) {
   // Store count before deletion
   const beforeResponse = await this.apiClient.get(ENDPOINTS.ACTIVITIES);
 
-  // Handle both array and paginated response
-  const activities = Array.isArray(beforeResponse.data)
-    ? beforeResponse.data
-    : beforeResponse.data?.data || [];
+  const activities = beforeResponse.data?.data || [];
 
   this.context.activityCountBefore = activities.length;
 
@@ -245,8 +245,7 @@ Then('it should appear in my activity list for this period', async function (thi
   const response = await this.apiClient.get(ENDPOINTS.ACTIVITIES);
   expect(response.status).toBe(200);
 
-  // Handle both array and paginated response
-  const activities = Array.isArray(response.data) ? response.data : response.data?.data || [];
+  const activities = response.data?.data || [];
 
   const activityId = this.context.lastActivityId;
   const found = activities.some((a: any) => a.id === activityId);
@@ -257,8 +256,7 @@ Then('I should have {int} activities recorded for this period', async function (
   const response = await this.apiClient.get(ENDPOINTS.ACTIVITIES);
   expect(response.status).toBe(200);
 
-  // Handle both array and paginated response
-  const activities = Array.isArray(response.data) ? response.data : response.data?.data || [];
+  const activities = response.data?.data || [];
 
   // Count activities from this test session
   const createdIds = this.context.createdActivities || [];
@@ -274,10 +272,7 @@ Then('each activity should have the correct type', function (this: CustomWorld) 
 Then('I should see all my logged activities', function (this: CustomWorld) {
   expect(this.context.lastResponse?.status).toBe(200);
 
-  // Handle both array and paginated response
-  const activities = Array.isArray(this.context.lastResponse?.data)
-    ? this.context.lastResponse?.data
-    : this.context.lastResponse?.data?.data || [];
+  const activities = this.context.lastResponse?.data?.data || [];
 
   expect(Array.isArray(activities)).toBe(true);
   expect(activities.length).toBeGreaterThan(0);
@@ -286,10 +281,7 @@ Then('I should see all my logged activities', function (this: CustomWorld) {
 Then('they should be organized by date', function (this: CustomWorld) {
   expect(this.context.lastResponse?.status).toBe(200);
 
-  // Handle both array and paginated response
-  const activities = Array.isArray(this.context.lastResponse?.data)
-    ? this.context.lastResponse?.data
-    : this.context.lastResponse?.data?.data || [];
+  const activities = this.context.lastResponse?.data?.data || [];
 
   // Activities should have activityDate field
   for (const activity of activities) {
@@ -325,8 +317,7 @@ Then('it should be removed from my activity list', async function (this: CustomW
   const activityId = this.context.lastActivityId;
   const response = await this.apiClient.get(ENDPOINTS.ACTIVITIES);
 
-  // Handle both array and paginated response
-  const activities = Array.isArray(response.data) ? response.data : response.data?.data || [];
+  const activities = response.data?.data || [];
 
   // Activity should be archived/removed
   const found = activities.some((a: any) => a.id === activityId && a.status === 'active');
@@ -336,8 +327,7 @@ Then('it should be removed from my activity list', async function (this: CustomW
 Then('my activity count should decrease by one', async function (this: CustomWorld) {
   const response = await this.apiClient.get(ENDPOINTS.ACTIVITIES);
 
-  // Handle both array and paginated response
-  const activities = Array.isArray(response.data) ? response.data : response.data?.data || [];
+  const activities = response.data?.data || [];
   const currentCount = activities.length;
 
   // Count should be less than or equal to before (archived activities may be filtered)

--- a/e2e/step-definitions/journeys/pastor/reporting-cycle.steps.ts
+++ b/e2e/step-definitions/journeys/pastor/reporting-cycle.steps.ts
@@ -11,9 +11,10 @@ async function ensureActivePeriod(world: CustomWorld, periodName: string): Promi
     `${ENDPOINTS.REPORTING_PERIODS}?entityId=${entityId}`,
   );
 
-  if (listResponse.status === 200 && Array.isArray(listResponse.data)) {
+  const periodsList = listResponse.data?.data || listResponse.data;
+  if (listResponse.status === 200 && Array.isArray(periodsList)) {
     // Look for an existing active period
-    const activePeriod = listResponse.data.find((p: any) => p.status === 'active');
+    const activePeriod = periodsList.find((p: any) => p.status === 'active');
     if (activePeriod) {
       world.context.createdReportingPeriodId = activePeriod.id;
       world.context.createdPeriodName = activePeriod.name;
@@ -23,7 +24,7 @@ async function ensureActivePeriod(world: CustomWorld, periodName: string): Promi
     }
 
     // Look for a locked period we can unlock
-    const lockedPeriod = listResponse.data.find((p: any) => p.status === 'locked');
+    const lockedPeriod = periodsList.find((p: any) => p.status === 'locked');
     if (lockedPeriod) {
       await world.apiClient.patch(`${ENDPOINTS.REPORTING_PERIODS}/${lockedPeriod.id}/unlock`);
       world.context.createdReportingPeriodId = lockedPeriod.id;
@@ -67,9 +68,10 @@ async function ensureLockedPeriod(world: CustomWorld, periodName: string): Promi
     `${ENDPOINTS.REPORTING_PERIODS}?entityId=${entityId}`,
   );
 
-  if (listResponse.status === 200 && Array.isArray(listResponse.data)) {
+  const periodsList = listResponse.data?.data || listResponse.data;
+  if (listResponse.status === 200 && Array.isArray(periodsList)) {
     // Look for an existing locked period
-    const lockedPeriod = listResponse.data.find((p: any) => p.status === 'locked');
+    const lockedPeriod = periodsList.find((p: any) => p.status === 'locked');
     if (lockedPeriod) {
       world.context.createdReportingPeriodId = lockedPeriod.id;
       world.context.createdPeriodName = lockedPeriod.name;
@@ -79,7 +81,7 @@ async function ensureLockedPeriod(world: CustomWorld, periodName: string): Promi
     }
 
     // Look for an active period we can lock
-    const activePeriod = listResponse.data.find((p: any) => p.status === 'active');
+    const activePeriod = periodsList.find((p: any) => p.status === 'active');
     if (activePeriod) {
       await world.apiClient.patch(`${ENDPOINTS.REPORTING_PERIODS}/${activePeriod.id}/lock`);
       world.context.createdReportingPeriodId = activePeriod.id;
@@ -101,7 +103,7 @@ Given('my organization has team members who log activities', async function (thi
   // Verify we have users in the system
   const response = await this.apiClient.get(ENDPOINTS.ADMIN_USERS);
   expect(response.status).toBe(200);
-  expect(Array.isArray(response.data)).toBe(true);
+  expect(Array.isArray(response.data?.data || response.data)).toBe(true);
 });
 
 Given('there are no active reporting periods', async function (this: CustomWorld) {
@@ -110,8 +112,9 @@ Given('there are no active reporting periods', async function (this: CustomWorld
     `${ENDPOINTS.REPORTING_PERIODS}?entityId=${this.context.entityId}`,
   );
 
-  if (listResponse.status === 200 && Array.isArray(listResponse.data)) {
-    for (const period of listResponse.data) {
+  const periodsList = listResponse.data?.data || listResponse.data;
+  if (listResponse.status === 200 && Array.isArray(periodsList)) {
+    for (const period of periodsList) {
       if (period.status === 'active') {
         await this.apiClient.patch(`${ENDPOINTS.REPORTING_PERIODS}/${period.id}/lock`);
       }
@@ -176,8 +179,9 @@ Then('the period should be visible to all team members', async function (this: C
     `${ENDPOINTS.REPORTING_PERIODS}?entityId=${this.context.entityId}`,
   );
   expect(response.status).toBe(200);
-  expect(Array.isArray(response.data)).toBe(true);
-  expect(response.data.length).toBeGreaterThan(0);
+  const periodsList = response.data?.data || response.data;
+  expect(Array.isArray(periodsList)).toBe(true);
+  expect(periodsList.length).toBeGreaterThan(0);
 });
 
 Then('no more activities can be added to this period', function (this: CustomWorld) {

--- a/e2e/step-definitions/journeys/pastor/reports-and-analytics.steps.ts
+++ b/e2e/step-definitions/journeys/pastor/reports-and-analytics.steps.ts
@@ -7,16 +7,18 @@ import { ENDPOINTS } from '../../../support/api/api-client';
 
 async function ensureActivityType(world: CustomWorld, typeName: string): Promise<string> {
   const response = await world.apiClient.get(ENDPOINTS.ACTIVITY_TYPES);
+  const activityTypesList = response.data?.data || response.data;
 
-  if (response.status === 200 && Array.isArray(response.data)) {
-    const existing = response.data.find((t: any) => t.name.includes(typeName));
+  if (response.status === 200 && Array.isArray(activityTypesList)) {
+    const existing = activityTypesList.find((t: any) => t.name.includes(typeName));
     if (existing) {
       return existing.id;
     }
   }
 
   const rolesResponse = await world.apiClient.get(ENDPOINTS.ROLES);
-  const roleId = rolesResponse.data?.[0]?.id;
+  const rolesList = rolesResponse.data?.data || rolesResponse.data;
+  const roleId = rolesList?.[0]?.id;
 
   const timestamp = Date.now();
   const createResponse = await world.apiClient.post(ENDPOINTS.ACTIVITY_TYPES, {
@@ -43,8 +45,9 @@ async function ensureCompletedPeriodWithActivities(world: CustomWorld): Promise<
   let periodId: string;
   let startDate: string;
 
-  if (listResponse.status === 200 && Array.isArray(listResponse.data)) {
-    const lockedPeriod = listResponse.data.find((p: any) => p.status === 'locked');
+  const listData = listResponse.data?.data || listResponse.data;
+  if (listResponse.status === 200 && Array.isArray(listData)) {
+    const lockedPeriod = listData.find((p: any) => p.status === 'locked');
     if (lockedPeriod) {
       periodId = lockedPeriod.id;
       startDate = lockedPeriod.startDate;
@@ -54,7 +57,7 @@ async function ensureCompletedPeriodWithActivities(world: CustomWorld): Promise<
     }
 
     // Use active period and lock it after adding activities
-    const activePeriod = listResponse.data.find((p: any) => p.status === 'active');
+    const activePeriod = listData.find((p: any) => p.status === 'active');
     if (activePeriod) {
       periodId = activePeriod.id;
       startDate = activePeriod.startDate;
@@ -110,7 +113,8 @@ async function ensureMultiplePeriods(world: CustomWorld): Promise<void> {
     `${ENDPOINTS.REPORTING_PERIODS}?entityId=${entityId}`,
   );
 
-  if (listResponse.status === 200 && Array.isArray(listResponse.data) && listResponse.data.length >= 2) {
+  const multiPeriodsList = listResponse.data?.data || listResponse.data;
+  if (listResponse.status === 200 && Array.isArray(multiPeriodsList) && multiPeriodsList.length >= 2) {
     // Already have multiple periods
     return;
   }


### PR DESCRIPTION
## Overview
Implements standardized pagination across all list endpoints in the application, improving performance and user experience when dealing with large datasets.

## Changes
### New Features
-Created reusable `PaginationQueryDto` for consistent pagination parameters
-Added pagination utility functions (`normalizePagination`, `buildPagination`)
- Updated all list endpoints to support pagination with `page` and `limit` query parameters
- Returns paginated responses with metadata (`page`, `limit`, `total`, `totalPages`)

### Core Utilities
**`PaginationQueryDto`**
- `page`: Page number (default: 1, min: 1)
- `limit`: Items per page (default: 20, min: 1, max: 100)
- Includes validation and Swagger documentation

**Pagination Helpers**
- `normalizePagination()`: Normalizes and validates pagination parameters
- `buildPagination()`: Generates pagination metadata for responses

### Updated Modules
- **Activity Types** - `activity-types.controller.ts`, `activity-types.service.ts`
- **Entities** - `entities.controller.ts`, `entities.service.ts`
- **Reporting Periods** - `reporting-periods.controller.ts`, `reporting-periods.service.ts`
- **Roles** - `roles.controller.ts`, `roles.service.ts`
- **Users** - `admin-users.controller.ts`, `users.service.ts`