### PR TITLE
fix(auth): improve error messages with user-friendly Spanish translations

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -30,14 +30,14 @@ class MyApp extends ConsumerWidget {
                 if (authState.isLoading) ...[
                   const CircularProgressIndicator(),
                   const SizedBox(height: 16),
-                  const Text('Redirigiendo a Auth0...'),
+                  const Text('Redirigiendo al inicio de sesión...'),
                 ],
                 if (authState.lastError != null) ...[
                   const Icon(Icons.error, color: Colors.red, size: 48),
                   const SizedBox(height: 16),
                   ConstrainedBox(
                     constraints: const BoxConstraints(maxWidth: 520),
-                    child: Text('Error: ${authState.lastError}',
+                    child: Text(authState.lastError!,
                         textAlign: TextAlign.center,
                         style: const TextStyle(color: Colors.red)),
                   ),
@@ -46,7 +46,7 @@ class MyApp extends ConsumerWidget {
                     onPressed: () {
                       authNotifier.login();
                     },
-                    child: const Text('Reintentar'),
+                    child: const Text('Iniciar sesión'),
                   ),
                 ],
               ],

--- a/frontend/lib/providers/auth.dart
+++ b/frontend/lib/providers/auth.dart
@@ -29,6 +29,36 @@ class AuthNotifier extends Notifier<AuthState> {
   bool _bootstrapped = false;
   bool _isRedirecting = false;
 
+  String _friendlyAuthError(Object error) {
+    final message = error.toString().toLowerCase();
+
+    if (message.contains('pkce') ||
+        message.contains('authorization code') ||
+        message.contains('authentication flow') ||
+        message.contains('no token found')) {
+      return 'Tu sesión ha expirado. Por favor, inicia sesión nuevamente.';
+    }
+
+    if (message.contains('exchange code') ||
+        message.contains('failed to exchange') ||
+        message.contains('oauth/token')) {
+      return 'No pudimos iniciar sesión. Por favor, inténtalo de nuevo.';
+    }
+
+    if (message.contains('auth0') ||
+        message.contains('not configured') ||
+        message.contains('dart-define')) {
+      return 'La autenticación no está disponible en este momento.';
+    }
+
+    return 'Ocurrió un problema al iniciar sesión. Por favor, inténtalo de nuevo.';
+  }
+
+  String _authError(Object error) {
+    debugPrint('[AuthNotifier] Auth error: $error');
+    return _friendlyAuthError(error);
+  }
+
   @override
   AuthState build() {
     _bootstrapped = false;
@@ -59,8 +89,8 @@ class AuthNotifier extends Notifier<AuthState> {
     if (!AuthConfig.isConfigured) {
       state = state.copyWith(
         isLoading: false,
-        lastError:
-            'Auth0 no está configurado. Revisa tus --dart-define en auth_config.dart',
+        lastError: _friendlyAuthError(
+            'Auth0 no está configurado. Revisa tus --dart-define en auth_config.dart'),
       );
       return;
     }
@@ -96,7 +126,7 @@ class AuthNotifier extends Notifier<AuthState> {
       state = state.copyWith(
         isLoading: false,
         isAuthenticated: false,
-        lastError: e.toString(),
+        lastError: _authError(e),
       );
     }
   }
@@ -211,7 +241,7 @@ class AuthNotifier extends Notifier<AuthState> {
       state = state.copyWith(
         isLoading: false,
         isAuthenticated: false,
-        lastError: e.toString(),
+        lastError: _authError(e),
       );
     }
   }
@@ -266,7 +296,7 @@ class AuthNotifier extends Notifier<AuthState> {
       state = state.copyWith(
         isLoading: false,
         isAuthenticated: false,
-        lastError: e.toString(),
+        lastError: _authError(e),
       );
     }
   }
@@ -298,7 +328,7 @@ class AuthNotifier extends Notifier<AuthState> {
       web.window.location.assign(authUrl.toString());
     } catch (e) {
       _isRedirecting = false;
-      state = state.copyWith(lastError: e.toString());
+      state = state.copyWith(lastError: _authError(e));
     }
   }
 
@@ -316,7 +346,7 @@ class AuthNotifier extends Notifier<AuthState> {
       state = state.copyWith(accessToken: accessToken);
       return accessToken;
     } catch (e) {
-      state = state.copyWith(lastError: e.toString());
+      state = state.copyWith(lastError: _authError(e));
       return null;
     }
   }


### PR DESCRIPTION
### Summary
Replaces technical authentication error messages with user-friendly Spanish messages, significantly improving the user experience during authentication failures. Removes technical jargon and provides clear, actionable guidance to users.

### Changes

#### Auth Provider Error Handling
- **Added error message translation layer**: New `_friendlyAuthError()` method maps technical errors to user-friendly Spanish messages
  - Detects PKCE/session expiration errors → "Tu sesión ha expirado. Por favor, inicia sesión nuevamente."
  - Detects OAuth token exchange failures → "No pudimos iniciar sesión. Por favor, inténtalo de nuevo."
  - Detects configuration errors → "La autenticación no está disponible en este momento."
  - Default fallback → "Ocurrió un problema al iniciar sesión. Por favor, inténtalo de nuevo."

- **Enhanced error logging**: New `_authError()` wrapper logs technical details to console while returning friendly messages
  - Preserves debugging capability with `debugPrint`
  - Shields users from confusing technical details

- **Applied across all error scenarios**:
  - Bootstrap initialization errors
  - Login failures
  - Auth callback processing errors
  - Session refresh failures
  - Token retrieval errors

#### UI Improvements
- **Updated loading message**: "Redirigiendo a Auth0..." → "Redirigiendo al inicio de sesión..."
  - Removes technical service name for clearer communication

- **Simplified error display**: Removed "Error:" prefix from error messages
  - Error messages now stand on their own without redundant labeling

- **Better call-to-action**: "Reintentar" → "Iniciar sesión"
  - More explicit action for users encountering auth errors