### PR TITLE
fix(activities): guard against null activity type on form submit

### DIFF
--- a/frontend/lib/widgets/dialogs/activity_form_dialog.dart
+++ b/frontend/lib/widgets/dialogs/activity_form_dialog.dart
@@ -154,6 +154,11 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
     });
 
     try {
+      if (_selectedType == null) {
+        setState(() => _error = 'Selecciona un tipo de actividad.');
+        return;
+      }
+
       final iso = _selectedDate.toUtc().toIso8601String();
       final typeId = _selectedType!.id;
       final desc = _descCtrl.text.trim();

--- a/frontend/test/core/validators_test.dart
+++ b/frontend/test/core/validators_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/core/validators.dart';
+
+void main() {
+  group('Validators.required', () {
+    test('rejects null', () {
+      expect(Validators.required(null), isNotNull);
+    });
+
+    test('rejects empty string', () {
+      expect(Validators.required(''), isNotNull);
+    });
+
+    test('rejects whitespace-only string', () {
+      expect(Validators.required('   '), isNotNull);
+    });
+
+    test('accepts non-empty string', () {
+      expect(Validators.required('hello'), isNull);
+    });
+
+    test('uses custom field name in message', () {
+      final error = Validators.required(null, fieldName: 'La fecha');
+      expect(error, contains('La fecha'));
+    });
+  });
+
+  group('Validators.requiredField', () {
+    test('rejects null value', () {
+      expect(Validators.requiredField<String>(null), isNotNull);
+    });
+
+    test('accepts non-null value', () {
+      expect(Validators.requiredField<String>('value'), isNull);
+    });
+
+    test('accepts non-null object', () {
+      expect(Validators.requiredField<int>(42), isNull);
+    });
+
+    test('uses custom field name in message', () {
+      final error = Validators.requiredField<String>(
+        null,
+        fieldName: 'El tipo de actividad',
+      );
+      expect(error, contains('El tipo de actividad'));
+    });
+  });
+
+  group('Validators.positiveNumber', () {
+    test('accepts valid positive number', () {
+      expect(Validators.positiveNumber('10'), isNull);
+    });
+
+    test('rejects zero', () {
+      expect(Validators.positiveNumber('0'), isNotNull);
+    });
+
+    test('rejects negative number', () {
+      expect(Validators.positiveNumber('-5'), isNotNull);
+    });
+
+    test('rejects non-numeric input', () {
+      expect(Validators.positiveNumber('abc'), isNotNull);
+    });
+
+    test('allows null (optional field pattern)', () {
+      expect(Validators.positiveNumber(null), isNull);
+    });
+  });
+
+  group('Validators.dateNotInFuture', () {
+    test('allows past date', () {
+      final past = DateTime.now().subtract(const Duration(days: 1));
+      expect(Validators.dateNotInFuture(past), isNull);
+    });
+
+    test('allows today', () {
+      expect(Validators.dateNotInFuture(DateTime.now()), isNull);
+    });
+
+    test('rejects future date', () {
+      final future = DateTime.now().add(const Duration(days: 1));
+      expect(Validators.dateNotInFuture(future), isNotNull);
+    });
+
+    test('allows null (optional field pattern)', () {
+      expect(Validators.dateNotInFuture(null), isNull);
+    });
+  });
+
+  group('Validators.combine', () {
+    test('returns null when all validators pass', () {
+      final result = Validators.combine([
+        () => null,
+        () => null,
+      ]);
+      expect(result, isNull);
+    });
+
+    test('returns first error encountered', () {
+      final result = Validators.combine([
+        () => null,
+        () => 'error one',
+        () => 'error two',
+      ]);
+      expect(result, 'error one');
+    });
+
+    test('short-circuits on first failure', () {
+      var secondCalled = false;
+      Validators.combine([
+        () => 'fail',
+        () {
+          secondCalled = true;
+          return null;
+        },
+      ]);
+      expect(secondCalled, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Activity form dialog crashes with `Null check operator used on a null value` when submitting without an activity type selected
- Root cause: when no activity types exist (user has no roles), the dropdown never renders, so its form validator never executes — but `_submit()` still runs and hits `_selectedType!.id`
- Added a null guard before the assertion that shows a user-friendly error instead of crashing

## Test plan
- [x] Added `validators_test.dart` with 21 tests covering all `Validators` methods including `requiredField` (the validator that should catch null selections)
- [ ] Manually verify: open create activity dialog with a user that has no roles, tap save — should show error message, not crash

Closes #243