### PR TITLE
feat(activity): add date range filtering to recent activities

### DIFF
--- a/frontend/lib/providers/activities.dart
+++ b/frontend/lib/providers/activities.dart
@@ -28,8 +28,15 @@ class RecentActivitiesNotifier extends AsyncNotifier<List<Activity>> {
 
   Future<List<Activity>> _fetchActivities() async {
     final service = ref.read(activityServiceProvider);
+    final now = DateTime.now();
+    final firstDay = DateTime(now.year, now.month, 1);
+    final lastDay = DateTime(now.year, now.month + 1, 0);
+    final startDate = _formatDate(firstDay);
+    final endDate = _formatDate(lastDay);
     final activitiesData = await service.getRecentActivities(
       limit: _dashboardActivityLimit,
+      startDate: startDate,
+      endDate: endDate,
     );
     return activitiesData.map((data) => Activity.fromApi(data)).toList();
   }
@@ -43,3 +50,7 @@ class RecentActivitiesNotifier extends AsyncNotifier<List<Activity>> {
 final recentActivitiesProvider =
     AsyncNotifierProvider<RecentActivitiesNotifier, List<Activity>>(
         RecentActivitiesNotifier.new);
+
+String _formatDate(DateTime date) {
+  return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+}

--- a/frontend/lib/services/activity.dart
+++ b/frontend/lib/services/activity.dart
@@ -53,13 +53,18 @@ class ActivityService {
     return (data['total'] as num).toDouble();
   }
 
-  Future<List<Map<String, dynamic>>> getRecentActivities(
-      {int limit = 5}) async {
+  Future<List<Map<String, dynamic>>> getRecentActivities({
+    int limit = 5,
+    String? startDate,
+    String? endDate,
+  }) async {
     final data = await apiClient.get(
       'activities',
       queryParameters: {
         'page': '1',
         'limit': limit.toString(),
+        if (startDate != null) 'startDate': startDate,
+        if (endDate != null) 'endDate': endDate,
       },
     );
 


### PR DESCRIPTION
### Summary
Adds date range filtering to the recent activities feature, automatically scoping the dashboard activity list to the current month instead of showing all recent activities across all time periods.

### Changes

#### Activity Service
- **Added optional date parameters**: Extended `getRecentActivities()` method with optional `startDate` and `endDate` parameters
  - Parameters are conditionally added to API query only when provided
  - Maintains backward compatibility with existing calls

#### Activities Provider
- **Implemented current month filtering**: `_fetchActivities()` now calculates and passes date range
  - Automatically computes first day of current month (`firstDay`)
  - Automatically computes last day of current month (`lastDay`)
  - Formats dates as ISO strings (YYYY-MM-DD format)

- **Added date formatting helper**: New `_formatDate()` function ensures consistent date string formatting
  - Zero-pads month and day values for proper API compatibility

### Behavior Change
**Before**: Recent activities showed the latest N activities regardless of date
**After**: Recent activities shows only activities from the current month, up to N items