### PR TITLE
fix: resolve report status, date picker UX, and dashboard expenses bugs

### DIFF
--- a/backend/src/activity/activities.controller.ts
+++ b/backend/src/activity/activities.controller.ts
@@ -152,6 +152,33 @@ export class ActivitiesController {
     };
   }
 
+  @Get('stats/monthly-expenses')
+  @ApiOperation({ summary: 'Get monthly expense total for the current user' })
+  @ApiResponse({ status: 200, description: 'Monthly expense total' })
+  @ApiQuery({
+    name: 'year',
+    required: false,
+    type: Number,
+    description: 'Year (default: current year)',
+  })
+  @ApiQuery({
+    name: 'month',
+    required: false,
+    type: Number,
+    description: 'Month 1-12 (default: current month)',
+  })
+  async getMonthlyExpenses(
+    @Req() req: Request,
+    @Query('year', new DefaultValuePipe(new Date().getFullYear()), ParseIntPipe) year: number,
+    @Query('month', new DefaultValuePipe(new Date().getMonth() + 1), ParseIntPipe) month: number,
+  ) {
+    const { sub, iss } = (req.user as any) ?? {};
+    const user = await this.identity.resolveUserBySubAndIssuer(sub, iss);
+
+    const total = await this.activities.getMonthlyExpenseTotal(user.id, year, month);
+    return { total, year, month };
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get a single activity by ID' })
   @ApiResponse({ status: 200, description: 'Activity details', type: ActivityResponseDto })
@@ -218,32 +245,5 @@ export class ActivitiesController {
 
     await this.activities.archiveMine(id, user.id);
     return { ok: true };
-  }
-
-  @Get('stats/monthly-expenses')
-  @ApiOperation({ summary: 'Get monthly expense total for the current user' })
-  @ApiResponse({ status: 200, description: 'Monthly expense total' })
-  @ApiQuery({
-    name: 'year',
-    required: false,
-    type: Number,
-    description: 'Year (default: current year)',
-  })
-  @ApiQuery({
-    name: 'month',
-    required: false,
-    type: Number,
-    description: 'Month 1-12 (default: current month)',
-  })
-  async getMonthlyExpenses(
-    @Req() req: Request,
-    @Query('year', new DefaultValuePipe(new Date().getFullYear()), ParseIntPipe) year: number,
-    @Query('month', new DefaultValuePipe(new Date().getMonth() + 1), ParseIntPipe) month: number,
-  ) {
-    const { sub, iss } = (req.user as any) ?? {};
-    const user = await this.identity.resolveUserBySubAndIssuer(sub, iss);
-
-    const total = await this.activities.getMonthlyExpenseTotal(user.id, year, month);
-    return { total, year, month };
   }
 }

--- a/backend/src/reports/calculators/summary.calculator.ts
+++ b/backend/src/reports/calculators/summary.calculator.ts
@@ -6,6 +6,7 @@ import { User } from '../../users/user.entity';
 import { Entity } from '../../entities/entity.entity';
 import { UserStatus } from '../../users/user-status.enum';
 import { SummaryResponse } from '../dto/report-responses.dto';
+import { getCurrentDateString } from '../../common/date.utils';
 
 @Injectable()
 export class SummaryCalculator {
@@ -63,7 +64,7 @@ export class SummaryCalculator {
         id: '',
         startDate: timeScope.dateFrom || '',
         endDate: timeScope.dateTo || '',
-        status: 'custom',
+        status: timeScope.dateTo && timeScope.dateTo < getCurrentDateString() ? 'locked' : 'active',
       },
       scope,
       entity: {

--- a/backend/src/reports/reports.service.hierarchy.spec.ts
+++ b/backend/src/reports/reports.service.hierarchy.spec.ts
@@ -63,7 +63,7 @@ describe('ReportsService - Hierarchy Features', () => {
   ] as unknown as Activity[];
 
   const mockSummaryResponse = {
-    period: { id: '', startDate: '2024-01-01', endDate: '2024-01-14', status: 'custom' },
+    period: { id: '', startDate: '2024-01-01', endDate: '2024-01-14', status: 'locked' },
     scope: 'entity' as const,
     entity: { id: 'entity-1', name: 'Test Union', type: 'UNION' },
     totals: {

--- a/frontend/lib/models/report_summary.dart
+++ b/frontend/lib/models/report_summary.dart
@@ -37,7 +37,7 @@ class ReportSummary {
       isReported: isReported,
       periodStart: period['startDate'] as String? ?? '',
       periodEnd: period['endDate'] as String? ?? '',
-      status: period['status'] as String? ?? 'Activo',
+      status: period['status'] as String? ?? 'active',
     );
   }
 
@@ -48,7 +48,7 @@ class ReportSummary {
       isReported: false,
       periodStart: '',
       periodEnd: '',
-      status: 'Activo',
+      status: 'active',
     );
   }
 }

--- a/frontend/lib/widgets/activities/activity_filters.dart
+++ b/frontend/lib/widgets/activities/activity_filters.dart
@@ -128,7 +128,7 @@ class _ActivityFiltersState extends ConsumerState<ActivityFilters> {
               child: ConstrainedBox(
                 constraints: const BoxConstraints(
                   maxWidth: 400,
-                  maxHeight: 500,
+                  maxHeight: 700,
                 ),
                 child: child,
               ),

--- a/frontend/test/models/report_summary_test.dart
+++ b/frontend/test/models/report_summary_test.dart
@@ -41,7 +41,7 @@ void main() {
         expect(summary.statusLabel, equals('custom'));
       });
 
-      test('status defaults to "Activo" when missing from API', () {
+      test('status defaults to "active" when missing from API', () {
         final summary = ReportSummary.fromApi({
           'totals': {'activities': 0, 'expenses': 0},
           'period': {
@@ -49,12 +49,14 @@ void main() {
             'endDate': '2026-02-28',
           },
         });
-        expect(summary.status, equals('Activo'));
+        expect(summary.status, equals('active'));
+        expect(summary.statusLabel, equals('Activo'));
       });
 
-      test('status defaults to "Activo" when period is null', () {
+      test('status defaults to "active" when period is null', () {
         final summary = ReportSummary.fromApi({});
-        expect(summary.status, equals('Activo'));
+        expect(summary.status, equals('active'));
+        expect(summary.statusLabel, equals('Activo'));
       });
     });
 
@@ -140,7 +142,8 @@ void main() {
         expect(empty.totalActivities, equals(0));
         expect(empty.totalExpenses, equals(0.0));
         expect(empty.isReported, isFalse);
-        expect(empty.status, equals('Activo'));
+        expect(empty.status, equals('active'));
+        expect(empty.statusLabel, equals('Activo'));
       });
     });
   });


### PR DESCRIPTION
## Summary

- **#240**: Report page showed raw `Estado: custom` — backend now computes `active`/`locked` from period dates, frontend maps to Spanish labels via existing `statusLabel` getter
- **#228**: Custom date range picker clipped at 500px hiding month navigation — increased to 700px for full visibility
- **#233**: Dashboard expense card always showed `L.0` — NestJS `@Get(':id')` route shadowed `@Get('stats/monthly-expenses')`, reordered so static route matches first

## Test plan

- [x] Backend: 306 tests pass, 0 lint errors
- [x] Frontend: 223 tests pass, flutter analyze clean
- [ ] Verify report status shows "Activo" or "Bloqueado" instead of "custom"
- [ ] Verify date range picker shows full month with scroll indicator
- [ ] Verify dashboard expense card loads real data