### PR TITLE
feat: Leadership Dashboard with proper error handling and permission gating

### DIFF
--- a/backend/src/reports/dto/report-query.dto.spec.ts
+++ b/backend/src/reports/dto/report-query.dto.spec.ts
@@ -1,0 +1,21 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { RankingsQueryDto } from './report-query.dto';
+
+describe('RankingsQueryDto', () => {
+  it('accepts topN as a valid legacy query parameter', async () => {
+    const dto = plainToInstance(RankingsQueryDto, { topN: '10' });
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.topN).toBe(10);
+  });
+
+  it('prioritizes limit when both limit and topN are provided', async () => {
+    const dto = plainToInstance(RankingsQueryDto, { limit: '7', topN: '10' });
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+    expect(dto.limit).toBe(7);
+  });
+});

--- a/backend/src/reports/dto/report-query.dto.ts
+++ b/backend/src/reports/dto/report-query.dto.ts
@@ -135,5 +135,15 @@ export class RankingsQueryDto extends ReportQueryDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
-  limit?: number = 5;
+  limit?: number;
+
+  @ApiPropertyOptional({
+    description: 'Legacy alias for limit',
+    minimum: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  topN?: number;
 }

--- a/backend/src/reports/reports.service.spec.ts
+++ b/backend/src/reports/reports.service.spec.ts
@@ -596,6 +596,108 @@ describe('ReportsService', () => {
       expect(result.periods[0].activities).toBe(1);
       expect(result.periods[0].expenses).toBe(50);
     });
+
+    it('should return empty trends when no reporting periods exist', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { rolePermissions: [] },
+        entity: { id: 'entity-1' },
+      };
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(periodRepo, 'find').mockResolvedValue([]);
+
+      const result = await service.getTrends('user-1', {});
+
+      expect(result).toEqual({ periods: [] });
+      expect(queryFactory.buildActivityQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getComparison', () => {
+    it('should return empty comparison when fewer than 2 reporting periods exist', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { rolePermissions: [] },
+        entity: { id: 'entity-1' },
+      };
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(periodRepo, 'find').mockResolvedValue([
+        {
+          id: 'period-1',
+          startDate: '2024-12-01',
+          endDate: '2024-12-14',
+          entityId: 'entity-1',
+        },
+      ] as any);
+
+      const result = await service.getComparison('user-1', {});
+
+      expect(result.current.periodId).toBe('');
+      expect(result.previous.periodId).toBe('');
+      expect(result.current.activities).toBe(0);
+      expect(result.previous.activities).toBe(0);
+      expect(result.changes.activities.value).toBe(0);
+      expect(queryFactory.buildActivityQuery).not.toHaveBeenCalled();
+    });
+
+    it('should compare by periodType boundaries when provided', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { rolePermissions: [] },
+        entity: { id: 'entity-1' },
+      };
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest.spyOn(periodRepo, 'find').mockResolvedValue([]);
+      jest
+        .spyOn(userRepo, 'find')
+        .mockResolvedValue([{ id: 'user-1', status: 'active', entity_id: 'entity-1' }] as any);
+      mockQueryBuilder.getMany
+        .mockResolvedValueOnce([{ id: 'a1', userId: 'user-1', expenseAmount: '10.00' }] as any)
+        .mockResolvedValueOnce([{ id: 'a2', userId: 'user-1', expenseAmount: '5.00' }] as any);
+
+      const result = await service.getComparison('user-1', {
+        periodType: 'monthly' as any,
+        year: 2026,
+        month: 2,
+      });
+
+      expect(result.current.periodId).toContain('current-monthly-2026-2');
+      expect(result.previous.periodId).toContain('previous-monthly-2026-1');
+      expect(queryFactory.buildActivityQuery).toHaveBeenCalledTimes(2);
+      expect(periodRepo.find).not.toHaveBeenCalled();
+    });
+
+    it('should compare provided date range with immediately previous range', async () => {
+      const mockUser = {
+        id: 'user-1',
+        entity_id: 'entity-1',
+        role: { rolePermissions: [] },
+        entity: { id: 'entity-1' },
+      };
+
+      jest.spyOn(userRepo, 'findOne').mockResolvedValue(mockUser as any);
+      jest
+        .spyOn(userRepo, 'find')
+        .mockResolvedValue([{ id: 'user-1', status: 'active', entity_id: 'entity-1' }] as any);
+      mockQueryBuilder.getMany
+        .mockResolvedValueOnce([{ id: 'a1', userId: 'user-1', expenseAmount: '10.00' }] as any)
+        .mockResolvedValueOnce([{ id: 'a2', userId: 'user-1', expenseAmount: '5.00' }] as any);
+
+      const result = await service.getComparison('user-1', {
+        dateFrom: '2026-02-01',
+        dateTo: '2026-02-28',
+      });
+
+      expect(result.current.periodId).toContain('current-range-2026-02-01-2026-02-28');
+      expect(result.previous.periodId).toContain('previous-range-2026-01-04-2026-01-31');
+      expect(queryFactory.buildActivityQuery).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('getRankings', () => {

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -102,6 +102,130 @@ export class ReportsService {
     };
   }
 
+  private buildEmptyComparisonResponse(): ComparisonResponse {
+    return {
+      current: {
+        periodId: '',
+        dates: '',
+        activities: 0,
+        expenses: 0,
+        complianceRate: 0,
+        usersActive: 0,
+      },
+      previous: {
+        periodId: '',
+        dates: '',
+        activities: 0,
+        expenses: 0,
+        complianceRate: 0,
+        usersActive: 0,
+      },
+      changes: {
+        activities: { value: 0, percent: 0 },
+        expenses: { value: 0, percent: 0 },
+        complianceRate: { value: 0, percent: 0 },
+        usersActive: { value: 0, percent: 0 },
+      },
+    };
+  }
+
+  private createComparisonPeriod(start: Date, end: Date, id: string): ReportingPeriod {
+    return {
+      id,
+      entityId: '',
+      entity: {} as any,
+      name: id,
+      description: null,
+      startDate: start.toISOString().split('T')[0],
+      endDate: end.toISOString().split('T')[0],
+      status: 'active' as any,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      createdBy: '',
+      updatedBy: '',
+      isLocked: false,
+      containsDate: () => false,
+      activities: [],
+    } as ReportingPeriod;
+  }
+
+  private resolveComparisonDateRanges(query: ReportQueryDto): {
+    current: { start: Date; end: Date; id: string };
+    previous: { start: Date; end: Date; id: string };
+  } | null {
+    if (query.periodType && query.year) {
+      const periodIndex = this.periodBoundaryCalculator.getPeriodIndexFromQuery(
+        query.periodType,
+        query.month,
+        query.quarter,
+        query.half,
+      );
+
+      const current = this.periodBoundaryCalculator.calculateBoundaries(
+        query.periodType,
+        query.year,
+        periodIndex,
+      );
+      const previousRef = this.periodBoundaryCalculator.getPreviousPeriod(
+        query.periodType,
+        query.year,
+        periodIndex,
+      );
+      const previous = this.periodBoundaryCalculator.calculateBoundaries(
+        query.periodType,
+        previousRef.year,
+        previousRef.periodIndex,
+      );
+
+      return {
+        current: {
+          start: current.dateFrom,
+          end: current.dateTo,
+          id: `current-${query.periodType}-${query.year}-${periodIndex}`,
+        },
+        previous: {
+          start: previous.dateFrom,
+          end: previous.dateTo,
+          id: `previous-${query.periodType}-${previousRef.year}-${previousRef.periodIndex}`,
+        },
+      };
+    }
+
+    if (query.dateFrom && query.dateTo) {
+      const currentStart = new Date(`${query.dateFrom}T00:00:00.000Z`);
+      const currentEnd = new Date(`${query.dateTo}T23:59:59.999Z`);
+
+      if (Number.isNaN(currentStart.getTime()) || Number.isNaN(currentEnd.getTime())) {
+        throw new BadRequestException('Invalid date range for comparison');
+      }
+      if (currentStart > currentEnd) {
+        throw new BadRequestException('dateFrom must be before or equal to dateTo');
+      }
+
+      const totalDays =
+        Math.floor((currentEnd.getTime() - currentStart.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+      const previousEnd = new Date(currentStart);
+      previousEnd.setUTCDate(previousEnd.getUTCDate() - 1);
+      const previousStart = new Date(previousEnd);
+      previousStart.setUTCDate(previousStart.getUTCDate() - (totalDays - 1));
+
+      return {
+        current: {
+          start: currentStart,
+          end: currentEnd,
+          id: `current-range-${query.dateFrom}-${query.dateTo}`,
+        },
+        previous: {
+          start: previousStart,
+          end: previousEnd,
+          id: `previous-range-${previousStart.toISOString().split('T')[0]}-${previousEnd.toISOString().split('T')[0]}`,
+        },
+      };
+    }
+
+    return null;
+  }
+
   async getSummary(actorUserId: string, query: ReportQueryDto): Promise<SummaryResponse> {
     const actor = await this.userRepo.findOne({
       where: { id: actorUserId },
@@ -299,7 +423,7 @@ export class ReportsService {
     });
 
     if (periods.length === 0) {
-      throw new NotFoundException('No reporting periods found');
+      return { periods: [] };
     }
 
     const { entityIds, filterUserId, isUserFiltered } = await this.resolveReportScope(
@@ -351,39 +475,81 @@ export class ReportsService {
       throw new ForbiddenException('You do not have permission to view entity reports');
     }
 
-    const periods = await this.periodRepo.find({
-      where: { entityId: targetEntityId },
-      order: { startDate: 'DESC' },
-      take: 2,
-    });
-
-    if (periods.length < 2) {
-      throw new BadRequestException('Not enough periods for comparison');
-    }
-
-    const [currentPeriod, previousPeriod] = periods;
     const { entityIds, filterUserId, isUserFiltered } = await this.resolveReportScope(
       actorUserId,
       query,
       canViewReports,
       targetEntityId,
     );
+    const resolvedRanges = this.resolveComparisonDateRanges(query);
 
-    const currentQb = this.queryFactory.buildActivityQuery(
-      actorUserId,
-      entityIds,
-      { periodIds: [currentPeriod.id] },
-      filterUserId,
-    );
-    const currentActivities = await currentQb.getMany();
+    let currentPeriod: ReportingPeriod;
+    let previousPeriod: ReportingPeriod;
+    let currentActivities: Activity[];
+    let previousActivities: Activity[];
 
-    const previousQb = this.queryFactory.buildActivityQuery(
-      actorUserId,
-      entityIds,
-      { periodIds: [previousPeriod.id] },
-      filterUserId,
-    );
-    const previousActivities = await previousQb.getMany();
+    if (resolvedRanges) {
+      currentPeriod = this.createComparisonPeriod(
+        resolvedRanges.current.start,
+        resolvedRanges.current.end,
+        resolvedRanges.current.id,
+      );
+      previousPeriod = this.createComparisonPeriod(
+        resolvedRanges.previous.start,
+        resolvedRanges.previous.end,
+        resolvedRanges.previous.id,
+      );
+
+      const currentQb = this.queryFactory.buildActivityQuery(
+        actorUserId,
+        entityIds,
+        {
+          dateFrom: resolvedRanges.current.start.toISOString(),
+          dateTo: resolvedRanges.current.end.toISOString(),
+        },
+        filterUserId,
+      );
+      currentActivities = await currentQb.getMany();
+
+      const previousQb = this.queryFactory.buildActivityQuery(
+        actorUserId,
+        entityIds,
+        {
+          dateFrom: resolvedRanges.previous.start.toISOString(),
+          dateTo: resolvedRanges.previous.end.toISOString(),
+        },
+        filterUserId,
+      );
+      previousActivities = await previousQb.getMany();
+    } else {
+      const periods = await this.periodRepo.find({
+        where: { entityId: targetEntityId },
+        order: { startDate: 'DESC' },
+        take: 2,
+      });
+
+      if (periods.length < 2) {
+        return this.buildEmptyComparisonResponse();
+      }
+
+      [currentPeriod, previousPeriod] = periods;
+
+      const currentQb = this.queryFactory.buildActivityQuery(
+        actorUserId,
+        entityIds,
+        { periodIds: [currentPeriod.id] },
+        filterUserId,
+      );
+      currentActivities = await currentQb.getMany();
+
+      const previousQb = this.queryFactory.buildActivityQuery(
+        actorUserId,
+        entityIds,
+        { periodIds: [previousPeriod.id] },
+        filterUserId,
+      );
+      previousActivities = await previousQb.getMany();
+    }
 
     return this.comparisonCalculator.calculate(
       currentPeriod,
@@ -424,7 +590,7 @@ export class ReportsService {
 
     const entityIds = await this.accessService.getEntityHierarchy(targetEntityId);
     const timeScope = await this.timeScopeService.getOrDetermineTimeScope(query, actor.entity_id);
-    const limit = query.limit || 5;
+    const limit = query.limit ?? query.topN ?? 5;
 
     const qb = this.queryFactory.buildActivityQuery(actorUserId, entityIds, timeScope);
     const activities = await qb.getMany();

--- a/frontend/lib/models/leadership_dashboard_data.dart
+++ b/frontend/lib/models/leadership_dashboard_data.dart
@@ -1,0 +1,15 @@
+import 'leadership_reports.dart';
+
+class LeadershipDashboardData {
+  final TrendsResponse trends;
+  final ComparisonResponse comparison;
+  final RankingsResponse rankings;
+  final ExpensesResponse expenses;
+
+  const LeadershipDashboardData({
+    required this.trends,
+    required this.comparison,
+    required this.rankings,
+    required this.expenses,
+  });
+}

--- a/frontend/lib/models/leadership_reports.dart
+++ b/frontend/lib/models/leadership_reports.dart
@@ -105,8 +105,9 @@ class Change {
     );
   }
 
-  bool get isPositive => value >= 0;
+  bool get isPositive => value > 0;
   bool get isNegative => value < 0;
+  bool get isNeutral => value == 0;
 }
 
 class ComparisonChanges {

--- a/frontend/lib/models/leadership_reports.dart
+++ b/frontend/lib/models/leadership_reports.dart
@@ -146,10 +146,8 @@ class ComparisonResponse {
 
   factory ComparisonResponse.fromApi(Map<String, dynamic> data) {
     return ComparisonResponse(
-      current:
-          PeriodSummary.fromApi(data['current'] as Map<String, dynamic>),
-      previous:
-          PeriodSummary.fromApi(data['previous'] as Map<String, dynamic>),
+      current: PeriodSummary.fromApi(data['current'] as Map<String, dynamic>),
+      previous: PeriodSummary.fromApi(data['previous'] as Map<String, dynamic>),
       changes:
           ComparisonChanges.fromApi(data['changes'] as Map<String, dynamic>),
     );

--- a/frontend/lib/models/leadership_reports.dart
+++ b/frontend/lib/models/leadership_reports.dart
@@ -1,0 +1,410 @@
+/// Models for leadership dashboard endpoints:
+/// - Trends
+/// - Comparison
+/// - Rankings
+/// - Expenses
+
+/// Trends Response Models
+class TrendPeriod {
+  final String periodId;
+  final String startDate;
+  final String endDate;
+  final int activities;
+  final double expenses;
+  final double complianceRate;
+  final int usersSubmitted;
+  final int usersExpected;
+
+  const TrendPeriod({
+    required this.periodId,
+    required this.startDate,
+    required this.endDate,
+    required this.activities,
+    required this.expenses,
+    required this.complianceRate,
+    required this.usersSubmitted,
+    required this.usersExpected,
+  });
+
+  factory TrendPeriod.fromApi(Map<String, dynamic> data) {
+    return TrendPeriod(
+      periodId: data['periodId'] as String? ?? '',
+      startDate: data['startDate'] as String? ?? '',
+      endDate: data['endDate'] as String? ?? '',
+      activities: (data['activities'] as num?)?.toInt() ?? 0,
+      expenses: (data['expenses'] as num?)?.toDouble() ?? 0.0,
+      complianceRate: (data['complianceRate'] as num?)?.toDouble() ?? 0.0,
+      usersSubmitted: (data['usersSubmitted'] as num?)?.toInt() ?? 0,
+      usersExpected: (data['usersExpected'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+class TrendsResponse {
+  final List<TrendPeriod> periods;
+
+  const TrendsResponse({required this.periods});
+
+  factory TrendsResponse.fromApi(Map<String, dynamic> data) {
+    final periodsData = data['periods'] as List<dynamic>? ?? [];
+    final periods = periodsData
+        .map((period) => TrendPeriod.fromApi(period as Map<String, dynamic>))
+        .toList();
+
+    return TrendsResponse(periods: periods);
+  }
+
+  factory TrendsResponse.empty() {
+    return const TrendsResponse(periods: []);
+  }
+}
+
+/// Comparison Response Models
+class PeriodSummary {
+  final String periodId;
+  final String dates;
+  final int activities;
+  final double expenses;
+  final double complianceRate;
+  final int usersActive;
+
+  const PeriodSummary({
+    required this.periodId,
+    required this.dates,
+    required this.activities,
+    required this.expenses,
+    required this.complianceRate,
+    required this.usersActive,
+  });
+
+  factory PeriodSummary.fromApi(Map<String, dynamic> data) {
+    return PeriodSummary(
+      periodId: data['periodId'] as String? ?? '',
+      dates: data['dates'] as String? ?? '',
+      activities: (data['activities'] as num?)?.toInt() ?? 0,
+      expenses: (data['expenses'] as num?)?.toDouble() ?? 0.0,
+      complianceRate: (data['complianceRate'] as num?)?.toDouble() ?? 0.0,
+      usersActive: (data['usersActive'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+class Change {
+  final double value;
+  final double percent;
+
+  const Change({
+    required this.value,
+    required this.percent,
+  });
+
+  factory Change.fromApi(Map<String, dynamic> data) {
+    return Change(
+      value: (data['value'] as num?)?.toDouble() ?? 0.0,
+      percent: (data['percent'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
+  bool get isPositive => value >= 0;
+  bool get isNegative => value < 0;
+}
+
+class ComparisonChanges {
+  final Change activities;
+  final Change expenses;
+  final Change complianceRate;
+  final Change usersActive;
+
+  const ComparisonChanges({
+    required this.activities,
+    required this.expenses,
+    required this.complianceRate,
+    required this.usersActive,
+  });
+
+  factory ComparisonChanges.fromApi(Map<String, dynamic> data) {
+    return ComparisonChanges(
+      activities: Change.fromApi(data['activities'] as Map<String, dynamic>),
+      expenses: Change.fromApi(data['expenses'] as Map<String, dynamic>),
+      complianceRate:
+          Change.fromApi(data['complianceRate'] as Map<String, dynamic>),
+      usersActive: Change.fromApi(data['usersActive'] as Map<String, dynamic>),
+    );
+  }
+}
+
+class ComparisonResponse {
+  final PeriodSummary current;
+  final PeriodSummary previous;
+  final ComparisonChanges changes;
+
+  const ComparisonResponse({
+    required this.current,
+    required this.previous,
+    required this.changes,
+  });
+
+  factory ComparisonResponse.fromApi(Map<String, dynamic> data) {
+    return ComparisonResponse(
+      current:
+          PeriodSummary.fromApi(data['current'] as Map<String, dynamic>),
+      previous:
+          PeriodSummary.fromApi(data['previous'] as Map<String, dynamic>),
+      changes:
+          ComparisonChanges.fromApi(data['changes'] as Map<String, dynamic>),
+    );
+  }
+
+  factory ComparisonResponse.empty() {
+    return ComparisonResponse(
+      current: PeriodSummary.fromApi(const {}),
+      previous: PeriodSummary.fromApi(const {}),
+      changes: ComparisonChanges.fromApi(const {
+        'activities': {'value': 0.0, 'percent': 0.0},
+        'expenses': {'value': 0.0, 'percent': 0.0},
+        'complianceRate': {'value': 0.0, 'percent': 0.0},
+        'usersActive': {'value': 0.0, 'percent': 0.0},
+      }),
+    );
+  }
+}
+
+/// Rankings Response Models
+class TopPerformer {
+  final String userId;
+  final String name;
+  final String entity;
+  final int count;
+  final double expenses;
+
+  const TopPerformer({
+    required this.userId,
+    required this.name,
+    required this.entity,
+    required this.count,
+    required this.expenses,
+  });
+
+  factory TopPerformer.fromApi(Map<String, dynamic> data) {
+    return TopPerformer(
+      userId: data['userId'] as String? ?? '',
+      name: data['name'] as String? ?? '',
+      entity: data['entity'] as String? ?? '',
+      count: (data['count'] as num?)?.toInt() ?? 0,
+      expenses: (data['expenses'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+}
+
+class LowCompliance {
+  final String entityId;
+  final String name;
+  final double rate;
+  final int missing;
+
+  const LowCompliance({
+    required this.entityId,
+    required this.name,
+    required this.rate,
+    required this.missing,
+  });
+
+  factory LowCompliance.fromApi(Map<String, dynamic> data) {
+    return LowCompliance(
+      entityId: data['entityId'] as String? ?? '',
+      name: data['name'] as String? ?? '',
+      rate: (data['rate'] as num?)?.toDouble() ?? 0.0,
+      missing: (data['missing'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+class InactiveUser {
+  final String userId;
+  final String name;
+  final String entity;
+  final int periodsInactive;
+
+  const InactiveUser({
+    required this.userId,
+    required this.name,
+    required this.entity,
+    required this.periodsInactive,
+  });
+
+  factory InactiveUser.fromApi(Map<String, dynamic> data) {
+    return InactiveUser(
+      userId: data['userId'] as String? ?? '',
+      name: data['name'] as String? ?? '',
+      entity: data['entity'] as String? ?? '',
+      periodsInactive: (data['periodsInactive'] as num?)?.toInt() ?? 0,
+    );
+  }
+}
+
+class RankingsResponse {
+  final List<TopPerformer> topPerformers;
+  final List<LowCompliance> lowestCompliance;
+  final List<InactiveUser> inactiveUsers;
+
+  const RankingsResponse({
+    required this.topPerformers,
+    required this.lowestCompliance,
+    required this.inactiveUsers,
+  });
+
+  factory RankingsResponse.fromApi(Map<String, dynamic> data) {
+    final topPerformersData = data['topPerformers'] as List<dynamic>? ?? [];
+    final topPerformers = topPerformersData
+        .map((item) => TopPerformer.fromApi(item as Map<String, dynamic>))
+        .toList();
+
+    final lowestComplianceData =
+        data['lowestCompliance'] as List<dynamic>? ?? [];
+    final lowestCompliance = lowestComplianceData
+        .map((item) => LowCompliance.fromApi(item as Map<String, dynamic>))
+        .toList();
+
+    final inactiveUsersData = data['inactiveUsers'] as List<dynamic>? ?? [];
+    final inactiveUsers = inactiveUsersData
+        .map((item) => InactiveUser.fromApi(item as Map<String, dynamic>))
+        .toList();
+
+    return RankingsResponse(
+      topPerformers: topPerformers,
+      lowestCompliance: lowestCompliance,
+      inactiveUsers: inactiveUsers,
+    );
+  }
+
+  factory RankingsResponse.empty() {
+    return const RankingsResponse(
+      topPerformers: [],
+      lowestCompliance: [],
+      inactiveUsers: [],
+    );
+  }
+}
+
+/// Expenses Response Models
+class ExpenseByType {
+  final String typeId;
+  final String name;
+  final double total;
+  final double percent;
+  final double avgPerActivity;
+
+  const ExpenseByType({
+    required this.typeId,
+    required this.name,
+    required this.total,
+    required this.percent,
+    required this.avgPerActivity,
+  });
+
+  factory ExpenseByType.fromApi(Map<String, dynamic> data) {
+    return ExpenseByType(
+      typeId: data['typeId'] as String? ?? '',
+      name: data['name'] as String? ?? '',
+      total: (data['total'] as num?)?.toDouble() ?? 0.0,
+      percent: (data['percent'] as num?)?.toDouble() ?? 0.0,
+      avgPerActivity: (data['avgPerActivity'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+}
+
+class ExpenseByEntity {
+  final String entityId;
+  final String name;
+  final double total;
+  final double percent;
+  final double perUser;
+
+  const ExpenseByEntity({
+    required this.entityId,
+    required this.name,
+    required this.total,
+    required this.percent,
+    required this.perUser,
+  });
+
+  factory ExpenseByEntity.fromApi(Map<String, dynamic> data) {
+    return ExpenseByEntity(
+      entityId: data['entityId'] as String? ?? '',
+      name: data['name'] as String? ?? '',
+      total: (data['total'] as num?)?.toDouble() ?? 0.0,
+      percent: (data['percent'] as num?)?.toDouble() ?? 0.0,
+      perUser: (data['perUser'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+}
+
+class ExpenseByUser {
+  final String userId;
+  final String name;
+  final double total;
+  final double percent;
+
+  const ExpenseByUser({
+    required this.userId,
+    required this.name,
+    required this.total,
+    required this.percent,
+  });
+
+  factory ExpenseByUser.fromApi(Map<String, dynamic> data) {
+    return ExpenseByUser(
+      userId: data['userId'] as String? ?? '',
+      name: data['name'] as String? ?? '',
+      total: (data['total'] as num?)?.toDouble() ?? 0.0,
+      percent: (data['percent'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+}
+
+class ExpensesResponse {
+  final double total;
+  final List<ExpenseByType> byType;
+  final List<ExpenseByEntity> byEntity;
+  final List<ExpenseByUser> byUser;
+
+  const ExpensesResponse({
+    required this.total,
+    required this.byType,
+    required this.byEntity,
+    required this.byUser,
+  });
+
+  factory ExpensesResponse.fromApi(Map<String, dynamic> data) {
+    final byTypeData = data['byType'] as List<dynamic>? ?? [];
+    final byType = byTypeData
+        .map((item) => ExpenseByType.fromApi(item as Map<String, dynamic>))
+        .toList();
+
+    final byEntityData = data['byEntity'] as List<dynamic>? ?? [];
+    final byEntity = byEntityData
+        .map((item) => ExpenseByEntity.fromApi(item as Map<String, dynamic>))
+        .toList();
+
+    final byUserData = data['byUser'] as List<dynamic>? ?? [];
+    final byUser = byUserData
+        .map((item) => ExpenseByUser.fromApi(item as Map<String, dynamic>))
+        .toList();
+
+    return ExpensesResponse(
+      total: (data['total'] as num?)?.toDouble() ?? 0.0,
+      byType: byType,
+      byEntity: byEntity,
+      byUser: byUser,
+    );
+  }
+
+  factory ExpensesResponse.empty() {
+    return const ExpensesResponse(
+      total: 0.0,
+      byType: [],
+      byEntity: [],
+      byUser: [],
+    );
+  }
+}

--- a/frontend/lib/models/leadership_reports.dart
+++ b/frontend/lib/models/leadership_reports.dart
@@ -1,8 +1,8 @@
-/// Models for leadership dashboard endpoints:
-/// - Trends
-/// - Comparison
-/// - Rankings
-/// - Expenses
+// Models for leadership dashboard endpoints:
+// - Trends
+// - Comparison
+// - Rankings
+// - Expenses
 
 /// Trends Response Models
 class TrendPeriod {

--- a/frontend/lib/pages/leadership_dashboard_page.dart
+++ b/frontend/lib/pages/leadership_dashboard_page.dart
@@ -1,0 +1,758 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../providers/leadership_dashboard_provider.dart';
+import '../providers/auth.dart';
+import '../router.dart';
+import '../utils/currency_formatter.dart';
+import '../models/leadership_reports.dart';
+import '../widgets/reports/period_type_selector.dart';
+import '../widgets/reports/enhanced_time_selector.dart';
+
+/// Leadership Dashboard Page - Displays trends, comparison, rankings, and expenses
+/// Requires REPORT_VIEW_HIERARCHY permission
+class LeadershipDashboardContent extends ConsumerStatefulWidget {
+  const LeadershipDashboardContent({super.key});
+
+  @override
+  ConsumerState<LeadershipDashboardContent> createState() =>
+      _LeadershipDashboardContentState();
+}
+
+class _LeadershipDashboardContentState
+    extends ConsumerState<LeadershipDashboardContent> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadDashboard();
+    });
+  }
+
+  Future<void> _loadDashboard() async {
+    final authState = ref.read(authNotifierProvider);
+    final primaryEntity =
+        authState.user?['primary_entity'] as Map<String, dynamic>?;
+    final entityId = primaryEntity?['id'] as String?;
+    final currentState = ref.read(leadershipDashboardProvider);
+
+    await ref.read(leadershipDashboardProvider.notifier).loadDashboard(
+          entityId: entityId,
+          periodType: currentState.periodType,
+          year: currentState.year,
+          periodIndex: currentState.periodIndex,
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(leadershipDashboardProvider);
+    final theme = Theme.of(context);
+
+    if (state.isLoading && !state.hasData) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.error != null && !state.hasData) {
+      final isPermissionError = state.error!.contains('permisos') || 
+                                 state.error!.contains('REPORT_VIEW_HIERARCHY');
+      
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                isPermissionError ? Icons.lock_outline : Icons.error_outline,
+                size: 64,
+                color: isPermissionError 
+                    ? theme.colorScheme.primary.withValues(alpha: 0.7)
+                    : theme.colorScheme.error,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                isPermissionError ? 'Acceso Restringido' : 'Error',
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                state.error!,
+                style: theme.textTheme.bodyLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              if (!isPermissionError)
+                ElevatedButton(
+                  onPressed: _loadDashboard,
+                  child: const Text('Reintentar'),
+                )
+              else
+                OutlinedButton.icon(
+                  onPressed: () => context.go(AppRoutes.reports),
+                  icon: const Icon(Icons.arrow_back),
+                  label: const Text('Volver a Reportes'),
+                ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _loadDashboard,
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(theme),
+            const SizedBox(height: 16),
+            _buildPeriodControls(theme),
+            const SizedBox(height: 16),
+            // Show warning banner if there's an error but we have some data
+            if (state.error != null && state.hasData)
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: theme.colorScheme.primary.withValues(alpha: 0.3),
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.info_outline,
+                      color: theme.colorScheme.primary,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        state.error!,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.primary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            if (state.error != null && state.hasData)
+              const SizedBox(height: 24),
+            if (state.comparison != null)
+              _buildComparisonSection(state.comparison!, theme),
+            if (state.comparison != null)
+              const SizedBox(height: 24),
+            if (state.trends != null) _buildTrendsSection(state.trends!, theme),
+            if (state.trends != null)
+              const SizedBox(height: 24),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (state.rankings != null)
+                  Expanded(
+                    flex: 2,
+                    child: _buildRankingsSection(state.rankings!, theme),
+                  ),
+                if (state.rankings != null && state.expenses != null)
+                  const SizedBox(width: 16),
+                if (state.expenses != null)
+                  Expanded(
+                    flex: 1,
+                    child: _buildExpensesSection(state.expenses!, theme),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(ThemeData theme) {
+    final state = ref.watch(leadershipDashboardProvider);
+    
+    String dateRangeText = 'Período actual';
+    if (state.dateFrom != null && state.dateTo != null) {
+      try {
+        final from = DateTime.parse(state.dateFrom!);
+        final to = DateTime.parse(state.dateTo!);
+        dateRangeText = '${from.day}/${from.month}/${from.year} - ${to.day}/${to.month}/${to.year}';
+      } catch (e) {
+        // Keep default text if parsing fails
+      }
+    }
+    
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Rendimiento',
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Métricas de alto nivel para toma de decisiones',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.calendar_today,
+                        size: 14,
+                        color: theme.colorScheme.primary,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        dateRangeText,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.primary,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              onPressed: _loadDashboard,
+              tooltip: 'Actualizar',
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPeriodControls(ThemeData theme) {
+    final state = ref.watch(leadershipDashboardProvider);
+    final notifier = ref.read(leadershipDashboardProvider.notifier);
+
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Text(
+                  'Tipo de comparación:',
+                  style: TextStyle(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: PeriodTypeSelector(
+                    selectedType: state.periodType,
+                    onTypeChanged: (type) {
+                      notifier.updatePeriodType(type);
+                    },
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            EnhancedTimeSelector(
+              periodType: state.periodType,
+              year: state.year,
+              periodIndex: state.periodIndex,
+              onPrevious: () => notifier.previousPeriod(),
+              onNext: () => notifier.nextPeriod(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildComparisonSection(
+      ComparisonResponse comparison, ThemeData theme) {
+    final hasNoComparisonData =
+        comparison.current.activities == 0 &&
+        comparison.current.expenses == 0 &&
+        comparison.current.usersActive == 0 &&
+        comparison.current.complianceRate == 0 &&
+        comparison.changes.activities.value == 0 &&
+        comparison.changes.expenses.value == 0 &&
+        comparison.changes.usersActive.value == 0 &&
+        comparison.changes.complianceRate.value == 0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Comparación de Períodos',
+          style: theme.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 16),
+        if (hasNoComparisonData)
+          Card(
+            elevation: 2,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                'No hay datos de actividades para comparar en este período.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+            ),
+          )
+        else
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final isWide = constraints.maxWidth > 800;
+            if (isWide) {
+              return Row(
+                children: [
+                  Expanded(
+                    child: _buildComparisonCard(
+                      'Actividades',
+                      comparison.current.activities,
+                      comparison.changes.activities,
+                      Icons.assignment,
+                      theme,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: _buildComparisonCard(
+                      'Gastos',
+                      comparison.current.expenses,
+                      comparison.changes.expenses,
+                      Icons.attach_money,
+                      theme,
+                      isCurrency: true,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: _buildComparisonCard(
+                      'Cumplimiento',
+                      comparison.current.complianceRate,
+                      comparison.changes.complianceRate,
+                      Icons.check_circle,
+                      theme,
+                      isPercentage: true,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: _buildComparisonCard(
+                      'Usuarios Activos',
+                      comparison.current.usersActive,
+                      comparison.changes.usersActive,
+                      Icons.people,
+                      theme,
+                    ),
+                  ),
+                ],
+              );
+            } else {
+              return Column(
+                children: [
+                  _buildComparisonCard(
+                    'Actividades',
+                    comparison.current.activities,
+                    comparison.changes.activities,
+                    Icons.assignment,
+                    theme,
+                  ),
+                  const SizedBox(height: 12),
+                  _buildComparisonCard(
+                    'Gastos',
+                    comparison.current.expenses,
+                    comparison.changes.expenses,
+                    Icons.attach_money,
+                    theme,
+                    isCurrency: true,
+                  ),
+                  const SizedBox(height: 12),
+                  _buildComparisonCard(
+                    'Cumplimiento',
+                    comparison.current.complianceRate,
+                    comparison.changes.complianceRate,
+                    Icons.check_circle,
+                    theme,
+                    isPercentage: true,
+                  ),
+                  const SizedBox(height: 12),
+                  _buildComparisonCard(
+                    'Usuarios Activos',
+                    comparison.current.usersActive,
+                    comparison.changes.usersActive,
+                    Icons.people,
+                    theme,
+                  ),
+                ],
+              );
+            }
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildComparisonCard(
+    String label,
+    num currentValue,
+    Change change,
+    IconData icon,
+    ThemeData theme, {
+    bool isCurrency = false,
+    bool isPercentage = false,
+  }) {
+    String formattedValue;
+    if (isCurrency) {
+      formattedValue = CurrencyFormatter.format(currentValue.toDouble(), 'L');
+    } else if (isPercentage) {
+      formattedValue = '${currentValue.toStringAsFixed(1)}%';
+    } else {
+      formattedValue = currentValue.toString();
+    }
+
+    final isPositive = change.isPositive;
+    final changeColor = isPositive ? Colors.green : Colors.red;
+    final changeIcon = isPositive ? Icons.arrow_upward : Icons.arrow_downward;
+
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, size: 24, color: theme.colorScheme.primary),
+                const SizedBox(width: 8),
+                Text(
+                  label,
+                  style: theme.textTheme.titleMedium,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              formattedValue,
+              style: theme.textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Icon(changeIcon, size: 16, color: changeColor),
+                const SizedBox(width: 4),
+                Text(
+                  '${change.percent.abs().toStringAsFixed(1)}%',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: changeColor,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'vs período anterior',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTrendsSection(TrendsResponse trends, ThemeData theme) {
+    if (trends.periods.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Tendencias (Últimos 5 Períodos)',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: DataTable(
+                columns: const [
+                  DataColumn(label: Text('Período')),
+                  DataColumn(label: Text('Actividades')),
+                  DataColumn(label: Text('Gastos')),
+                  DataColumn(label: Text('Cumplimiento')),
+                  DataColumn(label: Text('Usuarios')),
+                ],
+                rows: trends.periods.map((period) {
+                  return DataRow(cells: [
+                    DataCell(Text(
+                      '${period.startDate.split('T')[0]} - ${period.endDate.split('T')[0]}',
+                    )),
+                    DataCell(Text(period.activities.toString())),
+                    DataCell(Text(
+                      CurrencyFormatter.format(period.expenses, 'L'),
+                    )),
+                    DataCell(Text('${period.complianceRate.toStringAsFixed(1)}%')),
+                    DataCell(Text('${period.usersSubmitted}/${period.usersExpected}')),
+                  ]);
+                }).toList(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRankingsSection(RankingsResponse rankings, ThemeData theme) {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Rankings y Alertas',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _buildRankingSubsection(
+              'Top Performers',
+              Icons.star,
+              rankings.topPerformers.isEmpty
+                  ? [const Text('Sin datos')]
+                  : rankings.topPerformers
+                      .map((performer) => ListTile(
+                            dense: true,
+                            leading: CircleAvatar(
+                              backgroundColor: Colors.amber,
+                              child: Text(
+                                performer.name[0].toUpperCase(),
+                                style: const TextStyle(color: Colors.white),
+                              ),
+                            ),
+                            title: Text(performer.name),
+                            subtitle: Text(performer.entity),
+                            trailing: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              children: [
+                                Text(
+                                  '${performer.count} actividades',
+                                  style: theme.textTheme.bodySmall,
+                                ),
+                                Text(
+                                  CurrencyFormatter.format(
+                                      performer.expenses, 'L'),
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: theme.colorScheme.primary,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            onTap: () => context.go(
+                              AppRoutes.userActivitiesPath(performer.userId),
+                            ),
+                          ))
+                      .toList(),
+              theme,
+            ),
+            const Divider(height: 32),
+            _buildRankingSubsection(
+              'Bajo Cumplimiento',
+              Icons.warning,
+              rankings.lowestCompliance.isEmpty
+                  ? [const Text('Sin datos')]
+                  : rankings.lowestCompliance
+                      .map((entity) => ListTile(
+                            dense: true,
+                            leading: Icon(
+                              Icons.business,
+                              color: Colors.orange,
+                            ),
+                            title: Text(entity.name),
+                            subtitle: Text(
+                                '${entity.rate.toStringAsFixed(1)}% cumplimiento'),
+                            trailing: Text(
+                              '${entity.missing} faltantes',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.error,
+                              ),
+                            ),
+                          ))
+                      .toList(),
+              theme,
+            ),
+            const Divider(height: 32),
+            _buildRankingSubsection(
+              'Usuarios Inactivos',
+              Icons.person_off,
+              rankings.inactiveUsers.isEmpty
+                  ? [const Text('Sin datos')]
+                  : rankings.inactiveUsers
+                      .map((user) => ListTile(
+                            dense: true,
+                            leading: const Icon(
+                              Icons.person_off,
+                              color: Colors.grey,
+                            ),
+                            title: Text(user.name),
+                            subtitle: Text(user.entity),
+                            trailing: Text(
+                              '${user.periodsInactive}+ períodos',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurface
+                                    .withValues(alpha: 0.6),
+                              ),
+                            ),
+                            onTap: () =>
+                                context.go(AppRoutes.userActivitiesPath(user.userId)),
+                          ))
+                      .toList(),
+              theme,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRankingSubsection(
+    String title,
+    IconData icon,
+    List<Widget> children,
+    ThemeData theme,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(icon, size: 20),
+            const SizedBox(width: 8),
+            Text(
+              title,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ...children,
+      ],
+    );
+  }
+
+  Widget _buildExpensesSection(ExpensesResponse expenses, ThemeData theme) {
+    return Card(
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Desglose de Gastos',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Total: ${CurrencyFormatter.format(expenses.total, 'L')}',
+              style: theme.textTheme.headlineSmall?.copyWith(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Por Tipo',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            ...expenses.byType.take(5).map((expense) => Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              expense.name,
+                              style: theme.textTheme.bodyMedium,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            Text(
+                              '${expense.percent.toStringAsFixed(1)}%',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurface
+                                    .withValues(alpha: 0.6),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Text(
+                        CurrencyFormatter.format(expense.total, 'L'),
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                )),
+            if (expenses.byType.isEmpty)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Text('Sin datos de gastos'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/pages/leadership_dashboard_page.dart
+++ b/frontend/lib/pages/leadership_dashboard_page.dart
@@ -54,9 +54,9 @@ class _LeadershipDashboardContentState
     }
 
     if (state.error != null && !state.hasData) {
-      final isPermissionError = state.error!.contains('permisos') || 
-                                 state.error!.contains('REPORT_VIEW_HIERARCHY');
-      
+      final isPermissionError = state.error!.contains('permisos') ||
+          state.error!.contains('REPORT_VIEW_HIERARCHY');
+
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
@@ -66,7 +66,7 @@ class _LeadershipDashboardContentState
               Icon(
                 isPermissionError ? Icons.lock_outline : Icons.error_outline,
                 size: 64,
-                color: isPermissionError 
+                color: isPermissionError
                     ? theme.colorScheme.primary.withValues(alpha: 0.7)
                     : theme.colorScheme.error,
               ),
@@ -147,11 +147,9 @@ class _LeadershipDashboardContentState
               const SizedBox(height: 24),
             if (state.comparison != null)
               _buildComparisonSection(state.comparison!, theme),
-            if (state.comparison != null)
-              const SizedBox(height: 24),
+            if (state.comparison != null) const SizedBox(height: 24),
             if (state.trends != null) _buildTrendsSection(state.trends!, theme),
-            if (state.trends != null)
-              const SizedBox(height: 24),
+            if (state.trends != null) const SizedBox(height: 24),
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -177,18 +175,19 @@ class _LeadershipDashboardContentState
 
   Widget _buildHeader(ThemeData theme) {
     final state = ref.watch(leadershipDashboardProvider);
-    
+
     String dateRangeText = 'Período actual';
     if (state.dateFrom != null && state.dateTo != null) {
       try {
         final from = DateTime.parse(state.dateFrom!);
         final to = DateTime.parse(state.dateTo!);
-        dateRangeText = '${from.day}/${from.month}/${from.year} - ${to.day}/${to.month}/${to.year}';
+        dateRangeText =
+            '${from.day}/${from.month}/${from.year} - ${to.day}/${to.month}/${to.year}';
       } catch (e) {
         // Keep default text if parsing fails
       }
     }
-    
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -288,8 +287,7 @@ class _LeadershipDashboardContentState
 
   Widget _buildComparisonSection(
       ComparisonResponse comparison, ThemeData theme) {
-    final hasNoComparisonData =
-        comparison.current.activities == 0 &&
+    final hasNoComparisonData = comparison.current.activities == 0 &&
         comparison.current.expenses == 0 &&
         comparison.current.usersActive == 0 &&
         comparison.current.complianceRate == 0 &&
@@ -322,24 +320,67 @@ class _LeadershipDashboardContentState
             ),
           )
         else
-        LayoutBuilder(
-          builder: (context, constraints) {
-            final isWide = constraints.maxWidth > 800;
-            if (isWide) {
-              return Row(
-                children: [
-                  Expanded(
-                    child: _buildComparisonCard(
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final isWide = constraints.maxWidth > 800;
+              if (isWide) {
+                return Row(
+                  children: [
+                    Expanded(
+                      child: _buildComparisonCard(
+                        'Actividades',
+                        comparison.current.activities,
+                        comparison.changes.activities,
+                        Icons.assignment,
+                        theme,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _buildComparisonCard(
+                        'Gastos',
+                        comparison.current.expenses,
+                        comparison.changes.expenses,
+                        Icons.attach_money,
+                        theme,
+                        isCurrency: true,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _buildComparisonCard(
+                        'Cumplimiento',
+                        comparison.current.complianceRate,
+                        comparison.changes.complianceRate,
+                        Icons.check_circle,
+                        theme,
+                        isPercentage: true,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _buildComparisonCard(
+                        'Usuarios Activos',
+                        comparison.current.usersActive,
+                        comparison.changes.usersActive,
+                        Icons.people,
+                        theme,
+                      ),
+                    ),
+                  ],
+                );
+              } else {
+                return Column(
+                  children: [
+                    _buildComparisonCard(
                       'Actividades',
                       comparison.current.activities,
                       comparison.changes.activities,
                       Icons.assignment,
                       theme,
                     ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: _buildComparisonCard(
+                    const SizedBox(height: 12),
+                    _buildComparisonCard(
                       'Gastos',
                       comparison.current.expenses,
                       comparison.changes.expenses,
@@ -347,10 +388,8 @@ class _LeadershipDashboardContentState
                       theme,
                       isCurrency: true,
                     ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: _buildComparisonCard(
+                    const SizedBox(height: 12),
+                    _buildComparisonCard(
                       'Cumplimiento',
                       comparison.current.complianceRate,
                       comparison.changes.complianceRate,
@@ -358,60 +397,19 @@ class _LeadershipDashboardContentState
                       theme,
                       isPercentage: true,
                     ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: _buildComparisonCard(
+                    const SizedBox(height: 12),
+                    _buildComparisonCard(
                       'Usuarios Activos',
                       comparison.current.usersActive,
                       comparison.changes.usersActive,
                       Icons.people,
                       theme,
                     ),
-                  ),
-                ],
-              );
-            } else {
-              return Column(
-                children: [
-                  _buildComparisonCard(
-                    'Actividades',
-                    comparison.current.activities,
-                    comparison.changes.activities,
-                    Icons.assignment,
-                    theme,
-                  ),
-                  const SizedBox(height: 12),
-                  _buildComparisonCard(
-                    'Gastos',
-                    comparison.current.expenses,
-                    comparison.changes.expenses,
-                    Icons.attach_money,
-                    theme,
-                    isCurrency: true,
-                  ),
-                  const SizedBox(height: 12),
-                  _buildComparisonCard(
-                    'Cumplimiento',
-                    comparison.current.complianceRate,
-                    comparison.changes.complianceRate,
-                    Icons.check_circle,
-                    theme,
-                    isPercentage: true,
-                  ),
-                  const SizedBox(height: 12),
-                  _buildComparisonCard(
-                    'Usuarios Activos',
-                    comparison.current.usersActive,
-                    comparison.changes.usersActive,
-                    Icons.people,
-                    theme,
-                  ),
-                ],
-              );
-            }
-          },
-        ),
+                  ],
+                );
+              }
+            },
+          ),
       ],
     );
   }
@@ -527,8 +525,10 @@ class _LeadershipDashboardContentState
                     DataCell(Text(
                       CurrencyFormatter.format(period.expenses, 'L'),
                     )),
-                    DataCell(Text('${period.complianceRate.toStringAsFixed(1)}%')),
-                    DataCell(Text('${period.usersSubmitted}/${period.usersExpected}')),
+                    DataCell(
+                        Text('${period.complianceRate.toStringAsFixed(1)}%')),
+                    DataCell(Text(
+                        '${period.usersSubmitted}/${period.usersExpected}')),
                   ]);
                 }).toList(),
               ),
@@ -643,8 +643,8 @@ class _LeadershipDashboardContentState
                                     .withValues(alpha: 0.6),
                               ),
                             ),
-                            onTap: () =>
-                                context.go(AppRoutes.userActivitiesPath(user.userId)),
+                            onTap: () => context
+                                .go(AppRoutes.userActivitiesPath(user.userId)),
                           ))
                       .toList(),
               theme,

--- a/frontend/lib/pages/leadership_dashboard_page.dart
+++ b/frontend/lib/pages/leadership_dashboard_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../core/errors/app_exception.dart';
+import '../models/leadership_dashboard_data.dart';
+import '../models/report_period_type.dart';
 import '../providers/leadership_dashboard_provider.dart';
 import '../providers/auth.dart';
 import '../router.dart';
@@ -29,80 +32,102 @@ class _LeadershipDashboardContentState
     });
   }
 
-  Future<void> _loadDashboard() async {
+  void _loadDashboard() {
     final authState = ref.read(authNotifierProvider);
     final primaryEntity =
         authState.user?['primary_entity'] as Map<String, dynamic>?;
     final entityId = primaryEntity?['id'] as String?;
-    final currentState = ref.read(leadershipDashboardProvider);
-
-    await ref.read(leadershipDashboardProvider.notifier).loadDashboard(
+    ref.read(leadershipDashboardProvider.notifier).loadDashboard(
           entityId: entityId,
-          periodType: currentState.periodType,
-          year: currentState.year,
-          periodIndex: currentState.periodIndex,
         );
   }
 
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(leadershipDashboardProvider);
-    final theme = Theme.of(context);
-
-    if (state.isLoading && !state.hasData) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
-    if (state.error != null && !state.hasData) {
-      final isPermissionError = state.error!.contains('permisos') ||
-          state.error!.contains('REPORT_VIEW_HIERARCHY');
-
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(
-                isPermissionError ? Icons.lock_outline : Icons.error_outline,
-                size: 64,
-                color: isPermissionError
-                    ? theme.colorScheme.primary.withValues(alpha: 0.7)
-                    : theme.colorScheme.error,
-              ),
-              const SizedBox(height: 24),
-              Text(
-                isPermissionError ? 'Acceso Restringido' : 'Error',
-                style: theme.textTheme.headlineSmall?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Text(
-                state.error!,
-                style: theme.textTheme.bodyLarge,
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 24),
-              if (!isPermissionError)
-                ElevatedButton(
-                  onPressed: _loadDashboard,
-                  child: const Text('Reintentar'),
-                )
-              else
-                OutlinedButton.icon(
-                  onPressed: () => context.go(AppRoutes.reports),
-                  icon: const Icon(Icons.arrow_back),
-                  label: const Text('Volver a Reportes'),
-                ),
-            ],
-          ),
-        ),
+    final canView = ref.watch(canViewReportsProvider);
+    if (!canView) {
+      return const Center(
+        child: Text('No tienes acceso a esta secci\u00f3n.'),
       );
     }
 
+    final dashboardAsync = ref.watch(leadershipDashboardProvider);
+    final theme = Theme.of(context);
+
+    return dashboardAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, _) => _buildErrorState(error, theme),
+      data: (data) => _buildDashboard(data, theme),
+    );
+  }
+
+  Widget _buildErrorState(Object error, ThemeData theme) {
+    String message;
+    bool canRetry = false;
+
+    if (error is AuthException) {
+      message = error.userMessage;
+    } else if (error is NetworkException) {
+      message = error.userMessage;
+      canRetry = true;
+    } else if (error is ServerException) {
+      message = error.userMessage;
+      canRetry = true;
+    } else if (error is AppException) {
+      message = error.userMessage;
+      canRetry = error.shouldRetry;
+    } else {
+      message = 'Error inesperado. Intente de nuevo.';
+      canRetry = true;
+    }
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              error is AuthException ? Icons.lock_outline : Icons.error_outline,
+              size: 64,
+              color: error is AuthException
+                  ? theme.colorScheme.primary.withValues(alpha: 0.7)
+                  : theme.colorScheme.error,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              error is AuthException ? 'Acceso Restringido' : 'Error',
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              style: theme.textTheme.bodyLarge,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            if (canRetry)
+              ElevatedButton(
+                onPressed: _loadDashboard,
+                child: const Text('Reintentar'),
+              )
+            else if (error is AuthException)
+              OutlinedButton.icon(
+                onPressed: () => context.go(AppRoutes.reports),
+                icon: const Icon(Icons.arrow_back),
+                label: const Text('Volver a Reportes'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDashboard(LeadershipDashboardData data, ThemeData theme) {
     return RefreshIndicator(
-      onRefresh: _loadDashboard,
+      onRefresh: () async => _loadDashboard(),
       child: SingleChildScrollView(
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(16),
@@ -113,58 +138,22 @@ class _LeadershipDashboardContentState
             const SizedBox(height: 16),
             _buildPeriodControls(theme),
             const SizedBox(height: 16),
-            // Show warning banner if there's an error but we have some data
-            if (state.error != null && state.hasData)
-              Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.primary.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(8),
-                  border: Border.all(
-                    color: theme.colorScheme.primary.withValues(alpha: 0.3),
-                  ),
-                ),
-                child: Row(
-                  children: [
-                    Icon(
-                      Icons.info_outline,
-                      color: theme.colorScheme.primary,
-                      size: 20,
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: Text(
-                        state.error!,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.primary,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            if (state.error != null && state.hasData)
-              const SizedBox(height: 24),
-            if (state.comparison != null)
-              _buildComparisonSection(state.comparison!, theme),
-            if (state.comparison != null) const SizedBox(height: 24),
-            if (state.trends != null) _buildTrendsSection(state.trends!, theme),
-            if (state.trends != null) const SizedBox(height: 24),
+            _buildComparisonSection(data.comparison, theme),
+            const SizedBox(height: 24),
+            _buildTrendsSection(data.trends, theme),
+            const SizedBox(height: 24),
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                if (state.rankings != null)
-                  Expanded(
-                    flex: 2,
-                    child: _buildRankingsSection(state.rankings!, theme),
-                  ),
-                if (state.rankings != null && state.expenses != null)
-                  const SizedBox(width: 16),
-                if (state.expenses != null)
-                  Expanded(
-                    flex: 1,
-                    child: _buildExpensesSection(state.expenses!, theme),
-                  ),
+                Expanded(
+                  flex: 2,
+                  child: _buildRankingsSection(data.rankings, theme),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  flex: 1,
+                  child: _buildExpensesSection(data.expenses, theme),
+                ),
               ],
             ),
           ],
@@ -174,18 +163,29 @@ class _LeadershipDashboardContentState
   }
 
   Widget _buildHeader(ThemeData theme) {
-    final state = ref.watch(leadershipDashboardProvider);
+    final notifier = ref.read(leadershipDashboardProvider.notifier);
+    final periodType = notifier.periodType;
+    final year = notifier.year;
+    final periodIndex = notifier.periodIndex;
 
-    String dateRangeText = 'Período actual';
-    if (state.dateFrom != null && state.dateTo != null) {
-      try {
-        final from = DateTime.parse(state.dateFrom!);
-        final to = DateTime.parse(state.dateTo!);
-        dateRangeText =
-            '${from.day}/${from.month}/${from.year} - ${to.day}/${to.month}/${to.year}';
-      } catch (e) {
-        // Keep default text if parsing fails
-      }
+    String dateRangeText;
+    switch (periodType) {
+      case ReportPeriodType.monthly:
+        const months = [
+          'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun',
+          'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic',
+        ];
+        dateRangeText = '${months[periodIndex - 1]} $year';
+        break;
+      case ReportPeriodType.quarterly:
+        dateRangeText = 'Q$periodIndex $year';
+        break;
+      case ReportPeriodType.biannual:
+        dateRangeText = 'Semestre $periodIndex $year';
+        break;
+      case ReportPeriodType.annual:
+        dateRangeText = 'A\u00f1o $year';
+        break;
     }
 
     return Column(
@@ -206,7 +206,7 @@ class _LeadershipDashboardContentState
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    'Métricas de alto nivel para toma de decisiones',
+                    'M\u00e9tricas de alto nivel para toma de decisiones',
                     style: theme.textTheme.bodyMedium?.copyWith(
                       color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
                     ),
@@ -244,7 +244,6 @@ class _LeadershipDashboardContentState
   }
 
   Widget _buildPeriodControls(ThemeData theme) {
-    final state = ref.watch(leadershipDashboardProvider);
     final notifier = ref.read(leadershipDashboardProvider.notifier);
 
     return Card(
@@ -257,13 +256,13 @@ class _LeadershipDashboardContentState
             Row(
               children: [
                 const Text(
-                  'Tipo de comparación:',
+                  'Tipo de comparaci\u00f3n:',
                   style: TextStyle(fontWeight: FontWeight.w600),
                 ),
                 const SizedBox(width: 12),
                 Expanded(
                   child: PeriodTypeSelector(
-                    selectedType: state.periodType,
+                    selectedType: notifier.periodType,
                     onTypeChanged: (type) {
                       notifier.updatePeriodType(type);
                     },
@@ -273,9 +272,9 @@ class _LeadershipDashboardContentState
             ),
             const SizedBox(height: 12),
             EnhancedTimeSelector(
-              periodType: state.periodType,
-              year: state.year,
-              periodIndex: state.periodIndex,
+              periodType: notifier.periodType,
+              year: notifier.year,
+              periodIndex: notifier.periodIndex,
               onPrevious: () => notifier.previousPeriod(),
               onNext: () => notifier.nextPeriod(),
             ),
@@ -300,7 +299,7 @@ class _LeadershipDashboardContentState
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Comparación de Períodos',
+          'Comparaci\u00f3n de Per\u00edodos',
           style: theme.textTheme.titleLarge?.copyWith(
             fontWeight: FontWeight.bold,
           ),
@@ -312,7 +311,7 @@ class _LeadershipDashboardContentState
             child: Padding(
               padding: const EdgeInsets.all(16),
               child: Text(
-                'No hay datos de actividades para comparar en este período.',
+                'No hay datos de actividades para comparar en este per\u00edodo.',
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onSurface.withValues(alpha: 0.7),
                 ),
@@ -432,9 +431,18 @@ class _LeadershipDashboardContentState
       formattedValue = currentValue.toString();
     }
 
-    final isPositive = change.isPositive;
-    final changeColor = isPositive ? Colors.green : Colors.red;
-    final changeIcon = isPositive ? Icons.arrow_upward : Icons.arrow_downward;
+    Color changeColor;
+    IconData changeIcon;
+    if (change.isNeutral) {
+      changeColor = Colors.grey;
+      changeIcon = Icons.remove;
+    } else if (change.isPositive) {
+      changeColor = Colors.green;
+      changeIcon = Icons.arrow_upward;
+    } else {
+      changeColor = Colors.red;
+      changeIcon = Icons.arrow_downward;
+    }
 
     return Card(
       elevation: 2,
@@ -474,7 +482,7 @@ class _LeadershipDashboardContentState
                 ),
                 const SizedBox(width: 8),
                 Text(
-                  'vs período anterior',
+                  'vs per\u00edodo anterior',
                   style: theme.textTheme.bodySmall?.copyWith(
                     color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
                   ),
@@ -500,7 +508,7 @@ class _LeadershipDashboardContentState
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Tendencias (Últimos 5 Períodos)',
+              'Tendencias (\u00daltimos 5 Per\u00edodos)',
               style: theme.textTheme.titleLarge?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -510,7 +518,7 @@ class _LeadershipDashboardContentState
               scrollDirection: Axis.horizontal,
               child: DataTable(
                 columns: const [
-                  DataColumn(label: Text('Período')),
+                  DataColumn(label: Text('Per\u00edodo')),
                   DataColumn(label: Text('Actividades')),
                   DataColumn(label: Text('Gastos')),
                   DataColumn(label: Text('Cumplimiento')),
@@ -637,7 +645,7 @@ class _LeadershipDashboardContentState
                             title: Text(user.name),
                             subtitle: Text(user.entity),
                             trailing: Text(
-                              '${user.periodsInactive}+ períodos',
+                              '${user.periodsInactive}+ per\u00edodos',
                               style: theme.textTheme.bodySmall?.copyWith(
                                 color: theme.colorScheme.onSurface
                                     .withValues(alpha: 0.6),

--- a/frontend/lib/pages/reports_view.dart
+++ b/frontend/lib/pages/reports_view.dart
@@ -44,18 +44,29 @@ class _ReportsViewContentState extends ConsumerState<ReportsViewContent> {
       _isLoading = true;
     });
 
-    try {
-      final periodBounds = _calculatePeriodBounds();
-      final periodStart = periodBounds['start']!.toIso8601String();
-      final periodEnd = periodBounds['end']!.toIso8601String();
+    final periodBounds = _calculatePeriodBounds();
+    final periodStart = periodBounds['start']!.toIso8601String();
+    final periodEnd = periodBounds['end']!.toIso8601String();
 
-      final summary = await _reportsService.getPersonalSummary(
+    ReportSummary? summary;
+    BreakdownsComparisonResponse? comparisonBreakdown;
+    String? comparisonError;
+
+    try {
+      summary = await _reportsService.getPersonalSummary(
         periodStart: periodStart,
         periodEnd: periodEnd,
       );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error al cargar resumen: $e')),
+        );
+      }
+    }
 
-      final comparisonBreakdown =
-          await _reportsService.getBreakdownWithComparison(
+    try {
+      comparisonBreakdown = await _reportsService.getBreakdownWithComparison(
         periodType: _periodType,
         year: _year,
         month: _periodType == ReportPeriodType.monthly ? _periodIndex : null,
@@ -63,21 +74,20 @@ class _ReportsViewContentState extends ConsumerState<ReportsViewContent> {
             _periodType == ReportPeriodType.quarterly ? _periodIndex : null,
         half: _periodType == ReportPeriodType.biannual ? _periodIndex : null,
       );
-
-      if (mounted) {
-        setState(() {
-          _summary = summary;
-          _comparisonBreakdown = comparisonBreakdown;
-          _isLoading = false;
-        });
-      }
     } catch (e) {
-      if (mounted) {
-        setState(() {
-          _isLoading = false;
-        });
+      comparisonError = 'No se pudo cargar el desglose de datos';
+    }
+
+    if (mounted) {
+      setState(() {
+        _summary = summary;
+        _comparisonBreakdown = comparisonBreakdown;
+        _isLoading = false;
+      });
+
+      if (comparisonError != null) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error al cargar reportes: $e')),
+          SnackBar(content: Text(comparisonError!)),
         );
       }
     }
@@ -281,6 +291,14 @@ class _ReportsViewContentState extends ConsumerState<ReportsViewContent> {
               ComparisonBreakdownTable(
                 breakdown: _comparisonBreakdown!.byType,
                 showComparison: true,
+              ),
+            if (_comparisonBreakdown == null)
+              const Padding(
+                padding: EdgeInsets.all(12),
+                child: Text(
+                  'No se pudo cargar el desglose de datos para este período.',
+                  style: TextStyle(color: Colors.grey),
+                ),
               ),
           ] else
             const Center(

--- a/frontend/lib/pages/reports_view.dart
+++ b/frontend/lib/pages/reports_view.dart
@@ -50,7 +50,6 @@ class _ReportsViewContentState extends ConsumerState<ReportsViewContent> {
 
     ReportSummary? summary;
     BreakdownsComparisonResponse? comparisonBreakdown;
-    String? comparisonError;
 
     try {
       summary = await _reportsService.getPersonalSummary(
@@ -58,11 +57,7 @@ class _ReportsViewContentState extends ConsumerState<ReportsViewContent> {
         periodEnd: periodEnd,
       );
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error al cargar resumen: $e')),
-        );
-      }
+      // Summary failed — continue, we'll show what we can
     }
 
     try {
@@ -75,19 +70,22 @@ class _ReportsViewContentState extends ConsumerState<ReportsViewContent> {
         half: _periodType == ReportPeriodType.biannual ? _periodIndex : null,
       );
     } catch (e) {
-      comparisonError = 'No se pudo cargar el desglose de datos';
+      // Breakdown failed — continue, we'll show what we can
     }
 
     if (mounted) {
       setState(() {
-        _summary = summary;
-        _comparisonBreakdown = comparisonBreakdown;
+        if (summary != null) _summary = summary;
+        if (comparisonBreakdown != null) {
+          _comparisonBreakdown = comparisonBreakdown;
+        }
         _isLoading = false;
       });
 
-      if (comparisonError != null) {
+      if (summary == null && comparisonBreakdown == null) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(comparisonError)),
+          const SnackBar(
+              content: Text('Error al cargar reportes. Intente de nuevo.')),
         );
       }
     }

--- a/frontend/lib/pages/reports_view.dart
+++ b/frontend/lib/pages/reports_view.dart
@@ -87,7 +87,7 @@ class _ReportsViewContentState extends ConsumerState<ReportsViewContent> {
 
       if (comparisonError != null) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(comparisonError!)),
+          SnackBar(content: Text(comparisonError)),
         );
       }
     }

--- a/frontend/lib/providers/leadership_dashboard_provider.dart
+++ b/frontend/lib/providers/leadership_dashboard_provider.dart
@@ -85,12 +85,15 @@ class LeadershipDashboardState {
   }
 
   bool get hasData =>
-      trends != null || comparison != null || rankings != null || expenses != null;
+      trends != null ||
+      comparison != null ||
+      rankings != null ||
+      expenses != null;
 }
 
 /// Provider for leadership dashboard
-final leadershipDashboardProvider =
-    StateNotifierProvider<LeadershipDashboardNotifier, LeadershipDashboardState>(
+final leadershipDashboardProvider = StateNotifierProvider<
+    LeadershipDashboardNotifier, LeadershipDashboardState>(
   (ref) {
     final authState = ref.watch(authNotifierProvider);
     Future<String> getAccessToken() async => authState.accessToken ?? '';
@@ -102,7 +105,8 @@ final leadershipDashboardProvider =
   },
 );
 
-class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState> {
+class LeadershipDashboardNotifier
+    extends StateNotifier<LeadershipDashboardState> {
   LeadershipDashboardNotifier({
     required this.reportsService,
     required this.ref,
@@ -209,9 +213,15 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
         dateTo: effectiveDateTo,
         periodType: effectiveType,
         year: effectiveYear,
-        month: effectiveType == ReportPeriodType.monthly ? effectivePeriodIndex : null,
-        quarter: effectiveType == ReportPeriodType.quarterly ? effectivePeriodIndex : null,
-        half: effectiveType == ReportPeriodType.biannual ? effectivePeriodIndex : null,
+        month: effectiveType == ReportPeriodType.monthly
+            ? effectivePeriodIndex
+            : null,
+        quarter: effectiveType == ReportPeriodType.quarterly
+            ? effectivePeriodIndex
+            : null,
+        half: effectiveType == ReportPeriodType.biannual
+            ? effectivePeriodIndex
+            : null,
       );
     } catch (e) {
       // Comparison failure is not critical - skip it silently
@@ -226,8 +236,9 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
         dateTo: effectiveDateTo,
       );
     } catch (e) {
-      if (e is AuthException && (e.technicalMessage?.contains('403') == true || 
-          e.technicalMessage?.contains('Forbidden') == true)) {
+      if (e is AuthException &&
+          (e.technicalMessage?.contains('403') == true ||
+              e.technicalMessage?.contains('Forbidden') == true)) {
         errors.add('Rankings requiere el permiso REPORT_VIEW_HIERARCHY');
       }
       debugPrint('Rankings load failed: $e');
@@ -257,7 +268,7 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
         error: errorMessage,
       );
     }
-    
+
     // If we have at least some data, consider it a partial success
     return;
   }
@@ -265,7 +276,7 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
   /// Reload trends only
   Future<void> reloadTrends() async {
     if (state.dateFrom == null || state.dateTo == null) return;
-    
+
     try {
       final trends = await reportsService.getTrends(
         entityId: state.entityId,
@@ -287,7 +298,7 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
   /// Reload comparison only
   Future<void> reloadComparison() async {
     if (state.dateFrom == null || state.dateTo == null) return;
-    
+
     try {
       final comparison = await reportsService.getComparison(
         entityId: state.entityId,
@@ -295,12 +306,15 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
         dateTo: state.dateTo!,
         periodType: state.periodType,
         year: state.year,
-        month:
-            state.periodType == ReportPeriodType.monthly ? state.periodIndex : null,
-        quarter:
-            state.periodType == ReportPeriodType.quarterly ? state.periodIndex : null,
-        half:
-            state.periodType == ReportPeriodType.biannual ? state.periodIndex : null,
+        month: state.periodType == ReportPeriodType.monthly
+            ? state.periodIndex
+            : null,
+        quarter: state.periodType == ReportPeriodType.quarterly
+            ? state.periodIndex
+            : null,
+        half: state.periodType == ReportPeriodType.biannual
+            ? state.periodIndex
+            : null,
       );
       if (mounted) {
         state = state.copyWith(comparison: comparison);
@@ -317,7 +331,7 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
   /// Reload rankings only
   Future<void> reloadRankings() async {
     if (state.dateFrom == null || state.dateTo == null) return;
-    
+
     try {
       final rankings = await reportsService.getRankings(
         entityId: state.entityId,
@@ -339,7 +353,7 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
   /// Reload expenses only
   Future<void> reloadExpenses() async {
     if (state.dateFrom == null || state.dateTo == null) return;
-    
+
     try {
       final expenses = await reportsService.getExpenses(
         entityId: state.entityId,

--- a/frontend/lib/providers/leadership_dashboard_provider.dart
+++ b/frontend/lib/providers/leadership_dashboard_provider.dart
@@ -1,443 +1,159 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/leadership_dashboard_data.dart';
 import '../models/leadership_reports.dart';
 import '../models/report_period_type.dart';
 import '../services/reports_service.dart';
-import '../core/errors/app_exception.dart';
 import 'auth.dart';
 
-/// State for leadership dashboard
-class LeadershipDashboardState {
-  final bool isLoading;
-  final TrendsResponse? trends;
-  final ComparisonResponse? comparison;
-  final RankingsResponse? rankings;
-  final ExpensesResponse? expenses;
-  final String? error;
-  final String? entityId;
-  final String? dateFrom;
-  final String? dateTo;
-  final ReportPeriodType periodType;
-  final int year;
-  final int periodIndex;
-
-  const LeadershipDashboardState({
-    required this.isLoading,
-    this.trends,
-    this.comparison,
-    this.rankings,
-    this.expenses,
-    this.error,
-    this.entityId,
-    this.dateFrom,
-    this.dateTo,
-    required this.periodType,
-    required this.year,
-    required this.periodIndex,
-  });
-
-  factory LeadershipDashboardState.initial() {
-    final now = DateTime.now();
-    return LeadershipDashboardState(
-      isLoading: false,
-      trends: null,
-      comparison: null,
-      rankings: null,
-      expenses: null,
-      error: null,
-      entityId: null,
-      dateFrom: null,
-      dateTo: null,
-      periodType: ReportPeriodType.monthly,
-      year: now.year,
-      periodIndex: now.month,
-    );
-  }
-
-  LeadershipDashboardState copyWith({
-    bool? isLoading,
-    TrendsResponse? trends,
-    ComparisonResponse? comparison,
-    RankingsResponse? rankings,
-    ExpensesResponse? expenses,
-    String? error,
-    String? entityId,
-    String? dateFrom,
-    String? dateTo,
-    ReportPeriodType? periodType,
-    int? year,
-    int? periodIndex,
-  }) {
-    return LeadershipDashboardState(
-      isLoading: isLoading ?? this.isLoading,
-      trends: trends ?? this.trends,
-      comparison: comparison ?? this.comparison,
-      rankings: rankings ?? this.rankings,
-      expenses: expenses ?? this.expenses,
-      error: error,
-      entityId: entityId ?? this.entityId,
-      dateFrom: dateFrom ?? this.dateFrom,
-      dateTo: dateTo ?? this.dateTo,
-      periodType: periodType ?? this.periodType,
-      year: year ?? this.year,
-      periodIndex: periodIndex ?? this.periodIndex,
-    );
-  }
-
-  bool get hasData =>
-      trends != null ||
-      comparison != null ||
-      rankings != null ||
-      expenses != null;
-}
-
-/// Provider for leadership dashboard
 final leadershipDashboardProvider = StateNotifierProvider<
-    LeadershipDashboardNotifier, LeadershipDashboardState>(
+    LeadershipDashboardNotifier, AsyncValue<LeadershipDashboardData>>(
   (ref) {
     final authState = ref.watch(authNotifierProvider);
     Future<String> getAccessToken() async => authState.accessToken ?? '';
 
     return LeadershipDashboardNotifier(
       reportsService: ReportsService.localhost(getAccessToken),
-      ref: ref,
     );
   },
 );
 
 class LeadershipDashboardNotifier
-    extends StateNotifier<LeadershipDashboardState> {
-  LeadershipDashboardNotifier({
-    required this.reportsService,
-    required this.ref,
-  }) : super(LeadershipDashboardState.initial());
+    extends StateNotifier<AsyncValue<LeadershipDashboardData>> {
+  LeadershipDashboardNotifier({required this.reportsService})
+      : super(const AsyncValue.loading());
 
   final ReportsService reportsService;
-  final Ref ref;
 
-  Map<String, String> _calculatePeriodBounds(
-    ReportPeriodType periodType,
-    int year,
-    int periodIndex,
-  ) {
+  ReportPeriodType _periodType = ReportPeriodType.monthly;
+  int _year = DateTime.now().year;
+  int _periodIndex = DateTime.now().month;
+
+  ReportPeriodType get periodType => _periodType;
+  int get year => _year;
+  int get periodIndex => _periodIndex;
+
+  Map<String, String> _calculatePeriodBounds() {
     DateTime start;
     DateTime end;
 
-    switch (periodType) {
+    switch (_periodType) {
       case ReportPeriodType.monthly:
-        start = DateTime(year, periodIndex, 1);
-        end = DateTime(year, periodIndex + 1, 0, 23, 59, 59);
+        start = DateTime(_year, _periodIndex, 1);
+        end = DateTime(_year, _periodIndex + 1, 0, 23, 59, 59);
         break;
       case ReportPeriodType.quarterly:
-        final startMonth = (periodIndex - 1) * 3 + 1;
-        start = DateTime(year, startMonth, 1);
-        end = DateTime(year, startMonth + 3, 0, 23, 59, 59);
+        final startMonth = (_periodIndex - 1) * 3 + 1;
+        start = DateTime(_year, startMonth, 1);
+        end = DateTime(_year, startMonth + 3, 0, 23, 59, 59);
         break;
       case ReportPeriodType.biannual:
-        final startMonth = (periodIndex - 1) * 6 + 1;
-        start = DateTime(year, startMonth, 1);
-        end = DateTime(year, startMonth + 6, 0, 23, 59, 59);
+        final startMonth = (_periodIndex - 1) * 6 + 1;
+        start = DateTime(_year, startMonth, 1);
+        end = DateTime(_year, startMonth + 6, 0, 23, 59, 59);
         break;
       case ReportPeriodType.annual:
-        start = DateTime(year, 1, 1);
-        end = DateTime(year, 12, 31, 23, 59, 59);
+        start = DateTime(_year, 1, 1);
+        end = DateTime(_year, 12, 31, 23, 59, 59);
         break;
     }
 
     String format(DateTime d) =>
         '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
 
-    return {
-      'dateFrom': format(start),
-      'dateTo': format(end),
-    };
+    return {'dateFrom': format(start), 'dateTo': format(end)};
   }
 
-  /// Load all dashboard data
-  Future<void> loadDashboard({
-    String? entityId,
-    String? dateFrom,
-    String? dateTo,
-    ReportPeriodType? periodType,
-    int? year,
-    int? periodIndex,
-  }) async {
-    final effectiveEntityId = entityId ?? state.entityId;
-    final effectiveType = periodType ?? state.periodType;
-    final effectiveYear = year ?? state.year;
-    final effectivePeriodIndex = periodIndex ?? state.periodIndex;
-
-    final bounds = _calculatePeriodBounds(
-      effectiveType,
-      effectiveYear,
-      effectivePeriodIndex,
-    );
-    final effectiveDateFrom = dateFrom ?? bounds['dateFrom']!;
-    final effectiveDateTo = dateTo ?? bounds['dateTo']!;
-
-    state = state.copyWith(
-      isLoading: true,
-      error: null,
-      entityId: effectiveEntityId,
-      dateFrom: effectiveDateFrom,
-      dateTo: effectiveDateTo,
-      periodType: effectiveType,
-      year: effectiveYear,
-      periodIndex: effectivePeriodIndex,
-    );
-
-    // Load each section independently to handle partial failures gracefully
-    TrendsResponse? trends;
-    ComparisonResponse? comparison;
-    RankingsResponse? rankings;
-    ExpensesResponse? expenses;
-    final List<String> errors = [];
-
-    // Load trends
-    try {
-      trends = await reportsService.getTrends(
-        entityId: effectiveEntityId,
-        dateFrom: effectiveDateFrom,
-        dateTo: effectiveDateTo,
-      );
-    } catch (e) {
-      // Trends failure is not critical - skip it silently
-      debugPrint('Trends load failed: $e');
-    }
-
-    // Load comparison
-    try {
-      comparison = await reportsService.getComparison(
-        entityId: effectiveEntityId,
-        dateFrom: effectiveDateFrom,
-        dateTo: effectiveDateTo,
-        periodType: effectiveType,
-        year: effectiveYear,
-        month: effectiveType == ReportPeriodType.monthly
-            ? effectivePeriodIndex
-            : null,
-        quarter: effectiveType == ReportPeriodType.quarterly
-            ? effectivePeriodIndex
-            : null,
-        half: effectiveType == ReportPeriodType.biannual
-            ? effectivePeriodIndex
-            : null,
-      );
-    } catch (e) {
-      // Comparison failure is not critical - skip it silently
-      debugPrint('Comparison load failed: $e');
-    }
-
-    // Load rankings
-    try {
-      rankings = await reportsService.getRankings(
-        entityId: effectiveEntityId,
-        dateFrom: effectiveDateFrom,
-        dateTo: effectiveDateTo,
-      );
-    } catch (e) {
-      if (e is AuthException &&
-          (e.technicalMessage?.contains('403') == true ||
-              e.technicalMessage?.contains('Forbidden') == true)) {
-        errors.add('Rankings requiere el permiso REPORT_VIEW_HIERARCHY');
-      }
-      debugPrint('Rankings load failed: $e');
-    }
-
-    // Load expenses
-    try {
-      expenses = await reportsService.getExpenses(
-        entityId: effectiveEntityId,
-        dateFrom: effectiveDateFrom,
-        dateTo: effectiveDateTo,
-      );
-    } catch (e) {
-      errors.add('No se pudieron cargar los gastos');
-      debugPrint('Expenses load failed: $e');
-    }
-
-    // Update state with whatever data we could load
-    if (mounted) {
-      final errorMessage = errors.isEmpty ? null : errors.join('\n');
-      state = state.copyWith(
-        isLoading: false,
-        trends: trends,
-        comparison: comparison,
-        rankings: rankings,
-        expenses: expenses,
-        error: errorMessage,
-      );
-    }
-
-    // If we have at least some data, consider it a partial success
-    return;
-  }
-
-  /// Reload trends only
-  Future<void> reloadTrends() async {
-    if (state.dateFrom == null || state.dateTo == null) return;
+  Future<void> loadDashboard({String? entityId}) async {
+    state = const AsyncValue.loading();
+    final bounds = _calculatePeriodBounds();
+    final dateFrom = bounds['dateFrom']!;
+    final dateTo = bounds['dateTo']!;
 
     try {
-      final trends = await reportsService.getTrends(
-        entityId: state.entityId,
-        dateFrom: state.dateFrom!,
-        dateTo: state.dateTo!,
-      );
-      if (mounted) {
-        state = state.copyWith(trends: trends);
-      }
-    } catch (e) {
-      if (mounted) {
-        state = state.copyWith(
-          error: 'Error al cargar tendencias: ${e.toString()}',
-        );
-      }
-    }
-  }
+      final results = await Future.wait([
+        reportsService.getTrends(
+          entityId: entityId,
+          dateFrom: dateFrom,
+          dateTo: dateTo,
+        ),
+        reportsService.getComparison(
+          entityId: entityId,
+          dateFrom: dateFrom,
+          dateTo: dateTo,
+          periodType: _periodType,
+          year: _year,
+          month:
+              _periodType == ReportPeriodType.monthly ? _periodIndex : null,
+          quarter:
+              _periodType == ReportPeriodType.quarterly ? _periodIndex : null,
+          half:
+              _periodType == ReportPeriodType.biannual ? _periodIndex : null,
+        ),
+        reportsService.getRankings(
+          entityId: entityId,
+          dateFrom: dateFrom,
+          dateTo: dateTo,
+        ),
+        reportsService.getExpenses(
+          entityId: entityId,
+          dateFrom: dateFrom,
+          dateTo: dateTo,
+        ),
+      ]);
 
-  /// Reload comparison only
-  Future<void> reloadComparison() async {
-    if (state.dateFrom == null || state.dateTo == null) return;
-
-    try {
-      final comparison = await reportsService.getComparison(
-        entityId: state.entityId,
-        dateFrom: state.dateFrom!,
-        dateTo: state.dateTo!,
-        periodType: state.periodType,
-        year: state.year,
-        month: state.periodType == ReportPeriodType.monthly
-            ? state.periodIndex
-            : null,
-        quarter: state.periodType == ReportPeriodType.quarterly
-            ? state.periodIndex
-            : null,
-        half: state.periodType == ReportPeriodType.biannual
-            ? state.periodIndex
-            : null,
-      );
       if (mounted) {
-        state = state.copyWith(comparison: comparison);
+        state = AsyncValue.data(LeadershipDashboardData(
+          trends: results[0] as TrendsResponse,
+          comparison: results[1] as ComparisonResponse,
+          rankings: results[2] as RankingsResponse,
+          expenses: results[3] as ExpensesResponse,
+        ));
       }
-    } catch (e) {
+    } catch (e, stack) {
       if (mounted) {
-        state = state.copyWith(
-          error: 'Error al cargar comparación: ${e.toString()}',
-        );
-      }
-    }
-  }
-
-  /// Reload rankings only
-  Future<void> reloadRankings() async {
-    if (state.dateFrom == null || state.dateTo == null) return;
-
-    try {
-      final rankings = await reportsService.getRankings(
-        entityId: state.entityId,
-        dateFrom: state.dateFrom!,
-        dateTo: state.dateTo!,
-      );
-      if (mounted) {
-        state = state.copyWith(rankings: rankings);
-      }
-    } catch (e) {
-      if (mounted) {
-        state = state.copyWith(
-          error: 'Error al cargar rankings: ${e.toString()}',
-        );
-      }
-    }
-  }
-
-  /// Reload expenses only
-  Future<void> reloadExpenses() async {
-    if (state.dateFrom == null || state.dateTo == null) return;
-
-    try {
-      final expenses = await reportsService.getExpenses(
-        entityId: state.entityId,
-        dateFrom: state.dateFrom!,
-        dateTo: state.dateTo!,
-      );
-      if (mounted) {
-        state = state.copyWith(expenses: expenses);
-      }
-    } catch (e) {
-      if (mounted) {
-        state = state.copyWith(
-          error: 'Error al cargar gastos: ${e.toString()}',
-        );
+        state = AsyncValue.error(e, stack);
       }
     }
   }
 
   Future<void> updatePeriodType(ReportPeriodType newType) async {
     final now = DateTime.now();
-    int newIndex;
+    _periodType = newType;
+    _year = now.year;
     switch (newType) {
       case ReportPeriodType.monthly:
-        newIndex = now.month;
+        _periodIndex = now.month;
         break;
       case ReportPeriodType.quarterly:
-        newIndex = ((now.month - 1) ~/ 3) + 1;
+        _periodIndex = ((now.month - 1) ~/ 3) + 1;
         break;
       case ReportPeriodType.biannual:
-        newIndex = now.month <= 6 ? 1 : 2;
+        _periodIndex = now.month <= 6 ? 1 : 2;
         break;
       case ReportPeriodType.annual:
-        newIndex = 1;
+        _periodIndex = 1;
         break;
     }
-
-    await loadDashboard(
-      entityId: state.entityId,
-      periodType: newType,
-      year: now.year,
-      periodIndex: newIndex,
-    );
+    await loadDashboard();
   }
 
-  Future<void> previousPeriod() async {
-    int newYear = state.year;
-    int newIndex = state.periodIndex;
-
-    if (newIndex > 1) {
-      newIndex--;
+  Future<void> previousPeriod({String? entityId}) async {
+    if (_periodIndex > 1) {
+      _periodIndex--;
     } else {
-      newYear--;
-      newIndex = state.periodType.maxPeriodIndex;
+      _year--;
+      _periodIndex = _periodType.maxPeriodIndex;
     }
-
-    await loadDashboard(
-      entityId: state.entityId,
-      periodType: state.periodType,
-      year: newYear,
-      periodIndex: newIndex,
-    );
+    await loadDashboard(entityId: entityId);
   }
 
-  Future<void> nextPeriod() async {
-    int newYear = state.year;
-    int newIndex = state.periodIndex;
-
-    if (newIndex < state.periodType.maxPeriodIndex) {
-      newIndex++;
+  Future<void> nextPeriod({String? entityId}) async {
+    if (_periodIndex < _periodType.maxPeriodIndex) {
+      _periodIndex++;
     } else {
-      newYear++;
-      newIndex = 1;
+      _year++;
+      _periodIndex = 1;
     }
-
-    await loadDashboard(
-      entityId: state.entityId,
-      periodType: state.periodType,
-      year: newYear,
-      periodIndex: newIndex,
-    );
-  }
-
-  /// Clear error
-  void clearError() {
-    state = state.copyWith(error: null);
+    await loadDashboard(entityId: entityId);
   }
 }

--- a/frontend/lib/providers/leadership_dashboard_provider.dart
+++ b/frontend/lib/providers/leadership_dashboard_provider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/leadership_reports.dart';
 import '../models/report_period_type.dart';
@@ -92,7 +93,7 @@ final leadershipDashboardProvider =
     StateNotifierProvider<LeadershipDashboardNotifier, LeadershipDashboardState>(
   (ref) {
     final authState = ref.watch(authNotifierProvider);
-    final getAccessToken = () async => authState.accessToken ?? '';
+    Future<String> getAccessToken() async => authState.accessToken ?? '';
 
     return LeadershipDashboardNotifier(
       reportsService: ReportsService.localhost(getAccessToken),
@@ -197,7 +198,7 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
       );
     } catch (e) {
       // Trends failure is not critical - skip it silently
-      print('Trends load failed: $e');
+      debugPrint('Trends load failed: $e');
     }
 
     // Load comparison
@@ -214,7 +215,7 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
       );
     } catch (e) {
       // Comparison failure is not critical - skip it silently
-      print('Comparison load failed: $e');
+      debugPrint('Comparison load failed: $e');
     }
 
     // Load rankings
@@ -229,7 +230,7 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
           e.technicalMessage?.contains('Forbidden') == true)) {
         errors.add('Rankings requiere el permiso REPORT_VIEW_HIERARCHY');
       }
-      print('Rankings load failed: $e');
+      debugPrint('Rankings load failed: $e');
     }
 
     // Load expenses
@@ -241,7 +242,7 @@ class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState
       );
     } catch (e) {
       errors.add('No se pudieron cargar los gastos');
-      print('Expenses load failed: $e');
+      debugPrint('Expenses load failed: $e');
     }
 
     // Update state with whatever data we could load

--- a/frontend/lib/providers/leadership_dashboard_provider.dart
+++ b/frontend/lib/providers/leadership_dashboard_provider.dart
@@ -1,0 +1,428 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/leadership_reports.dart';
+import '../models/report_period_type.dart';
+import '../services/reports_service.dart';
+import '../core/errors/app_exception.dart';
+import 'auth.dart';
+
+/// State for leadership dashboard
+class LeadershipDashboardState {
+  final bool isLoading;
+  final TrendsResponse? trends;
+  final ComparisonResponse? comparison;
+  final RankingsResponse? rankings;
+  final ExpensesResponse? expenses;
+  final String? error;
+  final String? entityId;
+  final String? dateFrom;
+  final String? dateTo;
+  final ReportPeriodType periodType;
+  final int year;
+  final int periodIndex;
+
+  const LeadershipDashboardState({
+    required this.isLoading,
+    this.trends,
+    this.comparison,
+    this.rankings,
+    this.expenses,
+    this.error,
+    this.entityId,
+    this.dateFrom,
+    this.dateTo,
+    required this.periodType,
+    required this.year,
+    required this.periodIndex,
+  });
+
+  factory LeadershipDashboardState.initial() {
+    final now = DateTime.now();
+    return LeadershipDashboardState(
+      isLoading: false,
+      trends: null,
+      comparison: null,
+      rankings: null,
+      expenses: null,
+      error: null,
+      entityId: null,
+      dateFrom: null,
+      dateTo: null,
+      periodType: ReportPeriodType.monthly,
+      year: now.year,
+      periodIndex: now.month,
+    );
+  }
+
+  LeadershipDashboardState copyWith({
+    bool? isLoading,
+    TrendsResponse? trends,
+    ComparisonResponse? comparison,
+    RankingsResponse? rankings,
+    ExpensesResponse? expenses,
+    String? error,
+    String? entityId,
+    String? dateFrom,
+    String? dateTo,
+    ReportPeriodType? periodType,
+    int? year,
+    int? periodIndex,
+  }) {
+    return LeadershipDashboardState(
+      isLoading: isLoading ?? this.isLoading,
+      trends: trends ?? this.trends,
+      comparison: comparison ?? this.comparison,
+      rankings: rankings ?? this.rankings,
+      expenses: expenses ?? this.expenses,
+      error: error,
+      entityId: entityId ?? this.entityId,
+      dateFrom: dateFrom ?? this.dateFrom,
+      dateTo: dateTo ?? this.dateTo,
+      periodType: periodType ?? this.periodType,
+      year: year ?? this.year,
+      periodIndex: periodIndex ?? this.periodIndex,
+    );
+  }
+
+  bool get hasData =>
+      trends != null || comparison != null || rankings != null || expenses != null;
+}
+
+/// Provider for leadership dashboard
+final leadershipDashboardProvider =
+    StateNotifierProvider<LeadershipDashboardNotifier, LeadershipDashboardState>(
+  (ref) {
+    final authState = ref.watch(authNotifierProvider);
+    final getAccessToken = () async => authState.accessToken ?? '';
+
+    return LeadershipDashboardNotifier(
+      reportsService: ReportsService.localhost(getAccessToken),
+      ref: ref,
+    );
+  },
+);
+
+class LeadershipDashboardNotifier extends StateNotifier<LeadershipDashboardState> {
+  LeadershipDashboardNotifier({
+    required this.reportsService,
+    required this.ref,
+  }) : super(LeadershipDashboardState.initial());
+
+  final ReportsService reportsService;
+  final Ref ref;
+
+  Map<String, String> _calculatePeriodBounds(
+    ReportPeriodType periodType,
+    int year,
+    int periodIndex,
+  ) {
+    DateTime start;
+    DateTime end;
+
+    switch (periodType) {
+      case ReportPeriodType.monthly:
+        start = DateTime(year, periodIndex, 1);
+        end = DateTime(year, periodIndex + 1, 0, 23, 59, 59);
+        break;
+      case ReportPeriodType.quarterly:
+        final startMonth = (periodIndex - 1) * 3 + 1;
+        start = DateTime(year, startMonth, 1);
+        end = DateTime(year, startMonth + 3, 0, 23, 59, 59);
+        break;
+      case ReportPeriodType.biannual:
+        final startMonth = (periodIndex - 1) * 6 + 1;
+        start = DateTime(year, startMonth, 1);
+        end = DateTime(year, startMonth + 6, 0, 23, 59, 59);
+        break;
+      case ReportPeriodType.annual:
+        start = DateTime(year, 1, 1);
+        end = DateTime(year, 12, 31, 23, 59, 59);
+        break;
+    }
+
+    String format(DateTime d) =>
+        '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+    return {
+      'dateFrom': format(start),
+      'dateTo': format(end),
+    };
+  }
+
+  /// Load all dashboard data
+  Future<void> loadDashboard({
+    String? entityId,
+    String? dateFrom,
+    String? dateTo,
+    ReportPeriodType? periodType,
+    int? year,
+    int? periodIndex,
+  }) async {
+    final effectiveEntityId = entityId ?? state.entityId;
+    final effectiveType = periodType ?? state.periodType;
+    final effectiveYear = year ?? state.year;
+    final effectivePeriodIndex = periodIndex ?? state.periodIndex;
+
+    final bounds = _calculatePeriodBounds(
+      effectiveType,
+      effectiveYear,
+      effectivePeriodIndex,
+    );
+    final effectiveDateFrom = dateFrom ?? bounds['dateFrom']!;
+    final effectiveDateTo = dateTo ?? bounds['dateTo']!;
+
+    state = state.copyWith(
+      isLoading: true,
+      error: null,
+      entityId: effectiveEntityId,
+      dateFrom: effectiveDateFrom,
+      dateTo: effectiveDateTo,
+      periodType: effectiveType,
+      year: effectiveYear,
+      periodIndex: effectivePeriodIndex,
+    );
+
+    // Load each section independently to handle partial failures gracefully
+    TrendsResponse? trends;
+    ComparisonResponse? comparison;
+    RankingsResponse? rankings;
+    ExpensesResponse? expenses;
+    final List<String> errors = [];
+
+    // Load trends
+    try {
+      trends = await reportsService.getTrends(
+        entityId: effectiveEntityId,
+        dateFrom: effectiveDateFrom,
+        dateTo: effectiveDateTo,
+      );
+    } catch (e) {
+      // Trends failure is not critical - skip it silently
+      print('Trends load failed: $e');
+    }
+
+    // Load comparison
+    try {
+      comparison = await reportsService.getComparison(
+        entityId: effectiveEntityId,
+        dateFrom: effectiveDateFrom,
+        dateTo: effectiveDateTo,
+        periodType: effectiveType,
+        year: effectiveYear,
+        month: effectiveType == ReportPeriodType.monthly ? effectivePeriodIndex : null,
+        quarter: effectiveType == ReportPeriodType.quarterly ? effectivePeriodIndex : null,
+        half: effectiveType == ReportPeriodType.biannual ? effectivePeriodIndex : null,
+      );
+    } catch (e) {
+      // Comparison failure is not critical - skip it silently
+      print('Comparison load failed: $e');
+    }
+
+    // Load rankings
+    try {
+      rankings = await reportsService.getRankings(
+        entityId: effectiveEntityId,
+        dateFrom: effectiveDateFrom,
+        dateTo: effectiveDateTo,
+      );
+    } catch (e) {
+      if (e is AuthException && (e.technicalMessage?.contains('403') == true || 
+          e.technicalMessage?.contains('Forbidden') == true)) {
+        errors.add('Rankings requiere el permiso REPORT_VIEW_HIERARCHY');
+      }
+      print('Rankings load failed: $e');
+    }
+
+    // Load expenses
+    try {
+      expenses = await reportsService.getExpenses(
+        entityId: effectiveEntityId,
+        dateFrom: effectiveDateFrom,
+        dateTo: effectiveDateTo,
+      );
+    } catch (e) {
+      errors.add('No se pudieron cargar los gastos');
+      print('Expenses load failed: $e');
+    }
+
+    // Update state with whatever data we could load
+    if (mounted) {
+      final errorMessage = errors.isEmpty ? null : errors.join('\n');
+      state = state.copyWith(
+        isLoading: false,
+        trends: trends,
+        comparison: comparison,
+        rankings: rankings,
+        expenses: expenses,
+        error: errorMessage,
+      );
+    }
+    
+    // If we have at least some data, consider it a partial success
+    return;
+  }
+
+  /// Reload trends only
+  Future<void> reloadTrends() async {
+    if (state.dateFrom == null || state.dateTo == null) return;
+    
+    try {
+      final trends = await reportsService.getTrends(
+        entityId: state.entityId,
+        dateFrom: state.dateFrom!,
+        dateTo: state.dateTo!,
+      );
+      if (mounted) {
+        state = state.copyWith(trends: trends);
+      }
+    } catch (e) {
+      if (mounted) {
+        state = state.copyWith(
+          error: 'Error al cargar tendencias: ${e.toString()}',
+        );
+      }
+    }
+  }
+
+  /// Reload comparison only
+  Future<void> reloadComparison() async {
+    if (state.dateFrom == null || state.dateTo == null) return;
+    
+    try {
+      final comparison = await reportsService.getComparison(
+        entityId: state.entityId,
+        dateFrom: state.dateFrom!,
+        dateTo: state.dateTo!,
+        periodType: state.periodType,
+        year: state.year,
+        month:
+            state.periodType == ReportPeriodType.monthly ? state.periodIndex : null,
+        quarter:
+            state.periodType == ReportPeriodType.quarterly ? state.periodIndex : null,
+        half:
+            state.periodType == ReportPeriodType.biannual ? state.periodIndex : null,
+      );
+      if (mounted) {
+        state = state.copyWith(comparison: comparison);
+      }
+    } catch (e) {
+      if (mounted) {
+        state = state.copyWith(
+          error: 'Error al cargar comparación: ${e.toString()}',
+        );
+      }
+    }
+  }
+
+  /// Reload rankings only
+  Future<void> reloadRankings() async {
+    if (state.dateFrom == null || state.dateTo == null) return;
+    
+    try {
+      final rankings = await reportsService.getRankings(
+        entityId: state.entityId,
+        dateFrom: state.dateFrom!,
+        dateTo: state.dateTo!,
+      );
+      if (mounted) {
+        state = state.copyWith(rankings: rankings);
+      }
+    } catch (e) {
+      if (mounted) {
+        state = state.copyWith(
+          error: 'Error al cargar rankings: ${e.toString()}',
+        );
+      }
+    }
+  }
+
+  /// Reload expenses only
+  Future<void> reloadExpenses() async {
+    if (state.dateFrom == null || state.dateTo == null) return;
+    
+    try {
+      final expenses = await reportsService.getExpenses(
+        entityId: state.entityId,
+        dateFrom: state.dateFrom!,
+        dateTo: state.dateTo!,
+      );
+      if (mounted) {
+        state = state.copyWith(expenses: expenses);
+      }
+    } catch (e) {
+      if (mounted) {
+        state = state.copyWith(
+          error: 'Error al cargar gastos: ${e.toString()}',
+        );
+      }
+    }
+  }
+
+  Future<void> updatePeriodType(ReportPeriodType newType) async {
+    final now = DateTime.now();
+    int newIndex;
+    switch (newType) {
+      case ReportPeriodType.monthly:
+        newIndex = now.month;
+        break;
+      case ReportPeriodType.quarterly:
+        newIndex = ((now.month - 1) ~/ 3) + 1;
+        break;
+      case ReportPeriodType.biannual:
+        newIndex = now.month <= 6 ? 1 : 2;
+        break;
+      case ReportPeriodType.annual:
+        newIndex = 1;
+        break;
+    }
+
+    await loadDashboard(
+      entityId: state.entityId,
+      periodType: newType,
+      year: now.year,
+      periodIndex: newIndex,
+    );
+  }
+
+  Future<void> previousPeriod() async {
+    int newYear = state.year;
+    int newIndex = state.periodIndex;
+
+    if (newIndex > 1) {
+      newIndex--;
+    } else {
+      newYear--;
+      newIndex = state.periodType.maxPeriodIndex;
+    }
+
+    await loadDashboard(
+      entityId: state.entityId,
+      periodType: state.periodType,
+      year: newYear,
+      periodIndex: newIndex,
+    );
+  }
+
+  Future<void> nextPeriod() async {
+    int newYear = state.year;
+    int newIndex = state.periodIndex;
+
+    if (newIndex < state.periodType.maxPeriodIndex) {
+      newIndex++;
+    } else {
+      newYear++;
+      newIndex = 1;
+    }
+
+    await loadDashboard(
+      entityId: state.entityId,
+      periodType: state.periodType,
+      year: newYear,
+      periodIndex: newIndex,
+    );
+  }
+
+  /// Clear error
+  void clearError() {
+    state = state.copyWith(error: null);
+  }
+}

--- a/frontend/lib/router.dart
+++ b/frontend/lib/router.dart
@@ -7,6 +7,7 @@ import 'pages/activities_list_page.dart';
 import 'pages/activity_detail_page.dart';
 import 'pages/reports_page.dart';
 import 'pages/user_activities_page.dart';
+import 'pages/leadership_dashboard_page.dart';
 
 /// Route path constants
 class AppRoutes {
@@ -15,6 +16,7 @@ class AppRoutes {
   static const activityDetail = '/activities/:id';
   static const reports = '/reports';
   static const userActivities = '/reports/user/:userId';
+  static const leadershipDashboard = '/leadership';
 
   /// Generate activity detail path with ID
   static String activityDetailPath(String id) => '/activities/$id';
@@ -71,6 +73,12 @@ final routerProvider = Provider<GoRouter>((ref) {
                 child: UserActivitiesPage(userId: userId),
               );
             },
+          ),
+          GoRoute(
+            path: AppRoutes.leadershipDashboard,
+            pageBuilder: (context, state) => const NoTransitionPage(
+              child: LeadershipDashboardContent(),
+            ),
           ),
         ],
       ),

--- a/frontend/lib/services/reports_service.dart
+++ b/frontend/lib/services/reports_service.dart
@@ -28,41 +28,33 @@ class ReportsService {
     required String periodStart,
     required String periodEnd,
   }) async {
-    try {
-      final data = await apiClient.get(
-        'reports/summary',
-        queryParameters: {
-          'dateFrom': periodStart,
-          'dateTo': periodEnd,
-        },
-      );
+    final data = await apiClient.get(
+      'reports/summary',
+      queryParameters: {
+        'dateFrom': periodStart,
+        'dateTo': periodEnd,
+      },
+    );
 
-      return ReportSummary.fromApi(data as Map<String, dynamic>);
-    } catch (e) {
-      return ReportSummary.empty();
-    }
+    return ReportSummary.fromApi(data as Map<String, dynamic>);
   }
 
   Future<List<ReportBreakdown>> getPersonalBreakdown({
     required String periodStart,
     required String periodEnd,
   }) async {
-    try {
-      final data = await apiClient.get(
-        'reports/breakdowns',
-        queryParameters: {
-          'dateFrom': periodStart,
-          'dateTo': periodEnd,
-        },
-      );
+    final data = await apiClient.get(
+      'reports/breakdowns',
+      queryParameters: {
+        'dateFrom': periodStart,
+        'dateTo': periodEnd,
+      },
+    );
 
-      final items = data['byType'] as List<dynamic>? ?? [];
-      return items
-          .map((item) => ReportBreakdown.fromApi(item as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-      return [];
-    }
+    final items = data['byType'] as List<dynamic>? ?? [];
+    return items
+        .map((item) => ReportBreakdown.fromApi(item as Map<String, dynamic>))
+        .toList();
   }
 
   Future<BreakdownsComparisonResponse> getBreakdownWithComparison({
@@ -96,26 +88,22 @@ class ReportsService {
     required String periodStart,
     required String periodEnd,
   }) async {
-    try {
-      final queryParams = <String, String>{
-        'dateFrom': periodStart,
-        'dateTo': periodEnd,
-      };
+    final queryParams = <String, String>{
+      'dateFrom': periodStart,
+      'dateTo': periodEnd,
+    };
 
-      if (entityId != null) queryParams['entityId'] = entityId;
+    if (entityId != null) queryParams['entityId'] = entityId;
 
-      final data = await apiClient.get(
-        'reports/breakdowns',
-        queryParameters: queryParams,
-      );
+    final data = await apiClient.get(
+      'reports/breakdowns',
+      queryParameters: queryParams,
+    );
 
-      final items = data['byType'] as List<dynamic>? ?? [];
-      return items
-          .map((item) => ReportBreakdown.fromApi(item as Map<String, dynamic>))
-          .toList();
-    } catch (e) {
-      return [];
-    }
+    final items = data['byType'] as List<dynamic>? ?? [];
+    return items
+        .map((item) => ReportBreakdown.fromApi(item as Map<String, dynamic>))
+        .toList();
   }
 
   /// Get summary report with optional hierarchy breakdown for entity leaders
@@ -125,24 +113,20 @@ class ReportsService {
     String? periodEnd,
     bool includeHierarchyBreakdown = true,
   }) async {
-    try {
-      final queryParams = <String, String>{
-        'includeHierarchyBreakdown': includeHierarchyBreakdown.toString(),
-      };
+    final queryParams = <String, String>{
+      'includeHierarchyBreakdown': includeHierarchyBreakdown.toString(),
+    };
 
-      if (entityId != null) queryParams['entityId'] = entityId;
-      if (periodStart != null) queryParams['dateFrom'] = periodStart;
-      if (periodEnd != null) queryParams['dateTo'] = periodEnd;
+    if (entityId != null) queryParams['entityId'] = entityId;
+    if (periodStart != null) queryParams['dateFrom'] = periodStart;
+    if (periodEnd != null) queryParams['dateTo'] = periodEnd;
 
-      final data = await apiClient.get(
-        'reports/summary',
-        queryParameters: queryParams,
-      );
+    final data = await apiClient.get(
+      'reports/summary',
+      queryParameters: queryParams,
+    );
 
-      return HierarchySummaryResponse.fromApi(data as Map<String, dynamic>);
-    } catch (e) {
-      return HierarchySummaryResponse.empty();
-    }
+    return HierarchySummaryResponse.fromApi(data as Map<String, dynamic>);
   }
 
   /// Get activities for a specific user (requires hierarchy access)
@@ -154,25 +138,21 @@ class ReportsService {
     int page = 1,
     int limit = 20,
   }) async {
-    try {
-      final queryParams = <String, String>{
-        'page': page.toString(),
-        'limit': limit.toString(),
-      };
+    final queryParams = <String, String>{
+      'page': page.toString(),
+      'limit': limit.toString(),
+    };
 
-      if (periodId != null) queryParams['periodId'] = periodId;
-      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
-      if (dateTo != null) queryParams['dateTo'] = dateTo;
+    if (periodId != null) queryParams['periodId'] = periodId;
+    if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+    if (dateTo != null) queryParams['dateTo'] = dateTo;
 
-      final data = await apiClient.get(
-        'reports/user/$userId/activities',
-        queryParameters: queryParams,
-      );
+    final data = await apiClient.get(
+      'reports/user/$userId/activities',
+      queryParameters: queryParams,
+    );
 
-      return UserActivitiesResponse.fromApi(data as Map<String, dynamic>);
-    } catch (e) {
-      rethrow;
-    }
+    return UserActivitiesResponse.fromApi(data as Map<String, dynamic>);
   }
 
   /// Get compliance report (submitted vs not submitted users)
@@ -181,22 +161,18 @@ class ReportsService {
     String? dateFrom,
     String? dateTo,
   }) async {
-    try {
-      final queryParams = <String, String>{};
+    final queryParams = <String, String>{};
 
-      if (entityId != null) queryParams['entityId'] = entityId;
-      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
-      if (dateTo != null) queryParams['dateTo'] = dateTo;
+    if (entityId != null) queryParams['entityId'] = entityId;
+    if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+    if (dateTo != null) queryParams['dateTo'] = dateTo;
 
-      final data = await apiClient.get(
-        'reports/compliance',
-        queryParameters: queryParams,
-      );
+    final data = await apiClient.get(
+      'reports/compliance',
+      queryParameters: queryParams,
+    );
 
-      return ComplianceResponse.fromApi(data as Map<String, dynamic>);
-    } catch (e) {
-      return ComplianceResponse.empty();
-    }
+    return ComplianceResponse.fromApi(data as Map<String, dynamic>);
   }
 
   /// Get paginated users report with activity metrics
@@ -211,29 +187,25 @@ class ReportsService {
     ComplianceFilter? compliance,
     String? search,
   }) async {
-    try {
-      final queryParams = <String, String>{
-        'page': page.toString(),
-        'limit': limit.toString(),
-      };
+    final queryParams = <String, String>{
+      'page': page.toString(),
+      'limit': limit.toString(),
+    };
 
-      if (entityId != null) queryParams['entityId'] = entityId;
-      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
-      if (dateTo != null) queryParams['dateTo'] = dateTo;
-      if (sortBy != null) queryParams['sortBy'] = sortBy;
-      if (sortOrder != null) queryParams['sortOrder'] = sortOrder;
-      if (compliance != null) queryParams['compliance'] = compliance.apiValue;
-      if (search != null && search.isNotEmpty) queryParams['search'] = search;
+    if (entityId != null) queryParams['entityId'] = entityId;
+    if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+    if (dateTo != null) queryParams['dateTo'] = dateTo;
+    if (sortBy != null) queryParams['sortBy'] = sortBy;
+    if (sortOrder != null) queryParams['sortOrder'] = sortOrder;
+    if (compliance != null) queryParams['compliance'] = compliance.apiValue;
+    if (search != null && search.isNotEmpty) queryParams['search'] = search;
 
-      final data = await apiClient.get(
-        'reports/users',
-        queryParameters: queryParams,
-      );
+    final data = await apiClient.get(
+      'reports/users',
+      queryParameters: queryParams,
+    );
 
-      return UsersReportResponse.fromApi(data as Map<String, dynamic>);
-    } catch (e) {
-      rethrow;
-    }
+    return UsersReportResponse.fromApi(data as Map<String, dynamic>);
   }
 
   /// Get export URL for downloading reports
@@ -310,22 +282,18 @@ class ReportsService {
     String? dateFrom,
     String? dateTo,
   }) async {
-    try {
-      final queryParams = <String, String>{};
+    final queryParams = <String, String>{};
 
-      if (entityId != null) queryParams['entityId'] = entityId;
-      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
-      if (dateTo != null) queryParams['dateTo'] = dateTo;
+    if (entityId != null) queryParams['entityId'] = entityId;
+    if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+    if (dateTo != null) queryParams['dateTo'] = dateTo;
 
-      final data = await apiClient.get(
-        'reports/trends',
-        queryParameters: queryParams,
-      );
+    final data = await apiClient.get(
+      'reports/trends',
+      queryParameters: queryParams,
+    );
 
-      return TrendsResponse.fromApi(data as Map<String, dynamic>);
-    } catch (e) {
-      return TrendsResponse.empty();
-    }
+    return TrendsResponse.fromApi(data as Map<String, dynamic>);
   }
 
   /// Compare current period with previous period
@@ -339,27 +307,23 @@ class ReportsService {
     int? quarter,
     int? half,
   }) async {
-    try {
-      final queryParams = <String, String>{};
+    final queryParams = <String, String>{};
 
-      if (entityId != null) queryParams['entityId'] = entityId;
-      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
-      if (dateTo != null) queryParams['dateTo'] = dateTo;
-      if (periodType != null) queryParams['periodType'] = periodType.apiValue;
-      if (year != null) queryParams['year'] = year.toString();
-      if (month != null) queryParams['month'] = month.toString();
-      if (quarter != null) queryParams['quarter'] = quarter.toString();
-      if (half != null) queryParams['half'] = half.toString();
+    if (entityId != null) queryParams['entityId'] = entityId;
+    if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+    if (dateTo != null) queryParams['dateTo'] = dateTo;
+    if (periodType != null) queryParams['periodType'] = periodType.apiValue;
+    if (year != null) queryParams['year'] = year.toString();
+    if (month != null) queryParams['month'] = month.toString();
+    if (quarter != null) queryParams['quarter'] = quarter.toString();
+    if (half != null) queryParams['half'] = half.toString();
 
-      final data = await apiClient.get(
-        'reports/comparison',
-        queryParameters: queryParams,
-      );
+    final data = await apiClient.get(
+      'reports/comparison',
+      queryParameters: queryParams,
+    );
 
-      return ComparisonResponse.fromApi(data as Map<String, dynamic>);
-    } catch (e) {
-      return ComparisonResponse.empty();
-    }
+    return ComparisonResponse.fromApi(data as Map<String, dynamic>);
   }
 
   /// Get rankings: top performers, lowest compliance, inactive users
@@ -370,24 +334,20 @@ class ReportsService {
     String? dateTo,
     int topN = 10,
   }) async {
-    try {
-      final queryParams = <String, String>{
-        'limit': topN.toString(),
-      };
+    final queryParams = <String, String>{
+      'limit': topN.toString(),
+    };
 
-      if (entityId != null) queryParams['entityId'] = entityId;
-      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
-      if (dateTo != null) queryParams['dateTo'] = dateTo;
+    if (entityId != null) queryParams['entityId'] = entityId;
+    if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+    if (dateTo != null) queryParams['dateTo'] = dateTo;
 
-      final data = await apiClient.get(
-        'reports/rankings',
-        queryParameters: queryParams,
-      );
+    final data = await apiClient.get(
+      'reports/rankings',
+      queryParameters: queryParams,
+    );
 
-      return RankingsResponse.fromApi(data as Map<String, dynamic>);
-    } catch (e) {
-      return RankingsResponse.empty();
-    }
+    return RankingsResponse.fromApi(data as Map<String, dynamic>);
   }
 
   /// Get expense breakdown by type, entity, and user
@@ -396,22 +356,18 @@ class ReportsService {
     String? dateFrom,
     String? dateTo,
   }) async {
-    try {
-      final queryParams = <String, String>{};
+    final queryParams = <String, String>{};
 
-      if (entityId != null) queryParams['entityId'] = entityId;
-      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
-      if (dateTo != null) queryParams['dateTo'] = dateTo;
+    if (entityId != null) queryParams['entityId'] = entityId;
+    if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+    if (dateTo != null) queryParams['dateTo'] = dateTo;
 
-      final data = await apiClient.get(
-        'reports/expenses',
-        queryParameters: queryParams,
-      );
+    final data = await apiClient.get(
+      'reports/expenses',
+      queryParameters: queryParams,
+    );
 
-      return ExpensesResponse.fromApi(data as Map<String, dynamic>);
-    } catch (e) {
-      return ExpensesResponse.empty();
-    }
+    return ExpensesResponse.fromApi(data as Map<String, dynamic>);
   }
 }
 

--- a/frontend/lib/services/reports_service.dart
+++ b/frontend/lib/services/reports_service.dart
@@ -7,6 +7,7 @@ import '../models/hierarchy_breakdown.dart';
 import '../models/user_activities.dart';
 import '../models/compliance_report.dart';
 import '../models/users_report.dart';
+import '../models/leadership_reports.dart';
 
 class ReportsService {
   ReportsService({
@@ -301,6 +302,116 @@ class ReportsService {
       contentType:
           response.headers['content-type'] ?? 'application/octet-stream',
     );
+  }
+
+  /// Get activity trends over multiple periods (last 5 periods)
+  Future<TrendsResponse> getTrends({
+    String? entityId,
+    String? dateFrom,
+    String? dateTo,
+  }) async {
+    try {
+      final queryParams = <String, String>{};
+
+      if (entityId != null) queryParams['entityId'] = entityId;
+      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+      if (dateTo != null) queryParams['dateTo'] = dateTo;
+
+      final data = await apiClient.get(
+        'reports/trends',
+        queryParameters: queryParams,
+      );
+
+      return TrendsResponse.fromApi(data as Map<String, dynamic>);
+    } catch (e) {
+      return TrendsResponse.empty();
+    }
+  }
+
+  /// Compare current period with previous period
+  Future<ComparisonResponse> getComparison({
+    String? entityId,
+    String? dateFrom,
+    String? dateTo,
+    ReportPeriodType? periodType,
+    int? year,
+    int? month,
+    int? quarter,
+    int? half,
+  }) async {
+    try {
+      final queryParams = <String, String>{};
+
+      if (entityId != null) queryParams['entityId'] = entityId;
+      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+      if (dateTo != null) queryParams['dateTo'] = dateTo;
+      if (periodType != null) queryParams['periodType'] = periodType.apiValue;
+      if (year != null) queryParams['year'] = year.toString();
+      if (month != null) queryParams['month'] = month.toString();
+      if (quarter != null) queryParams['quarter'] = quarter.toString();
+      if (half != null) queryParams['half'] = half.toString();
+
+      final data = await apiClient.get(
+        'reports/comparison',
+        queryParameters: queryParams,
+      );
+
+      return ComparisonResponse.fromApi(data as Map<String, dynamic>);
+    } catch (e) {
+      return ComparisonResponse.empty();
+    }
+  }
+
+  /// Get rankings: top performers, lowest compliance, inactive users
+  /// Requires REPORT_VIEW_HIERARCHY permission
+  Future<RankingsResponse> getRankings({
+    String? entityId,
+    String? dateFrom,
+    String? dateTo,
+    int topN = 10,
+  }) async {
+    try {
+      final queryParams = <String, String>{
+        'limit': topN.toString(),
+      };
+
+      if (entityId != null) queryParams['entityId'] = entityId;
+      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+      if (dateTo != null) queryParams['dateTo'] = dateTo;
+
+      final data = await apiClient.get(
+        'reports/rankings',
+        queryParameters: queryParams,
+      );
+
+      return RankingsResponse.fromApi(data as Map<String, dynamic>);
+    } catch (e) {
+      return RankingsResponse.empty();
+    }
+  }
+
+  /// Get expense breakdown by type, entity, and user
+  Future<ExpensesResponse> getExpenses({
+    String? entityId,
+    String? dateFrom,
+    String? dateTo,
+  }) async {
+    try {
+      final queryParams = <String, String>{};
+
+      if (entityId != null) queryParams['entityId'] = entityId;
+      if (dateFrom != null) queryParams['dateFrom'] = dateFrom;
+      if (dateTo != null) queryParams['dateTo'] = dateTo;
+
+      final data = await apiClient.get(
+        'reports/expenses',
+        queryParameters: queryParams,
+      );
+
+      return ExpensesResponse.fromApi(data as Map<String, dynamic>);
+    } catch (e) {
+      return ExpensesResponse.empty();
+    }
   }
 }
 

--- a/frontend/lib/widgets/layouts/app_shell.dart
+++ b/frontend/lib/widgets/layouts/app_shell.dart
@@ -108,6 +108,9 @@ class AppShell extends ConsumerWidget {
       case '/reports':
         title = 'Reportes';
         break;
+      case '/leadership':
+        title = 'Rendimiento';
+        break;
       default:
         if (currentPath.startsWith('/activities/')) {
           title = 'Actividades';

--- a/frontend/lib/widgets/nav/mobile_drawer.dart
+++ b/frontend/lib/widgets/nav/mobile_drawer.dart
@@ -89,6 +89,13 @@ class MobileDrawer extends StatelessWidget {
                           path: AppRoutes.reports,
                           isActive: currentPath == AppRoutes.reports,
                         ),
+                        _buildNavItem(
+                          context,
+                          icon: Icons.analytics,
+                          label: 'Rendimiento',
+                          path: AppRoutes.leadershipDashboard,
+                          isActive: currentPath == AppRoutes.leadershipDashboard,
+                        ),
                         const SizedBox(height: LayoutConstants.spacing12),
                       ],
                     ),

--- a/frontend/lib/widgets/nav/mobile_drawer.dart
+++ b/frontend/lib/widgets/nav/mobile_drawer.dart
@@ -94,7 +94,8 @@ class MobileDrawer extends StatelessWidget {
                           icon: Icons.analytics,
                           label: 'Rendimiento',
                           path: AppRoutes.leadershipDashboard,
-                          isActive: currentPath == AppRoutes.leadershipDashboard,
+                          isActive:
+                              currentPath == AppRoutes.leadershipDashboard,
                         ),
                         const SizedBox(height: LayoutConstants.spacing12),
                       ],

--- a/frontend/lib/widgets/nav/mobile_drawer.dart
+++ b/frontend/lib/widgets/nav/mobile_drawer.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/layout_constants.dart';
+import '../../providers/auth.dart';
 import '../../router.dart';
 import '../../theme/app_theme.dart';
 
 /// Mobile navigation drawer with the same styling as the desktop sidebar
-class MobileDrawer extends StatelessWidget {
+class MobileDrawer extends ConsumerWidget {
   final String userName;
   final String userEmail;
   final String? userPicture;
@@ -21,7 +23,7 @@ class MobileDrawer extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Drawer(
       child: Container(
         decoration: const BoxDecoration(
@@ -89,14 +91,15 @@ class MobileDrawer extends StatelessWidget {
                           path: AppRoutes.reports,
                           isActive: currentPath == AppRoutes.reports,
                         ),
-                        _buildNavItem(
-                          context,
-                          icon: Icons.analytics,
-                          label: 'Rendimiento',
-                          path: AppRoutes.leadershipDashboard,
-                          isActive:
-                              currentPath == AppRoutes.leadershipDashboard,
-                        ),
+                        if (ref.watch(canViewReportsProvider))
+                          _buildNavItem(
+                            context,
+                            icon: Icons.analytics,
+                            label: 'Rendimiento',
+                            path: AppRoutes.leadershipDashboard,
+                            isActive:
+                                currentPath == AppRoutes.leadershipDashboard,
+                          ),
                         const SizedBox(height: LayoutConstants.spacing12),
                       ],
                     ),

--- a/frontend/lib/widgets/nav/sidebar_nav.dart
+++ b/frontend/lib/widgets/nav/sidebar_nav.dart
@@ -94,13 +94,14 @@ class SidebarNav extends ConsumerWidget {
                       path: AppRoutes.reports,
                       isActive: currentPath == AppRoutes.reports,
                     ),
-                    _buildNavItem(
-                      context,
-                      icon: Icons.analytics,
-                      label: 'Rendimiento',
-                      path: AppRoutes.leadershipDashboard,
-                      isActive: currentPath == AppRoutes.leadershipDashboard,
-                    ),
+                    if (ref.watch(canViewReportsProvider))
+                      _buildNavItem(
+                        context,
+                        icon: Icons.analytics,
+                        label: 'Rendimiento',
+                        path: AppRoutes.leadershipDashboard,
+                        isActive: currentPath == AppRoutes.leadershipDashboard,
+                      ),
                     const SizedBox(height: LayoutConstants.spacing12),
                   ],
                 ),

--- a/frontend/lib/widgets/nav/sidebar_nav.dart
+++ b/frontend/lib/widgets/nav/sidebar_nav.dart
@@ -94,6 +94,13 @@ class SidebarNav extends ConsumerWidget {
                       path: AppRoutes.reports,
                       isActive: currentPath == AppRoutes.reports,
                     ),
+                    _buildNavItem(
+                      context,
+                      icon: Icons.analytics,
+                      label: 'Rendimiento',
+                      path: AppRoutes.leadershipDashboard,
+                      isActive: currentPath == AppRoutes.leadershipDashboard,
+                    ),
                     const SizedBox(height: LayoutConstants.spacing12),
                   ],
                 ),

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -297,10 +297,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -534,10 +534,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   typed_data:
     dependency: transitive
     description:

--- a/frontend/test/models/leadership_reports_test.dart
+++ b/frontend/test/models/leadership_reports_test.dart
@@ -1,0 +1,180 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/models/leadership_reports.dart';
+
+void main() {
+  group('TrendsResponse', () {
+    test('fromApi parses periods correctly', () {
+      final data = {
+        'periods': [
+          {
+            'periodId': 'p1',
+            'startDate': '2026-01-01',
+            'endDate': '2026-01-14',
+            'activities': 10,
+            'expenses': 500.0,
+            'complianceRate': 85.5,
+            'usersSubmitted': 8,
+            'usersExpected': 10,
+          }
+        ]
+      };
+      final result = TrendsResponse.fromApi(data);
+      expect(result.periods.length, 1);
+      expect(result.periods[0].activities, 10);
+      expect(result.periods[0].expenses, 500.0);
+      expect(result.periods[0].complianceRate, 85.5);
+    });
+
+    test('fromApi handles empty periods', () {
+      final result = TrendsResponse.fromApi({'periods': []});
+      expect(result.periods, isEmpty);
+    });
+
+    test('fromApi handles missing periods key', () {
+      final result = TrendsResponse.fromApi({});
+      expect(result.periods, isEmpty);
+    });
+
+    test('empty() returns empty response', () {
+      final result = TrendsResponse.empty();
+      expect(result.periods, isEmpty);
+    });
+  });
+
+  group('ComparisonResponse', () {
+    test('fromApi parses current and previous', () {
+      final data = {
+        'current': {
+          'periodId': 'p1',
+          'dates': '2026-01-01 - 2026-01-14',
+          'activities': 10,
+          'expenses': 500.0,
+          'complianceRate': 85.0,
+          'usersActive': 8,
+        },
+        'previous': {
+          'periodId': 'p0',
+          'dates': '2025-12-18 - 2025-12-31',
+          'activities': 7,
+          'expenses': 300.0,
+          'complianceRate': 70.0,
+          'usersActive': 6,
+        },
+        'changes': {
+          'activities': {'value': 3.0, 'percent': 42.9},
+          'expenses': {'value': 200.0, 'percent': 66.7},
+          'complianceRate': {'value': 15.0, 'percent': 21.4},
+          'usersActive': {'value': 2.0, 'percent': 33.3},
+        },
+      };
+      final result = ComparisonResponse.fromApi(data);
+      expect(result.current.activities, 10);
+      expect(result.previous.activities, 7);
+      expect(result.changes.activities.value, 3.0);
+      expect(result.changes.activities.percent, 42.9);
+    });
+  });
+
+  group('Change', () {
+    test('isPositive returns true for positive values', () {
+      const change = Change(value: 5.0, percent: 10.0);
+      expect(change.isPositive, isTrue);
+      expect(change.isNegative, isFalse);
+      expect(change.isNeutral, isFalse);
+    });
+
+    test('isNegative returns true for negative values', () {
+      const change = Change(value: -3.0, percent: -15.0);
+      expect(change.isPositive, isFalse);
+      expect(change.isNegative, isTrue);
+      expect(change.isNeutral, isFalse);
+    });
+
+    test('isNeutral returns true for zero value', () {
+      const change = Change(value: 0.0, percent: 0.0);
+      expect(change.isPositive, isFalse);
+      expect(change.isNegative, isFalse);
+      expect(change.isNeutral, isTrue);
+    });
+  });
+
+  group('RankingsResponse', () {
+    test('fromApi parses all three lists', () {
+      final data = {
+        'topPerformers': [
+          {
+            'userId': 'u1',
+            'name': 'Alice',
+            'entity': 'Field A',
+            'count': 15,
+            'expenses': 200.0,
+          }
+        ],
+        'lowestCompliance': [
+          {'entityId': 'e1', 'name': 'Field B', 'rate': 40.0, 'missing': 3}
+        ],
+        'inactiveUsers': [
+          {
+            'userId': 'u2',
+            'name': 'Bob',
+            'entity': 'Field C',
+            'periodsInactive': 2,
+          }
+        ],
+      };
+      final result = RankingsResponse.fromApi(data);
+      expect(result.topPerformers.length, 1);
+      expect(result.topPerformers[0].name, 'Alice');
+      expect(result.lowestCompliance.length, 1);
+      expect(result.lowestCompliance[0].rate, 40.0);
+      expect(result.inactiveUsers.length, 1);
+      expect(result.inactiveUsers[0].periodsInactive, 2);
+    });
+  });
+
+  group('ExpensesResponse', () {
+    test('fromApi parses total and breakdowns', () {
+      final data = {
+        'total': 1500.0,
+        'byType': [
+          {
+            'typeId': 't1',
+            'name': 'Travel',
+            'total': 800.0,
+            'percent': 53.3,
+            'avgPerActivity': 100.0,
+          }
+        ],
+        'byEntity': [
+          {
+            'entityId': 'e1',
+            'name': 'Field A',
+            'total': 1000.0,
+            'percent': 66.7,
+            'perUser': 250.0,
+          }
+        ],
+        'byUser': [
+          {
+            'userId': 'u1',
+            'name': 'Alice',
+            'total': 500.0,
+            'percent': 33.3,
+          }
+        ],
+      };
+      final result = ExpensesResponse.fromApi(data);
+      expect(result.total, 1500.0);
+      expect(result.byType.length, 1);
+      expect(result.byType[0].name, 'Travel');
+      expect(result.byEntity.length, 1);
+      expect(result.byUser.length, 1);
+    });
+
+    test('empty() returns zero total and empty lists', () {
+      final result = ExpensesResponse.empty();
+      expect(result.total, 0.0);
+      expect(result.byType, isEmpty);
+    });
+  });
+}

--- a/frontend/test/services/reports_service_test.dart
+++ b/frontend/test/services/reports_service_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/services/reports_service.dart';
 import 'package:logger/core/api_client.dart';
 import 'package:logger/core/errors/app_exception.dart';
-import 'package:logger/models/leadership_reports.dart';
 
 class ThrowingApiClient extends ApiClient {
   final Exception exception;

--- a/frontend/test/services/reports_service_test.dart
+++ b/frontend/test/services/reports_service_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/services/reports_service.dart';
+import 'package:logger/core/api_client.dart';
+import 'package:logger/core/errors/app_exception.dart';
+
+class ThrowingApiClient extends ApiClient {
+  final Exception exception;
+  ThrowingApiClient(this.exception)
+      : super(baseUrl: 'http://test', getAccessToken: () async => 'token');
+
+  @override
+  Future<dynamic> get(String path,
+      {Map<String, String>? queryParameters,
+      Map<String, String>? headers}) async {
+    throw exception;
+  }
+}
+
+void main() {
+  final exceptions = <String, Exception>{
+    'AuthException': AuthException.unauthorized(),
+    'NetworkException': const NetworkException(),
+    'ServerException': ServerException.internalError(),
+  };
+
+  group('ReportsService error propagation', () {
+    exceptions.forEach((name, exception) {
+      group('propagates $name', () {
+        late ReportsService service;
+
+        setUp(() {
+          service =
+              ReportsService(apiClient: ThrowingApiClient(exception));
+        });
+
+        test('getPersonalSummary throws $name', () async {
+          expect(
+            () => service.getPersonalSummary(
+              periodStart: '2024-01-01',
+              periodEnd: '2024-01-31',
+            ),
+            throwsA(isA<AppException>()),
+          );
+        });
+
+        test('getPersonalBreakdown throws $name', () async {
+          expect(
+            () => service.getPersonalBreakdown(
+              periodStart: '2024-01-01',
+              periodEnd: '2024-01-31',
+            ),
+            throwsA(isA<AppException>()),
+          );
+        });
+
+        test('getEntityBreakdown throws $name', () async {
+          expect(
+            () => service.getEntityBreakdown(
+              periodStart: '2024-01-01',
+              periodEnd: '2024-01-31',
+            ),
+            throwsA(isA<AppException>()),
+          );
+        });
+
+        test('getHierarchySummary throws $name', () async {
+          expect(
+            () => service.getHierarchySummary(),
+            throwsA(isA<AppException>()),
+          );
+        });
+
+        test('getCompliance throws $name', () async {
+          expect(
+            () => service.getCompliance(),
+            throwsA(isA<AppException>()),
+          );
+        });
+
+        test('getTrends throws $name', () async {
+          expect(
+            () => service.getTrends(),
+            throwsA(isA<AppException>()),
+          );
+        });
+
+        test('getComparison throws $name', () async {
+          expect(
+            () => service.getComparison(),
+            throwsA(isA<AppException>()),
+          );
+        });
+
+        test('getRankings throws $name', () async {
+          expect(
+            () => service.getRankings(),
+            throwsA(isA<AppException>()),
+          );
+        });
+
+        test('getExpenses throws $name', () async {
+          expect(
+            () => service.getExpenses(),
+            throwsA(isA<AppException>()),
+          );
+        });
+      });
+    });
+  });
+}

--- a/frontend/test/services/reports_service_test.dart
+++ b/frontend/test/services/reports_service_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/services/reports_service.dart';
 import 'package:logger/core/api_client.dart';
 import 'package:logger/core/errors/app_exception.dart';
+import 'package:logger/models/leadership_reports.dart';
 
 class ThrowingApiClient extends ApiClient {
   final Exception exception;
@@ -13,6 +14,22 @@ class ThrowingApiClient extends ApiClient {
       {Map<String, String>? queryParameters,
       Map<String, String>? headers}) async {
     throw exception;
+  }
+}
+
+class _CapturingApiClient extends ApiClient {
+  final dynamic response;
+  final void Function(String path, Map<String, String>? params)? onGet;
+
+  _CapturingApiClient({required this.response, this.onGet})
+      : super(baseUrl: 'http://test', getAccessToken: () async => 'token');
+
+  @override
+  Future<dynamic> get(String path,
+      {Map<String, String>? queryParameters,
+      Map<String, String>? headers}) async {
+    onGet?.call(path, queryParameters);
+    return response;
   }
 }
 
@@ -103,6 +120,136 @@ void main() {
             () => service.getExpenses(),
             throwsA(isA<AppException>()),
           );
+        });
+      });
+    });
+
+    group('Leadership endpoint methods', () {
+      group('getTrends', () {
+        test('should propagate exceptions', () {
+          final service = ReportsService(
+              apiClient: ThrowingApiClient(AuthException.forbidden()));
+          expect(
+            () => service.getTrends(
+                dateFrom: '2026-01-01', dateTo: '2026-01-31'),
+            throwsA(isA<AuthException>()),
+          );
+        });
+
+        test('should call correct endpoint', () async {
+          String? capturedPath;
+          final mockClient = _CapturingApiClient(
+            response: {'periods': []},
+            onGet: (path, params) => capturedPath = path,
+          );
+          final service = ReportsService(apiClient: mockClient);
+          await service.getTrends(
+              dateFrom: '2026-01-01', dateTo: '2026-01-31');
+          expect(capturedPath, 'reports/trends');
+        });
+      });
+
+      group('getComparison', () {
+        test('should propagate exceptions', () {
+          final service = ReportsService(
+              apiClient: ThrowingApiClient(ServerException.internalError()));
+          expect(
+            () => service.getComparison(
+                dateFrom: '2026-01-01', dateTo: '2026-01-31'),
+            throwsA(isA<ServerException>()),
+          );
+        });
+
+        test('should call correct endpoint', () async {
+          String? capturedPath;
+          final mockClient = _CapturingApiClient(
+            response: {
+              'current': {
+                'periodId': '',
+                'dates': '',
+                'activities': 0,
+                'expenses': 0.0,
+                'complianceRate': 0.0,
+                'usersActive': 0,
+              },
+              'previous': {
+                'periodId': '',
+                'dates': '',
+                'activities': 0,
+                'expenses': 0.0,
+                'complianceRate': 0.0,
+                'usersActive': 0,
+              },
+              'changes': {
+                'activities': {'value': 0.0, 'percent': 0.0},
+                'expenses': {'value': 0.0, 'percent': 0.0},
+                'complianceRate': {'value': 0.0, 'percent': 0.0},
+                'usersActive': {'value': 0.0, 'percent': 0.0},
+              },
+            },
+            onGet: (path, params) => capturedPath = path,
+          );
+          final service = ReportsService(apiClient: mockClient);
+          await service.getComparison(
+              dateFrom: '2026-01-01', dateTo: '2026-01-31');
+          expect(capturedPath, 'reports/comparison');
+        });
+      });
+
+      group('getRankings', () {
+        test('should propagate exceptions', () {
+          final service = ReportsService(
+              apiClient: ThrowingApiClient(AuthException.forbidden()));
+          expect(
+            () => service.getRankings(
+                dateFrom: '2026-01-01', dateTo: '2026-01-31'),
+            throwsA(isA<AuthException>()),
+          );
+        });
+
+        test('should call correct endpoint', () async {
+          String? capturedPath;
+          final mockClient = _CapturingApiClient(
+            response: {
+              'topPerformers': [],
+              'lowestCompliance': [],
+              'inactiveUsers': [],
+            },
+            onGet: (path, params) => capturedPath = path,
+          );
+          final service = ReportsService(apiClient: mockClient);
+          await service.getRankings(
+              dateFrom: '2026-01-01', dateTo: '2026-01-31');
+          expect(capturedPath, 'reports/rankings');
+        });
+      });
+
+      group('getExpenses', () {
+        test('should propagate exceptions', () {
+          final service = ReportsService(
+              apiClient: ThrowingApiClient(NetworkException.timeout()));
+          expect(
+            () => service.getExpenses(
+                dateFrom: '2026-01-01', dateTo: '2026-01-31'),
+            throwsA(isA<NetworkException>()),
+          );
+        });
+
+        test('should call correct endpoint', () async {
+          String? capturedPath;
+          final mockClient = _CapturingApiClient(
+            response: {
+              'total': 0.0,
+              'byType': [],
+              'byEntity': [],
+              'byUser': [],
+            },
+            onGet: (path, params) => capturedPath = path,
+          );
+          final service = ReportsService(apiClient: mockClient);
+          await service.getExpenses(
+              dateFrom: '2026-01-01', dateTo: '2026-01-31');
+          expect(capturedPath, 'reports/expenses');
         });
       });
     });


### PR DESCRIPTION
## Summary

- Rewrites the Leadership Dashboard (supersedes #194) with proper error handling, permission gating, and AsyncValue state management
- Removes catch-all error swallowing from all ReportsService methods, letting typed exceptions (AuthException, NetworkException, ServerException) propagate to the UI
- Gates the "Rendimiento" nav item behind `canViewReportsProvider` in both desktop sidebar and mobile drawer
- Replaces custom `LeadershipDashboardState` with `AsyncValue<LeadershipDashboardData>` and parallel loading via `Future.wait`
- Fixes `Change.isPositive` to exclude zero (was `>= 0`, now `> 0`) and adds `isNeutral` for three-way color display

## Test plan

- [ ] 122 frontend tests pass (`flutter test`) including 46 new tests
- [ ] 48 backend reports tests pass (`npm test -- --testPathPattern=reports`)
- [ ] `flutter analyze` reports 0 issues
- [ ] Non-leadership users should NOT see "Rendimiento" in navigation
- [ ] Leadership users see the dashboard with comparison cards, trends table, rankings, and expenses
- [ ] Network/auth errors show typed error messages with retry button
- [ ] Period controls (monthly/quarterly/biannual/annual) navigate correctly

Supersedes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)