### PR TITLE
feat(activities): add server-side column sorting to activities table

### DIFF
--- a/backend/src/activity/activities.controller.ts
+++ b/backend/src/activity/activities.controller.ts
@@ -101,6 +101,18 @@ export class ActivitiesController {
     required: false,
     description: 'Search by description or activity type name',
   })
+  @ApiQuery({
+    name: 'sortBy',
+    required: false,
+    enum: ['activityDate', 'activityType', 'description', 'expenseAmount'],
+    description: 'Column to sort by (default: activityDate)',
+  })
+  @ApiQuery({
+    name: 'sortOrder',
+    required: false,
+    enum: ['ASC', 'DESC'],
+    description: 'Sort direction (default: DESC)',
+  })
   async findMine(
     @Req() req: Request,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
@@ -110,6 +122,8 @@ export class ActivitiesController {
     @Query('activityTypeId') activityTypeId?: string,
     @Query('hasExpense') hasExpense?: string,
     @Query('search') search?: string,
+    @Query('sortBy') sortBy?: string,
+    @Query('sortOrder') sortOrder?: string,
   ) {
     const { sub, iss } = (req.user as any) ?? {};
     const user = await this.identity.resolveUserBySubAndIssuer(sub, iss);
@@ -120,6 +134,11 @@ export class ActivitiesController {
       activityTypeId: activityTypeId || undefined,
       hasExpense: hasExpense === 'true' ? true : hasExpense === 'false' ? false : undefined,
       search: search?.trim() || undefined,
+      sortBy: sortBy || undefined,
+      sortOrder: (sortOrder === 'ASC' ? 'ASC' : sortOrder === 'DESC' ? 'DESC' : undefined) as
+        | 'ASC'
+        | 'DESC'
+        | undefined,
     };
 
     const [items, total] = await this.activities.findMine(user.id, page, limit, filters);

--- a/backend/src/activity/activities.service.ts
+++ b/backend/src/activity/activities.service.ts
@@ -134,6 +134,8 @@ export class ActivitiesService {
       activityTypeId?: string;
       hasExpense?: boolean;
       search?: string;
+      sortBy?: string;
+      sortOrder?: 'ASC' | 'DESC';
     },
   ): Promise<[Activity[], number]> {
     const { skip, limit: take } = normalizePagination({ page, limit });
@@ -184,7 +186,24 @@ export class ActivitiesService {
       }
     }
 
-    qb.orderBy('activity.activityDate', 'DESC').addOrderBy('activity.createdAt', 'DESC');
+    const allowedSortColumns: Record<string, string> = {
+      activityDate: 'activity.activityDate',
+      description: 'activity.description',
+      expenseAmount: 'activity.expenseAmount',
+      activityType: 'activityType.name',
+    };
+
+    const sortColumn = allowedSortColumns[filters?.sortBy ?? ''];
+    const sortDirection = filters?.sortOrder === 'ASC' ? 'ASC' : 'DESC';
+
+    if (sortColumn) {
+      if (filters?.sortBy === 'activityType' && !filters?.search) {
+        qb.leftJoin('activity.activityType', 'activityType');
+      }
+      qb.orderBy(sortColumn, sortDirection).addOrderBy('activity.createdAt', 'DESC');
+    } else {
+      qb.orderBy('activity.activityDate', 'DESC').addOrderBy('activity.createdAt', 'DESC');
+    }
     qb.skip(skip).take(take);
 
     return qb.getManyAndCount();

--- a/frontend/lib/models/activities_list_state.dart
+++ b/frontend/lib/models/activities_list_state.dart
@@ -8,6 +8,8 @@ class ActivitiesListState {
   final int total;
   final ActivitiesFilter filter;
   final TimePreset? selectedPreset;
+  final String? sortBy;
+  final bool sortAscending;
 
   const ActivitiesListState({
     required this.items,
@@ -16,6 +18,8 @@ class ActivitiesListState {
     required this.total,
     required this.filter,
     this.selectedPreset,
+    this.sortBy,
+    this.sortAscending = false,
   });
 
   factory ActivitiesListState.initial() {
@@ -45,6 +49,9 @@ class ActivitiesListState {
     ActivitiesFilter? filter,
     TimePreset? selectedPreset,
     bool clearPreset = false,
+    String? sortBy,
+    bool? sortAscending,
+    bool clearSort = false,
   }) {
     return ActivitiesListState(
       items: items ?? this.items,
@@ -54,6 +61,8 @@ class ActivitiesListState {
       filter: filter ?? this.filter,
       selectedPreset:
           clearPreset ? null : (selectedPreset ?? this.selectedPreset),
+      sortBy: clearSort ? null : (sortBy ?? this.sortBy),
+      sortAscending: sortAscending ?? this.sortAscending,
     );
   }
 }

--- a/frontend/lib/pages/activities_list_page.dart
+++ b/frontend/lib/pages/activities_list_page.dart
@@ -25,6 +25,22 @@ class ActivitiesListContent extends ConsumerStatefulWidget {
 }
 
 class _ActivitiesListContentState extends ConsumerState<ActivitiesListContent> {
+  static const _sortColumns = ['activityDate', 'activityType', 'description', 'expenseAmount'];
+
+  int? _sortColumnIndex(String? sortBy) {
+    if (sortBy == null) return null;
+    final idx = _sortColumns.indexOf(sortBy);
+    return idx >= 0 ? idx : null;
+  }
+
+  void _onSort(int columnIndex, bool ascending) {
+    if (columnIndex >= _sortColumns.length) return;
+    ref.read(activitiesListProvider.notifier).setSort(
+          _sortColumns[columnIndex],
+          ascending,
+        );
+  }
+
   Future<void> _showEditDialog(Activity activity) async {
     final activityData = {
       'id': activity.id,
@@ -129,6 +145,9 @@ class _ActivitiesListContentState extends ConsumerState<ActivitiesListContent> {
               page: state.page,
               totalPages: state.totalPages,
               total: state.total,
+              sortColumnIndex: _sortColumnIndex(state.sortBy),
+              sortAscending: state.sortAscending,
+              onSort: _onSort,
               onPageChange: (page) {
                 ref.read(activitiesListProvider.notifier).setPage(page);
               },

--- a/frontend/lib/providers/activities_list_provider.dart
+++ b/frontend/lib/providers/activities_list_provider.dart
@@ -25,6 +25,10 @@ class ActivitiesListNotifier extends AsyncNotifier<ActivitiesListState> {
       activityTypeId: filterParams.activityTypeId,
       hasExpense: filterParams.hasExpense,
       search: filterParams.search,
+      sortBy: currentState.sortBy,
+      sortOrder: currentState.sortBy != null
+          ? (currentState.sortAscending ? 'ASC' : 'DESC')
+          : null,
     );
 
     final items = (data['data'] as List)
@@ -70,6 +74,17 @@ class ActivitiesListNotifier extends AsyncNotifier<ActivitiesListState> {
     if (state.value?.hasPreviousPage ?? false) {
       await setPage(state.value!.page - 1);
     }
+  }
+
+  Future<void> setSort(String sortBy, bool ascending) async {
+    if (state.value == null) return;
+    state = const AsyncLoading();
+    final newState = state.value!.copyWith(
+      sortBy: sortBy,
+      sortAscending: ascending,
+      page: 1,
+    );
+    state = await AsyncValue.guard(() => _fetchActivities(newState));
   }
 
   Future<void> refresh() async {

--- a/frontend/lib/services/activity.dart
+++ b/frontend/lib/services/activity.dart
@@ -80,6 +80,8 @@ class ActivityService {
     String? activityTypeId,
     bool? hasExpense,
     String? search,
+    String? sortBy,
+    String? sortOrder,
   }) async {
     final params = <String, String>{
       'page': page.toString(),
@@ -93,6 +95,8 @@ class ActivityService {
     if (search != null && search.trim().isNotEmpty) {
       params['search'] = search.trim();
     }
+    if (sortBy != null) params['sortBy'] = sortBy;
+    if (sortOrder != null) params['sortOrder'] = sortOrder;
 
     final data = await apiClient.get('activities', queryParameters: params);
     return data as Map<String, dynamic>;

--- a/frontend/lib/widgets/activities/paginated_activities_table.dart
+++ b/frontend/lib/widgets/activities/paginated_activities_table.dart
@@ -10,6 +10,9 @@ class PaginatedActivitiesTable extends StatelessWidget {
   final Function(Activity) onRowTap;
   final Function(Activity)? onEdit;
   final Function(Activity)? onDelete;
+  final int? sortColumnIndex;
+  final bool sortAscending;
+  final Function(int, bool)? onSort;
 
   const PaginatedActivitiesTable({
     super.key,
@@ -21,6 +24,9 @@ class PaginatedActivitiesTable extends StatelessWidget {
     required this.onRowTap,
     this.onEdit,
     this.onDelete,
+    this.sortColumnIndex,
+    this.sortAscending = false,
+    this.onSort,
   });
 
   bool get _showActions => onEdit != null || onDelete != null;
@@ -87,33 +93,40 @@ class PaginatedActivitiesTable extends StatelessWidget {
                           BoxConstraints(minWidth: constraints.maxWidth),
                       child: DataTable(
                         showCheckboxColumn: false,
+                        sortColumnIndex: sortColumnIndex,
+                        sortAscending: sortAscending,
                         headingRowColor: WidgetStateProperty.all(
                           Colors.grey.shade50,
                         ),
                         columns: [
-                          const DataColumn(
-                            label: Text(
+                          DataColumn(
+                            label: const Text(
                               'Fecha',
                               style: TextStyle(fontWeight: FontWeight.w600),
                             ),
+                            onSort: onSort,
                           ),
-                          const DataColumn(
-                            label: Text(
+                          DataColumn(
+                            label: const Text(
                               'Tipo',
                               style: TextStyle(fontWeight: FontWeight.w600),
                             ),
+                            onSort: onSort,
                           ),
-                          const DataColumn(
-                            label: Text(
+                          DataColumn(
+                            label: const Text(
                               'Descripcion',
                               style: TextStyle(fontWeight: FontWeight.w600),
                             ),
+                            onSort: onSort,
                           ),
-                          const DataColumn(
-                            label: Text(
+                          DataColumn(
+                            label: const Text(
                               'Gasto',
                               style: TextStyle(fontWeight: FontWeight.w600),
                             ),
+                            numeric: true,
+                            onSort: onSort,
                           ),
                           const DataColumn(
                             label: Text(


### PR DESCRIPTION
## Summary

- Backend accepts `sortBy` and `sortOrder` query params on `GET /activities` with an allowlist of columns (`activityDate`, `activityType`, `description`, `expenseAmount`) to prevent injection
- Frontend `DataTable` columns have `onSort` callbacks that trigger server-side re-fetch
- Sort state tracked in `ActivitiesListState`, reset to page 1 on sort change
- Estado column excluded from sorting since lock status is computed at runtime

## Changes

- **Backend**: `activities.service.ts` — dynamic ORDER BY with column allowlist; `activities.controller.ts` — new `sortBy`/`sortOrder` query params with Swagger docs
- **Frontend**: `paginated_activities_table.dart` — sortable DataColumn headers; `activities_list_page.dart` — sort callback wiring; `activities_list_provider.dart` — `setSort()` method; `activities_list_state.dart` — sort fields; `activity.dart` service — sort params

## Test plan

- [x] Backend: 306 tests pass, 0 lint errors
- [x] Frontend: 223 tests pass, flutter analyze clean
- [ ] Click column headers to verify sort indicator and data re-ordering
- [ ] Verify clicking same column toggles ASC/DESC
- [ ] Verify pagination resets to page 1 on sort change