### PR TITLE
refactor: Replace RoleEnum with roleId-based role assignment

### DIFF
--- a/backend/src/entities/tests/roles.controller.spec.ts
+++ b/backend/src/entities/tests/roles.controller.spec.ts
@@ -4,7 +4,7 @@ import { RolesService } from '../../roles/roles.service';
 import { RoleAssignmentService } from '../../roles/role-assignment.service';
 import { CreateRoleDto } from '../../roles/dto/create-role.dto';
 import { UpdateRoleDto } from '../../roles/dto/update-role.dto';
-import { AssignRoleDto, RoleEnum } from '../../roles/dto/assign-role.dto';
+import { AssignRoleDto } from '../../roles/dto/assign-role.dto';
 import { RemoveRoleDto } from '../../roles/dto/remove-role.dto';
 import { PermissionsService } from '../../auth/permissions/permissions.service';
 import { RolesGuard } from '../../auth/roles.guard';
@@ -105,8 +105,8 @@ describe('RolesController', () => {
     const users = [{ id: 'u1' }, { id: 'u2' }];
     roleAssignmentService.listUsersByRole.mockResolvedValue(users as any);
 
-    const res = await controller.usersByRole(RoleEnum.PASTOR);
-    expect(roleAssignmentService.listUsersByRole).toHaveBeenCalledWith(RoleEnum.PASTOR);
+    const res = await controller.usersByRole('PASTOR');
+    expect(roleAssignmentService.listUsersByRole).toHaveBeenCalledWith('PASTOR');
     expect(res).toEqual(users);
   });
 
@@ -123,7 +123,7 @@ describe('RolesController', () => {
   it('assign -> should create assignment', async () => {
     const dto: AssignRoleDto = {
       userId: '22222222-2222-2222-2222-222222222222',
-      role: RoleEnum.PASTOR,
+      roleId: '44444444-4444-4444-4444-444444444444',
       entityId: '33333333-3333-3333-3333-333333333333',
     };
     const created = { id: 'assign-1' };

--- a/backend/src/roles/dto/assign-role.dto.ts
+++ b/backend/src/roles/dto/assign-role.dto.ts
@@ -1,15 +1,5 @@
-import { IsUUID, IsEnum, IsOptional, IsDateString } from 'class-validator';
-import { Transform } from 'class-transformer';
+import { IsUUID, IsOptional, IsDateString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-
-export enum RoleEnum {
-  ADMIN = 'ADMIN',
-  MISSIONARY = 'MISSIONARY',
-  PASTOR = 'PASTOR',
-  MINISTER = 'MINISTER',
-  EXECUTIVE = 'EXECUTIVE',
-  DEPARTMENTAL = 'DEPARTMENTAL',
-}
 
 export class AssignRoleDto {
   @ApiProperty({
@@ -20,15 +10,11 @@ export class AssignRoleDto {
   userId!: string;
 
   @ApiProperty({
-    description: 'Role to assign',
-    enum: RoleEnum,
-    example: 'MISSIONARY',
+    description: 'UUID of the role to assign',
+    example: '123e4567-e89b-12d3-a456-426614174000',
   })
-  @Transform(({ value }) => String(value).trim().toUpperCase())
-  @IsEnum(RoleEnum, {
-    message: 'Invalid role enum value. Allowed: ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE, DEPARTMENTAL',
-  })
-  role!: RoleEnum;
+  @IsUUID()
+  roleId!: string;
 
   @ApiProperty({
     description: 'UUID of the entity where the role applies',

--- a/backend/src/roles/dto/bulk-assign-role.dto.ts
+++ b/backend/src/roles/dto/bulk-assign-role.dto.ts
@@ -1,6 +1,4 @@
-import { IsUUID, IsEnum, IsArray, ArrayNotEmpty, IsOptional, IsDateString } from 'class-validator';
-import { Transform } from 'class-transformer';
-import { RoleEnum } from './assign-role.dto';
+import { IsUUID, IsArray, ArrayNotEmpty, IsOptional, IsDateString } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class BulkAssignRoleDto {
@@ -12,15 +10,11 @@ export class BulkAssignRoleDto {
   userId!: string;
 
   @ApiProperty({
-    description: 'Role to assign',
-    enum: RoleEnum,
-    example: 'MISSIONARY',
+    description: 'UUID of the role to assign',
+    example: '123e4567-e89b-12d3-a456-426614174000',
   })
-  @Transform(({ value }) => String(value).trim().toUpperCase())
-  @IsEnum(RoleEnum, {
-    message: 'Invalid role enum value. Allowed: ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE, DEPARTMENTAL',
-  })
-  role!: RoleEnum;
+  @IsUUID()
+  roleId!: string;
 
   @ApiProperty({
     description: 'Array of entity UUIDs to assign the role for',

--- a/backend/src/roles/dto/get-user-entities-by-role.dto.ts
+++ b/backend/src/roles/dto/get-user-entities-by-role.dto.ts
@@ -1,6 +1,4 @@
-import { IsUUID, IsEnum } from 'class-validator';
-import { Transform } from 'class-transformer';
-import { RoleEnum } from './assign-role.dto';
+import { IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class GetUserEntitiesByRoleDto {
@@ -12,13 +10,9 @@ export class GetUserEntitiesByRoleDto {
   userId!: string;
 
   @ApiProperty({
-    description: 'Role to filter by',
-    enum: RoleEnum,
-    example: 'MISSIONARY',
+    description: 'UUID of the role to filter by',
+    example: '123e4567-e89b-12d3-a456-426614174000',
   })
-  @Transform(({ value }) => String(value).trim().toUpperCase())
-  @IsEnum(RoleEnum, {
-    message: 'Invalid role enum value. Allowed: ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE, DEPARTMENTAL',
-  })
-  role!: RoleEnum;
+  @IsUUID()
+  roleId!: string;
 }

--- a/backend/src/roles/role-assignment.service.ts
+++ b/backend/src/roles/role-assignment.service.ts
@@ -13,7 +13,7 @@ import { Role } from './role.entity';
 import { Entity as OrgEntity } from '../entities/entity.entity';
 
 import { UserRoleAssignment } from './user-role-assignment.entity';
-import { AssignRoleDto, RoleEnum } from './dto/assign-role.dto';
+import { AssignRoleDto } from './dto/assign-role.dto';
 import { RemoveRoleDto } from './dto/remove-role.dto';
 import { BulkAssignRoleDto } from './dto/bulk-assign-role.dto';
 import { GetUserEntitiesByRoleDto } from './dto/get-user-entities-by-role.dto';
@@ -74,10 +74,7 @@ export class RoleAssignmentService {
       throw new BadRequestException('Cannot assign roles to inactive users');
     }
 
-    if (!Object.values(RoleEnum).includes(dto.role)) {
-      throw new BadRequestException('Invalid role enum value');
-    }
-    const role = await this.rolesRepo.findOne({ where: { name: ILike(dto.role) } });
+    const role = await this.rolesRepo.findOne({ where: { id: dto.roleId } });
     if (!role) throw new NotFoundException('Role not found');
 
     const entity = await this.entitiesRepo.findOne({ where: { id: dto.entityId } });
@@ -151,10 +148,7 @@ export class RoleAssignmentService {
       throw new BadRequestException('Cannot assign roles to inactive users');
     }
 
-    if (!Object.values(RoleEnum).includes(dto.role)) {
-      throw new BadRequestException('Invalid role enum value');
-    }
-    const role = await this.rolesRepo.findOne({ where: { name: ILike(dto.role) } });
+    const role = await this.rolesRepo.findOne({ where: { id: dto.roleId } });
     if (!role) throw new NotFoundException('Role not found');
 
     const entities = await this.entitiesRepo.find({
@@ -229,7 +223,7 @@ export class RoleAssignmentService {
     const user = await this.usersRepo.findOne({ where: { id: dto.userId } });
     if (!user) throw new NotFoundException('User not found');
 
-    const role = await this.rolesRepo.findOne({ where: { name: ILike(dto.role) } });
+    const role = await this.rolesRepo.findOne({ where: { id: dto.roleId } });
     if (!role) throw new NotFoundException('Role not found');
 
     const assignments = await this.uraRepo.find({

--- a/backend/src/roles/roles.controller.ts
+++ b/backend/src/roles/roles.controller.ts
@@ -20,7 +20,7 @@ import { UpdateRoleDto } from './dto/update-role.dto';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { RoleAssignmentService } from './role-assignment.service';
-import { AssignRoleDto, RoleEnum } from './dto/assign-role.dto';
+import { AssignRoleDto } from './dto/assign-role.dto';
 import { RemoveRoleDto } from './dto/remove-role.dto';
 import { BulkAssignRoleDto } from './dto/bulk-assign-role.dto';
 import { GetUserEntitiesByRoleDto } from './dto/get-user-entities-by-role.dto';

--- a/backend/src/roles/tests/role-assignment-historical.spec.ts
+++ b/backend/src/roles/tests/role-assignment-historical.spec.ts
@@ -8,7 +8,7 @@ import { User } from '../../users/user.entity';
 import { Role } from '../role.entity';
 import { Entity as OrgEntity } from '../../entities/entity.entity';
 import { UserStatus } from '../../users/user-status.enum';
-import { AssignRoleDto, RoleEnum } from '../dto/assign-role.dto';
+import { AssignRoleDto } from '../dto/assign-role.dto';
 
 describe('RoleAssignmentService - Historical Tracking', () => {
   let service: RoleAssignmentService;
@@ -101,7 +101,7 @@ describe('RoleAssignmentService - Historical Tracking', () => {
     it('should set start_date to today and calculate end_date when not provided', async () => {
       const dto: AssignRoleDto = {
         userId: 'user-id',
-        role: RoleEnum.MISSIONARY,
+        roleId: 'role-id',
         entityId: 'entity-id',
       };
 
@@ -149,7 +149,7 @@ describe('RoleAssignmentService - Historical Tracking', () => {
     it('should use provided start_date and calculate correct end_date', async () => {
       const dto: AssignRoleDto = {
         userId: 'user-id',
-        role: RoleEnum.MISSIONARY,
+        roleId: 'role-id',
         entityId: 'entity-id',
         startDate: '2025-01-01',
       };

--- a/backend/src/roles/tests/role-assignment-validations.spec.ts
+++ b/backend/src/roles/tests/role-assignment-validations.spec.ts
@@ -8,7 +8,7 @@ import { User } from '../../users/user.entity';
 import { Role } from '../role.entity';
 import { Entity as OrgEntity } from '../../entities/entity.entity';
 import { UserStatus } from '../../users/user-status.enum';
-import { AssignRoleDto, RoleEnum } from '../dto/assign-role.dto';
+import { AssignRoleDto } from '../dto/assign-role.dto';
 
 describe('RoleAssignmentService - Validations', () => {
   let service: RoleAssignmentService;
@@ -101,7 +101,7 @@ describe('RoleAssignmentService - Validations', () => {
     it('should prevent creating overlapping assignments with exact same dates', async () => {
       const dto: AssignRoleDto = {
         userId: 'user-id',
-        role: RoleEnum.MISSIONARY,
+        roleId: 'role-id',
         entityId: 'entity-id',
         startDate: '2025-01-01',
       };
@@ -132,12 +132,13 @@ describe('RoleAssignmentService - Validations', () => {
           'An overlapping assignment already exists for this user, role, and entity from 2025-01-01 to 2029-12-31',
         ),
       );
+      expect(rolesRepo.findOne).toHaveBeenCalledWith({ where: { id: dto.roleId } });
     });
 
     it('should prevent creating assignment that starts during existing assignment', async () => {
       const dto: AssignRoleDto = {
         userId: 'user-id',
-        role: RoleEnum.MISSIONARY,
+        roleId: 'role-id',
         entityId: 'entity-id',
         startDate: '2026-06-01', // Starts during existing 2025-2029 assignment
       };
@@ -168,7 +169,7 @@ describe('RoleAssignmentService - Validations', () => {
     it('should prevent creating assignment that ends during existing assignment', async () => {
       const dto: AssignRoleDto = {
         userId: 'user-id',
-        role: RoleEnum.MISSIONARY,
+        roleId: 'role-id',
         entityId: 'entity-id',
         startDate: '2024-01-01', // Would end 2028-12-31, overlapping with 2025-2029
       };
@@ -199,7 +200,7 @@ describe('RoleAssignmentService - Validations', () => {
     it('should prevent creating assignment that completely overlaps existing assignment', async () => {
       const dto: AssignRoleDto = {
         userId: 'user-id',
-        role: RoleEnum.MISSIONARY,
+        roleId: 'role-id',
         entityId: 'entity-id',
         startDate: '2024-01-01', // 2024-2028 completely overlaps 2025-2027
       };
@@ -230,7 +231,7 @@ describe('RoleAssignmentService - Validations', () => {
     it('should allow creating assignment that starts after existing assignment ends', async () => {
       const dto: AssignRoleDto = {
         userId: 'user-id',
-        role: RoleEnum.MISSIONARY,
+        roleId: 'role-id',
         entityId: 'entity-id',
         startDate: '2030-01-01', // Starts after existing ends
       };
@@ -261,7 +262,7 @@ describe('RoleAssignmentService - Validations', () => {
     it('should allow creating assignment that ends before existing assignment starts', async () => {
       const dto: AssignRoleDto = {
         userId: 'user-id',
-        role: RoleEnum.MISSIONARY,
+        roleId: 'role-id',
         entityId: 'entity-id',
         startDate: '2020-01-01', // Ends 2024-12-31, before existing starts
       };
@@ -292,7 +293,7 @@ describe('RoleAssignmentService - Validations', () => {
     it('should allow same user to have same role in different entities', async () => {
       const dto: AssignRoleDto = {
         userId: 'user-id',
-        role: RoleEnum.MISSIONARY,
+        roleId: 'role-id',
         entityId: 'different-entity-id',
         startDate: '2025-01-01',
       };
@@ -320,6 +321,21 @@ describe('RoleAssignmentService - Validations', () => {
       });
 
       await expect(service.assign(dto)).resolves.toBeDefined();
+    });
+
+    it('should throw NotFoundException when role id does not exist', async () => {
+      const dto: AssignRoleDto = {
+        userId: 'user-id',
+        roleId: 'missing-role-id',
+        entityId: 'entity-id',
+        startDate: '2025-01-01',
+      };
+
+      usersRepo.findOne.mockResolvedValue(mockUser);
+      rolesRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.assign(dto)).rejects.toThrow('Role not found');
+      expect(rolesRepo.findOne).toHaveBeenCalledWith({ where: { id: dto.roleId } });
     });
   });
 


### PR DESCRIPTION
## Overview
Refactors the role assignment system from hardcoded enum strings to database-driven UUID references, enabling dynamic role management and eliminating the need for code changes when adding or modifying roles.

## Problem Statement
The previous implementation relied on a hardcoded `RoleEnum` with six fixed values (ADMIN, MISSIONARY, PASTOR, MINISTER, EXECUTIVE, DEPARTMENTAL). This design had several critical limitations:

- **Inflexible**: Adding a new role required modifying code, running tests, and deploying the application
- **Performance**: Used case-insensitive string matching (`ILIKE`) instead of indexed UUID lookups
- **Coupling**: Business data (role names) was hardcoded in application logic
- **Scalability**: Limited to predefined roles, couldn't adapt to organizational changes
- **Maintenance**: Role names embedded across codebase created multiple points of failure

## Solution
This refactor treats roles as first-class database entities referenced by UUID, similar to how users and entities are handled throughout the application.