### PR TITLE
feat: Add configurable CORS origins through environment variable

### DIFF
--- a/backend/src/config/config.validation.ts
+++ b/backend/src/config/config.validation.ts
@@ -11,6 +11,8 @@ export const configValidationSchema = Joi.object({
 
   AUTH0_AUDIENCE: Joi.string().required(),
 
+  CORS_ORIGINS: Joi.string().optional(),
+
   DB_HOST: Joi.string().required(),
   DB_PORT: Joi.number().default(5432),
   DB_USERNAME: Joi.string().required(),

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -6,12 +6,16 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  const corsOriginsEnv = process.env.CORS_ORIGINS?.trim();
+  const corsOrigins = corsOriginsEnv
+    ? corsOriginsEnv
+        .split(',')
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+    : ['http://localhost:3000', 'http://localhost:8080'];
+
   app.enableCors({
-    origin: [
-      'http://localhost:8080',
-      'http://localhost:3000',
-      'https://secretary-backend.pages.dev',
-    ],
+    origin: corsOrigins,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
     credentials: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       AUTH0_DOMAIN: dev-ohuspam6fnmh4tgt.us.auth0.com
       AUTH0_AUDIENCE: logger
       AUTH0_ISSUER: https://dev-ohuspam6fnmh4tgt.us.auth0.com/
+      CORS_ORIGINS: http://localhost:3000,http://localhost:8080
       ADMIN_EMAIL: hndoss@gmail.com
       ADMIN_USERNAME: "hndoss"
       ADMIN_IDP_ISSUER: https://dev-ohuspam6fnmh4tgt.us.auth0.com/
@@ -77,6 +78,7 @@ services:
       AUTH0_DOMAIN: dev-ohuspam6fnmh4tgt.us.auth0.com
       AUTH0_AUDIENCE: logger
       AUTH0_ISSUER: https://dev-ohuspam6fnmh4tgt.us.auth0.com/
+      CORS_ORIGINS: http://localhost:3000,http://localhost:8080
       ADMIN_EMAIL: hndoss@gmail.com
       ADMIN_USERNAME: "hndoss"
       ADMIN_IDP_ISSUER: https://dev-ohuspam6fnmh4tgt.us.auth0.com/

--- a/infra/modules/container_apps/main.tf
+++ b/infra/modules/container_apps/main.tf
@@ -92,6 +92,10 @@ resource "azurerm_container_app" "api" {
         value = var.auth0_issuer
       }
       env {
+        name  = "CORS_ORIGINS"
+        value = var.cors_origins
+      }
+      env {
         name  = "ADMIN_EMAIL"
         value = var.admin_email
       }

--- a/infra/modules/container_apps/variables.tf
+++ b/infra/modules/container_apps/variables.tf
@@ -66,7 +66,7 @@ variable "auth0_issuer" {
 
 variable "cors_origins" {
   type    = string
-  default = ""
+  default = "https://secretary-backend.pages.dev"
 }
 
 variable "admin_email" {

--- a/infra/modules/container_apps/variables.tf
+++ b/infra/modules/container_apps/variables.tf
@@ -64,6 +64,11 @@ variable "auth0_issuer" {
   type = string
 }
 
+variable "cors_origins" {
+  type    = string
+  default = ""
+}
+
 variable "admin_email" {
   type = string
 }

--- a/infra/root/main.tf
+++ b/infra/root/main.tf
@@ -57,6 +57,7 @@ module "container_apps" {
   auth0_domain               = var.auth0_domain
   auth0_audience             = var.auth0_audience
   auth0_issuer               = var.auth0_issuer
+  cors_origins               = var.cors_origins
   admin_email                = var.admin_email
   admin_username             = var.admin_username
   admin_idp_issuer           = var.admin_idp_issuer

--- a/infra/root/variables.tf
+++ b/infra/root/variables.tf
@@ -56,7 +56,7 @@ variable "auth0_issuer" {
 variable "cors_origins" {
   type        = string
   description = "Comma-separated CORS origins for the API."
-  default     = ""
+  default     = "https://secretary-backend.pages.dev"
 }
 
 variable "admin_email" {

--- a/infra/root/variables.tf
+++ b/infra/root/variables.tf
@@ -53,6 +53,12 @@ variable "auth0_issuer" {
   description = "Auth0 issuer URL."
 }
 
+variable "cors_origins" {
+  type        = string
+  description = "Comma-separated CORS origins for the API."
+  default     = ""
+}
+
 variable "admin_email" {
   type        = string
   description = "Admin user email for bootstrap."


### PR DESCRIPTION
### Summary
Introduces a new `CORS_ORIGINS` environment variable to make CORS configuration flexible across different deployment environments instead of hardcoding allowed origins.

### Changes
- **Backend Configuration**:
  - Added `CORS_ORIGINS` field to config validation schema (optional)
  - Refactored CORS setup in `main.ts` to parse and use `CORS_ORIGINS` environment variable
  - Falls back to default behavior if not provided

- **Docker Configuration**:
  - Added `CORS_ORIGINS` environment variable to backend and init services in `docker-compose.yml`

- **Infrastructure (Terraform)**:
  - Added `cors_origins` variable to container apps module
  - Configured `CORS_ORIGINS` environment variable in container apps
  - Exposed `cors_origins` variable at root level for environment-specific configuration