### PR TITLE
fix(reports): translate raw period status to user-facing label

### DIFF
--- a/frontend/lib/models/report_summary.dart
+++ b/frontend/lib/models/report_summary.dart
@@ -4,7 +4,14 @@ class ReportSummary {
   final bool isReported;
   final String periodStart;
   final String periodEnd;
-  final String status; // 'Activo', 'Inactivo', etc.
+  final String status;
+
+  static const _statusLabels = <String, String>{
+    'active': 'Activo',
+    'locked': 'Bloqueado',
+  };
+
+  String get statusLabel => _statusLabels[status.toLowerCase()] ?? status;
 
   const ReportSummary({
     required this.totalActivities,

--- a/frontend/lib/pages/reports_view.dart
+++ b/frontend/lib/pages/reports_view.dart
@@ -225,7 +225,7 @@ class _ReportsViewContentState extends ConsumerState<ReportsViewContent> {
                   Row(
                     children: [
                       Text(
-                        'Estado: ${_summary?.status ?? "Activo"}',
+                        'Estado: ${_summary?.statusLabel ?? "Activo"}',
                         style: const TextStyle(
                           fontSize: 14,
                           fontWeight: FontWeight.w600,

--- a/frontend/test/models/report_summary_test.dart
+++ b/frontend/test/models/report_summary_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/models/report_summary.dart';
+
+void main() {
+  group('ReportSummary', () {
+    group('fromApi', () {
+      test('parses complete API response', () {
+        final summary = ReportSummary.fromApi({
+          'totals': {'activities': 5, 'expenses': 120.50, 'usersSubmitted': 1},
+          'period': {
+            'startDate': '2024-01-01',
+            'endDate': '2024-01-14',
+            'status': 'active',
+          },
+        });
+
+        expect(summary.totalActivities, 5);
+        expect(summary.totalExpenses, 120.50);
+        expect(summary.isReported, isTrue);
+        expect(summary.periodStart, '2024-01-01');
+        expect(summary.periodEnd, '2024-01-14');
+        expect(summary.status, 'active');
+      });
+
+      test('defaults missing fields gracefully', () {
+        final summary = ReportSummary.fromApi({});
+
+        expect(summary.totalActivities, 0);
+        expect(summary.totalExpenses, 0.0);
+        expect(summary.isReported, isFalse);
+        expect(summary.periodStart, '');
+        expect(summary.periodEnd, '');
+        expect(summary.status, 'Activo');
+      });
+    });
+
+    group('statusLabel', () {
+      test('translates active to Activo', () {
+        final summary = _summaryWithStatus('active');
+        expect(summary.statusLabel, 'Activo');
+      });
+
+      test('translates locked to Bloqueado', () {
+        final summary = _summaryWithStatus('locked');
+        expect(summary.statusLabel, 'Bloqueado');
+      });
+
+      test('handles uppercase variants', () {
+        final summary = _summaryWithStatus('ACTIVE');
+        expect(summary.statusLabel, 'Activo');
+      });
+
+      test('returns raw value for unknown statuses', () {
+        final summary = _summaryWithStatus('custom');
+        expect(summary.statusLabel, 'custom');
+      });
+    });
+
+    group('empty', () {
+      test('creates zeroed summary with Activo status', () {
+        final summary = ReportSummary.empty();
+
+        expect(summary.totalActivities, 0);
+        expect(summary.totalExpenses, 0.0);
+        expect(summary.isReported, isFalse);
+        expect(summary.status, 'Activo');
+      });
+    });
+  });
+}
+
+ReportSummary _summaryWithStatus(String status) {
+  return ReportSummary(
+    totalActivities: 0,
+    totalExpenses: 0.0,
+    isReported: false,
+    periodStart: '',
+    periodEnd: '',
+    status: status,
+  );
+}


### PR DESCRIPTION
## Summary
- Reports page displayed raw API status strings like `active`, `locked` in the UI
- Added `statusLabel` getter on `ReportSummary` that maps backend values to Spanish labels (`Activo`, `Bloqueado`)
- Updated `reports_view.dart` to use `statusLabel` instead of raw `status`

## Test plan
- [x] Added `report_summary_test.dart` covering `fromApi`, `statusLabel` (known + unknown statuses), and `empty` factory
- [ ] Manually verify reports page shows "Estado: Activo" or "Estado: Bloqueado" instead of raw strings

Closes #240