### PR TITLE
feat(role-selector): add retry button for users with no assigned roles

### DIFF
--- a/frontend/lib/widgets/dialogs/role_selector_field.dart
+++ b/frontend/lib/widgets/dialogs/role_selector_field.dart
@@ -66,8 +66,21 @@ class RoleSelectorField extends StatelessWidget {
     final activeRoles = roles.where((r) => r.isActive).toList();
 
     if (activeRoles.isEmpty) {
-      return Text('No tienes roles asignados.',
-          style: theme.textTheme.bodyMedium);
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'No tienes roles asignados.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 8),
+          OutlinedButton.icon(
+            onPressed: submitting ? null : onRetry,
+            icon: const Icon(Icons.refresh),
+            label: const Text('Reintentar'),
+          ),
+        ],
+      );
     }
 
     if (activeRoles.length == 1 && selectedRole == null) {


### PR DESCRIPTION
### Summary
Improves the user experience when a user has no roles assigned by providing a retry button instead of just displaying an error message. This allows users to refresh their role assignments without leaving the form or reloading the page.

### Changes

#### Role Selector Field Widget
- **Enhanced empty state UI**: Converted simple error text into an actionable message with retry functionality
  - Displays the existing "No tienes roles asignados." message
  - Adds an outlined button with refresh icon and "Reintentar" label
  - Button respects form submission state (disabled when `submitting` is true)
  - Uses `onRetry` callback to trigger role refresh

- **Improved layout**: Changed from single `Text` widget to `Column` with proper spacing
  - Better visual hierarchy with 8px spacing between message and button
  - Left-aligned content for consistency with form fields

### User Impact
Users who encounter the "no roles assigned" state can now:
- Immediately retry without navigating away from the form
- Receive real-time feedback on their role assignment status
- Complete their task more efficiently without page reloads

This is particularly useful for:
- New users waiting for role assignments
- Users experiencing temporary sync issues
- Admin scenarios where roles are being assigned in real-time

### UI/UX Improvements
- More intuitive error recovery flow
- Follows Material Design patterns with `OutlinedButton.icon`
- Provides clear call-to-action for error resolution