### PR TITLE
fix: include migrations in TypeScript build for production

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -24,6 +24,6 @@
     "strict": true,
     "types": ["node", "jest"]
   },
-  "include": ["src", "scripts"],
+  "include": ["src", "scripts", "migrations"],
   "exclude": ["scripts/legacy"]
 }


### PR DESCRIPTION
## Summary

- Add `migrations` to `tsconfig.json` `include` array so `nest build` compiles migration `.ts` files to `dist/migrations/*.js`

## Problem

`tsconfig.json` only included `["src", "scripts"]`, so migration files were never compiled. In production (`node dist/main.js`), TypeORM's `migrationsRun: true` tried to load `.ts` files without ts-node, silently failing. This left `admin_lock` and `period_exception` tables missing, causing 500 errors on `/periods/availability`.

## Verification

- `nest build` now produces `dist/migrations/` with all 5 compiled migration files
- All 306 tests pass