### PR TITLE
feat(activities): default list view to current month filter

### DIFF
--- a/frontend/lib/models/activities_list_state.dart
+++ b/frontend/lib/models/activities_list_state.dart
@@ -1,0 +1,59 @@
+import 'activity.dart';
+import 'activities_filter.dart';
+
+class ActivitiesListState {
+  final List<Activity> items;
+  final int page;
+  final int limit;
+  final int total;
+  final ActivitiesFilter filter;
+  final TimePreset? selectedPreset;
+
+  const ActivitiesListState({
+    required this.items,
+    required this.page,
+    required this.limit,
+    required this.total,
+    required this.filter,
+    this.selectedPreset,
+  });
+
+  factory ActivitiesListState.initial() {
+    final range = TimePreset.thisMonth.getRange();
+    return ActivitiesListState(
+      items: const [],
+      page: 1,
+      limit: 20,
+      total: 0,
+      filter: ActivitiesFilter(
+        startDate: range.start,
+        endDate: range.end,
+      ),
+      selectedPreset: TimePreset.thisMonth,
+    );
+  }
+
+  int get totalPages => total == 0 ? 1 : (total / limit).ceil();
+  bool get hasNextPage => page < totalPages;
+  bool get hasPreviousPage => page > 1;
+
+  ActivitiesListState copyWith({
+    List<Activity>? items,
+    int? page,
+    int? limit,
+    int? total,
+    ActivitiesFilter? filter,
+    TimePreset? selectedPreset,
+    bool clearPreset = false,
+  }) {
+    return ActivitiesListState(
+      items: items ?? this.items,
+      page: page ?? this.page,
+      limit: limit ?? this.limit,
+      total: total ?? this.total,
+      filter: filter ?? this.filter,
+      selectedPreset:
+          clearPreset ? null : (selectedPreset ?? this.selectedPreset),
+    );
+  }
+}

--- a/frontend/lib/providers/activities_list_provider.dart
+++ b/frontend/lib/providers/activities_list_provider.dart
@@ -1,60 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/activity.dart';
 import '../models/activities_filter.dart';
+import '../models/activities_list_state.dart';
 import 'activities.dart';
 
-class ActivitiesListState {
-  final List<Activity> items;
-  final int page;
-  final int limit;
-  final int total;
-  final ActivitiesFilter filter;
-  final TimePreset? selectedPreset;
-
-  const ActivitiesListState({
-    required this.items,
-    required this.page,
-    required this.limit,
-    required this.total,
-    required this.filter,
-    this.selectedPreset,
-  });
-
-  factory ActivitiesListState.initial() {
-    return const ActivitiesListState(
-      items: [],
-      page: 1,
-      limit: 20,
-      total: 0,
-      filter: ActivitiesFilter(),
-      selectedPreset: null,
-    );
-  }
-
-  int get totalPages => total == 0 ? 1 : (total / limit).ceil();
-  bool get hasNextPage => page < totalPages;
-  bool get hasPreviousPage => page > 1;
-
-  ActivitiesListState copyWith({
-    List<Activity>? items,
-    int? page,
-    int? limit,
-    int? total,
-    ActivitiesFilter? filter,
-    TimePreset? selectedPreset,
-    bool clearPreset = false,
-  }) {
-    return ActivitiesListState(
-      items: items ?? this.items,
-      page: page ?? this.page,
-      limit: limit ?? this.limit,
-      total: total ?? this.total,
-      filter: filter ?? this.filter,
-      selectedPreset:
-          clearPreset ? null : (selectedPreset ?? this.selectedPreset),
-    );
-  }
-}
+export '../models/activities_list_state.dart';
 
 class ActivitiesListNotifier extends AsyncNotifier<ActivitiesListState> {
   @override

--- a/frontend/test/providers/activities_list_state_test.dart
+++ b/frontend/test/providers/activities_list_state_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/models/activities_filter.dart';
+import 'package:logger/models/activities_list_state.dart';
+
+void main() {
+  group('ActivitiesListState.initial', () {
+    test('defaults to thisMonth preset', () {
+      final state = ActivitiesListState.initial();
+      expect(state.selectedPreset, TimePreset.thisMonth);
+    });
+
+    test('sets start date to first of current month', () {
+      final state = ActivitiesListState.initial();
+      final now = DateTime.now();
+      expect(state.filter.startDate, DateTime(now.year, now.month, 1));
+    });
+
+    test('sets end date to today', () {
+      final state = ActivitiesListState.initial();
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      expect(state.filter.endDate, today);
+    });
+
+    test('starts on page 1 with default limit', () {
+      final state = ActivitiesListState.initial();
+      expect(state.page, 1);
+      expect(state.limit, 20);
+      expect(state.total, 0);
+      expect(state.items, isEmpty);
+    });
+  });
+
+  group('ActivitiesListState pagination', () {
+    test('totalPages is 1 when no results', () {
+      final state = ActivitiesListState.initial();
+      expect(state.totalPages, 1);
+    });
+
+    test('calculates total pages from total and limit', () {
+      final state = ActivitiesListState.initial().copyWith(total: 45, limit: 20);
+      expect(state.totalPages, 3);
+    });
+
+    test('hasNextPage is false on last page', () {
+      final state = ActivitiesListState.initial().copyWith(
+        page: 2,
+        total: 40,
+        limit: 20,
+      );
+      expect(state.hasNextPage, isFalse);
+    });
+
+    test('hasPreviousPage is false on first page', () {
+      final state = ActivitiesListState.initial();
+      expect(state.hasPreviousPage, isFalse);
+    });
+  });
+
+  group('ActivitiesListState.copyWith', () {
+    test('clearPreset removes the selected preset', () {
+      final state = ActivitiesListState.initial();
+      final cleared = state.copyWith(clearPreset: true);
+      expect(cleared.selectedPreset, isNull);
+    });
+
+    test('preserves filter when not overridden', () {
+      final state = ActivitiesListState.initial();
+      final updated = state.copyWith(page: 2);
+      expect(updated.filter.startDate, state.filter.startDate);
+      expect(updated.filter.endDate, state.filter.endDate);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Activities list previously loaded with no date filter, showing all-time data
- Changed `ActivitiesListState.initial()` to use `TimePreset.thisMonth` as the default filter
- Extracted `ActivitiesListState` into `models/activities_list_state.dart` so it can be unit tested without pulling in the auth provider chain

## Test plan
- [x] Added `activities_list_state_test.dart` covering initial state, pagination helpers, and copyWith behavior
- [x] All 132 existing frontend tests still pass
- [ ] Manually verify activities page opens showing current month's activities with "Este mes" preset selected

Closes #238