### PR TITLE
fix(activities): allow dismissing activity form with ESC or outside click

### DIFF
--- a/frontend/lib/pages/activities_list_page.dart
+++ b/frontend/lib/pages/activities_list_page.dart
@@ -37,7 +37,6 @@ class _ActivitiesListContentState extends ConsumerState<ActivitiesListContent> {
 
     final result = await showDialog<Map<String, dynamic>?>(
       context: context,
-      barrierDismissible: false,
       builder: (_) => ActivityFormDialog(
         baseUrl: ApiConfig.baseUrl,
         existingActivity: activityData,

--- a/frontend/lib/pages/activity_detail_page.dart
+++ b/frontend/lib/pages/activity_detail_page.dart
@@ -72,7 +72,6 @@ class _ActivityDetailContentState extends ConsumerState<ActivityDetailContent> {
 
     final result = await showDialog<Map<String, dynamic>?>(
       context: context,
-      barrierDismissible: false,
       builder: (_) => ActivityFormDialog(
         baseUrl: ApiConfig.baseUrl,
         existingActivity: activityData,

--- a/frontend/lib/pages/dashboard.dart
+++ b/frontend/lib/pages/dashboard.dart
@@ -52,7 +52,6 @@ class _DashboardContentState extends ConsumerState<DashboardContent> {
     try {
       final created = await showDialog<Map<String, dynamic>?>(
         context: context,
-        barrierDismissible: false,
         builder: (_) => ActivityFormDialog(
           baseUrl: ApiConfig.baseUrl,
           getAccessToken: () async {
@@ -110,7 +109,6 @@ class _DashboardContentState extends ConsumerState<DashboardContent> {
     try {
       final result = await showDialog<Map<String, dynamic>?>(
         context: context,
-        barrierDismissible: false,
         builder: (_) => ActivityFormDialog(
           baseUrl: ApiConfig.baseUrl,
           existingActivity: activityData,


### PR DESCRIPTION
## Summary
- Activity create/edit dialogs blocked ESC key and outside-click dismissal via `barrierDismissible: false`
- The dialog already has close (X) and cancel buttons, so this restriction was unnecessary
- Removed the flag from all 4 `ActivityFormDialog` call sites (dashboard create, dashboard edit, activities list edit, activity detail edit)
- Delete confirmation dialogs intentionally keep `barrierDismissible: false`

## Test plan
- [ ] Open create activity dialog, press ESC — dialog should close
- [ ] Open edit activity dialog, click outside — dialog should close
- [ ] Open delete confirmation dialog, press ESC — dialog should NOT close (unchanged)

Closes #235