### PR TITLE
feat(calendar): add interactive today's date button with navigation

### DIFF
--- a/frontend/lib/widgets/dialogs/calendar_dialog.dart
+++ b/frontend/lib/widgets/dialogs/calendar_dialog.dart
@@ -390,21 +390,41 @@ class _CalendarDialogState extends State<CalendarDialog> {
                 ),
               ),
             const SizedBox(height: 12),
-            Container(
-              width: double.infinity,
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.primary,
+            Material(
+              color: Theme.of(context).colorScheme.primary,
+              borderRadius: BorderRadius.circular(8),
+              child: InkWell(
                 borderRadius: BorderRadius.circular(8),
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Icon(Icons.today, size: 16, color: Colors.white),
-                  const SizedBox(width: 8),
-                  Text('Hoy: $today',
-                      style: const TextStyle(color: Colors.white)),
-                ],
+                mouseCursor: SystemMouseCursors.click,
+                onTap: () {
+                  final now = DateTime.now();
+                  final todayDate = DateTime(now.year, now.month, now.day);
+                  final isWithinRange = _isWithinSelectableRange(todayDate);
+
+                  setState(() {
+                    _focusedMonth =
+                        DateTime(todayDate.year, todayDate.month);
+                    if (isWithinRange) {
+                      _selected = todayDate;
+                    }
+                  });
+
+                  _loadAvailability();
+                },
+                child: Container(
+                  width: double.infinity,
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(Icons.today, size: 16, color: Colors.white),
+                      const SizedBox(width: 8),
+                      Text('Hoy: $today',
+                          style: const TextStyle(color: Colors.white)),
+                    ],
+                  ),
+                ),
               ),
             ),
             const SizedBox(height: 12),


### PR DESCRIPTION
### Summary
Enhances the calendar dialog by converting the "Today" display into an interactive button that allows users to quickly navigate to and select today's date.

### Changes

#### Calendar Dialog Widget
- **Made "Today" indicator interactive**: Converted from static `Container` to clickable `Material` with `InkWell`
  - Added tap handler to navigate to today's date
  - Includes hover cursor feedback (`SystemMouseCursors.click`) for better UX
  - Applies Material Design ripple effect on interaction

- **Navigation logic**: When clicked, the button:
  - Navigates the calendar view to the current month (`_focusedMonth`)
  - Selects today's date if it's within the selectable date range
  - Refreshes availability data for the current month (`_loadAvailability()`)

- **Improved UI responsiveness**: Uses `Material` + `InkWell` pattern for better touch/click feedback with ripple animations

### Testing
- Click the "Today" button from different months to verify navigation
- Confirm that today's date is selected if within the valid range
- Verify availability data loads correctly after navigation
- Test hover states and click feedback on desktop