### PR TITLE
fix(periods): replace check-then-act with upsert in setAdminLock

### DIFF
--- a/backend/src/periods/lock.service.ts
+++ b/backend/src/periods/lock.service.ts
@@ -115,14 +115,8 @@ export class LockService {
   }
 
   async setAdminLock(entityId: string, lockDate: string, lockedBy: string): Promise<AdminLock> {
-    let lock = await this.adminLockRepo.findOne({ where: { entityId } });
-    if (lock) {
-      lock.lockDate = lockDate;
-      lock.lockedBy = lockedBy;
-    } else {
-      lock = this.adminLockRepo.create({ entityId, lockDate, lockedBy });
-    }
-    return this.adminLockRepo.save(lock);
+    await this.adminLockRepo.upsert({ entityId, lockDate, lockedBy }, { conflictPaths: ['entityId'] });
+    return this.adminLockRepo.findOneByOrFail({ entityId });
   }
 
   async removeAdminLock(entityId: string): Promise<void> {

--- a/backend/src/periods/tests/lock-service.spec.ts
+++ b/backend/src/periods/tests/lock-service.spec.ts
@@ -14,9 +14,11 @@ describe('LockService', () => {
   beforeEach(async () => {
     adminLockRepo = {
       findOne: jest.fn(),
+      findOneByOrFail: jest.fn(),
       save: jest.fn(),
       create: jest.fn((data) => data),
       delete: jest.fn(),
+      upsert: jest.fn(),
     };
     exceptionRepo = {
       findOne: jest.fn(),
@@ -142,27 +144,27 @@ describe('LockService', () => {
   });
 
   describe('setAdminLock', () => {
-    it('creates lock entry for entity', async () => {
-      adminLockRepo.findOne.mockResolvedValue(null);
-      adminLockRepo.save.mockResolvedValue({
-        id: 'lock-1',
-        entityId: 'entity-1',
-        lockDate: '2026-03-15',
-      });
+    it('upserts lock entry for entity', async () => {
+      const expected = { id: 'lock-1', entityId: 'entity-1', lockDate: '2026-03-15', lockedBy: 'admin-1' };
+      adminLockRepo.upsert.mockResolvedValue(undefined);
+      adminLockRepo.findOneByOrFail.mockResolvedValue(expected);
 
-      await service.setAdminLock('entity-1', '2026-03-15', 'admin-1');
-      expect(adminLockRepo.save).toHaveBeenCalled();
+      const result = await service.setAdminLock('entity-1', '2026-03-15', 'admin-1');
+
+      expect(adminLockRepo.upsert).toHaveBeenCalledWith(
+        { entityId: 'entity-1', lockDate: '2026-03-15', lockedBy: 'admin-1' },
+        { conflictPaths: ['entityId'] },
+      );
+      expect(result).toEqual(expected);
     });
 
-    it('updates existing lock entry', async () => {
-      const existing = { id: 'lock-1', entityId: 'entity-1', lockDate: '2026-03-10' };
-      adminLockRepo.findOne.mockResolvedValue(existing);
-      adminLockRepo.save.mockResolvedValue({ ...existing, lockDate: '2026-03-20' });
+    it('returns the persisted lock after upsert', async () => {
+      const persisted = { id: 'lock-1', entityId: 'entity-1', lockDate: '2026-03-20', lockedBy: 'admin-1' };
+      adminLockRepo.upsert.mockResolvedValue(undefined);
+      adminLockRepo.findOneByOrFail.mockResolvedValue(persisted);
 
-      await service.setAdminLock('entity-1', '2026-03-20', 'admin-1');
-      expect(adminLockRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({ lockDate: '2026-03-20' }),
-      );
+      const result = await service.setAdminLock('entity-1', '2026-03-20', 'admin-1');
+      expect(result.lockDate).toBe('2026-03-20');
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace `findOne` + conditional `create`/`save` with atomic `upsert` using `conflictPaths: ['entityId']` in `setAdminLock()`
- Eliminates race condition where concurrent requests could both miss the existing row and attempt to create, violating the unique constraint
- Update tests to verify upsert API usage

## Test plan

- [x] `npm test -- --testPathPattern=lock-service` — 19 tests pass
- [x] Full backend suite — 37 suites, 317 tests pass