### PR TITLE
fix: make database migrations idempotent for existing databases

### DIFF
--- a/backend/migrations/InitialBaseline.ts
+++ b/backend/migrations/InitialBaseline.ts
@@ -3,6 +3,14 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 export class InitialBaseline1700000000000 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // Skip if tables already exist (DB was created by synchronize before migrations existed)
+    const tableExists = await queryRunner.query(
+      `SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'roles'`,
+    );
+    if (tableExists.length > 0) {
+      return;
+    }
+
     await queryRunner.query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
     await queryRunner.query('CREATE EXTENSION IF NOT EXISTS "citext"');
 

--- a/backend/migrations/StatelessPeriodLocking.ts
+++ b/backend/migrations/StatelessPeriodLocking.ts
@@ -2,9 +2,9 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class StatelessPeriodLocking1740700000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    // 1. Create new tables
+    // 1. Create new tables (IF NOT EXISTS for idempotency)
     await queryRunner.query(`
-      CREATE TABLE "admin_lock" (
+      CREATE TABLE IF NOT EXISTS "admin_lock" (
         "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
         "entity_id" uuid NOT NULL,
         "lock_date" date NOT NULL,
@@ -17,7 +17,7 @@ export class StatelessPeriodLocking1740700000000 implements MigrationInterface {
     `);
 
     await queryRunner.query(`
-      CREATE TABLE "period_exception" (
+      CREATE TABLE IF NOT EXISTS "period_exception" (
         "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
         "user_id" uuid NOT NULL,
         "entity_id" uuid NOT NULL,
@@ -33,19 +33,24 @@ export class StatelessPeriodLocking1740700000000 implements MigrationInterface {
       )
     `);
 
-    // 2. Migrate existing exceptions from old table
+    // 2. Migrate existing exceptions from old table (if it exists)
     await queryRunner.query(`
-      INSERT INTO "period_exception" ("user_id", "entity_id", "start_date", "end_date", "reason", "granted_by")
-      SELECT
-        rpe."user_id",
-        rp."entity_id",
-        rpe."start_date",
-        rpe."end_date",
-        rpe."reason",
-        rpe."granted_by"
-      FROM "reporting_period_exception" rpe
-      JOIN "reporting_period" rp ON rpe."reporting_period_id" = rp."id"
-      ON CONFLICT DO NOTHING
+      DO $$
+      BEGIN
+        IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'reporting_period_exception') THEN
+          INSERT INTO "period_exception" ("user_id", "entity_id", "start_date", "end_date", "reason", "granted_by")
+          SELECT
+            rpe."user_id",
+            rp."entity_id",
+            rpe."start_date",
+            rpe."end_date",
+            rpe."reason",
+            rpe."granted_by"
+          FROM "reporting_period_exception" rpe
+          JOIN "reporting_period" rp ON rpe."reporting_period_id" = rp."id"
+          ON CONFLICT DO NOTHING;
+        END IF;
+      END $$
     `);
 
     // 3. Drop FK and column from activity

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - ./backend/test:/app/test
       - ./backend/config:/app/config
       - ./backend/scripts:/app/scripts
+      - ./backend/migrations:/app/migrations
       - ./backend/package.json:/app/package.json
       - ./backend/tsconfig.json:/app/tsconfig.json
       - ./backend/package-lock.json:/app/package-lock.json


### PR DESCRIPTION
## Summary
- Make `InitialBaseline` migration skip if tables already exist (DB created by `synchronize: true`)
- Make `StatelessPeriodLocking` migration use `CREATE TABLE IF NOT EXISTS` and conditional data migration
- Mount `migrations/` directory in docker-compose backend service

## Problem
The Render production database was originally created by TypeORM `synchronize: true` before migrations were introduced. When `migrationsRun: true` kicks in on deployment:
1. `InitialBaseline` fails on `CREATE TABLE` for already-existing tables
2. All subsequent migrations (including `StatelessPeriodLocking`) never run
3. `admin_lock` and `period_exception` tables are never created
4. `/periods/availability` returns 500 on every request

## Fix
- `InitialBaseline`: Early-exit guard checks if `roles` table exists, skips entire migration
- `StatelessPeriodLocking`: `CREATE TABLE IF NOT EXISTS` + `DO $$ IF EXISTS ... END $$` for conditional data migration from old tables
- No manual DB intervention needed — next deploy auto-fixes

## Test plan
- [x] All 306 backend unit tests pass
- [x] Simulated production scenario locally: dropped new tables + migrations table, ran migrations from host — all 5 executed successfully
- [x] Verified `admin_lock` and `period_exception` tables created by migration
- [x] Backend starts healthy, `/periods/availability` returns 401 (not 500)
- [x] Confirmed Render still returns 500 (fix not deployed yet)