### PR TITLE
fix(activities): eliminate N+1 admin lock query in activities list

### DIFF
--- a/backend/src/activity/activities.controller.ts
+++ b/backend/src/activity/activities.controller.ts
@@ -58,12 +58,13 @@ export class ActivitiesController {
 
     const created = await this.activities.create(dto, user.id);
 
-    const [owner, type] = await Promise.all([
+    const [owner, type, adminLock] = await Promise.all([
       this.usersRepo.findOneByOrFail({ id: created.userId }),
       this.typesRepo.findOneByOrFail({ id: created.activityTypeId }),
+      this.lockService.getAdminLock(user.entity_id),
     ]);
 
-    const isLocked = await this.lockService.isDateLocked(owner.entity_id, created.activityDate);
+    const isLocked = this.lockService.isDateLockedSync(created.activityDate, adminLock);
 
     return ActivityResponseDto.fromEntity(created, owner.username, (type as any).name, isLocked);
   }
@@ -143,7 +144,7 @@ export class ActivitiesController {
 
     const [items, total] = await this.activities.findMine(user.id, page, limit, filters);
 
-    const [owner, typesMap] = await Promise.all([
+    const [owner, typesMap, adminLock] = await Promise.all([
       this.usersRepo.findOneByOrFail({ id: user.id }),
       (async () => {
         const ids = [...new Set(items.map((i) => i.activityTypeId))];
@@ -151,22 +152,21 @@ export class ActivitiesController {
         const types = await this.typesRepo.find({ where: { id: In(ids) } });
         return new Map(types.map((t) => [t.id, (t as any).name]));
       })(),
+      this.lockService.getAdminLock(user.entity_id),
     ]);
 
-    const itemsWithLocked = await Promise.all(
-      items.map(async (a) => {
-        const isLocked = await this.lockService.isDateLocked(owner.entity_id, a.activityDate);
-        return ActivityResponseDto.fromEntity(
-          a,
-          owner.username,
-          typesMap.get(a.activityTypeId) ?? '',
-          isLocked,
-        );
-      }),
-    );
+    const data = items.map((a) => {
+      const isLocked = this.lockService.isDateLockedSync(a.activityDate, adminLock);
+      return ActivityResponseDto.fromEntity(
+        a,
+        owner.username,
+        typesMap.get(a.activityTypeId) ?? '',
+        isLocked,
+      );
+    });
 
     return {
-      data: itemsWithLocked,
+      data,
       pagination: buildPagination(page, limit, total),
     };
   }
@@ -207,12 +207,13 @@ export class ActivitiesController {
     const user = await this.identity.resolveUserBySubAndIssuer(sub, iss);
 
     const a = await this.activities.findOneMine(id, user.id);
-    const [owner, type] = await Promise.all([
+    const [owner, type, adminLock] = await Promise.all([
       this.usersRepo.findOneByOrFail({ id: a.userId }),
       this.typesRepo.findOneByOrFail({ id: a.activityTypeId }),
+      this.lockService.getAdminLock(user.entity_id),
     ]);
 
-    const isLocked = await this.lockService.isDateLocked(owner.entity_id, a.activityDate);
+    const isLocked = this.lockService.isDateLockedSync(a.activityDate, adminLock);
 
     return ActivityResponseDto.fromEntity(a, owner.username, (type as any).name, isLocked);
   }
@@ -235,12 +236,13 @@ export class ActivitiesController {
     const user = await this.identity.resolveUserBySubAndIssuer(sub, iss);
 
     const updated = await this.activities.updateMine(id, dto, user.id);
-    const [owner, type] = await Promise.all([
+    const [owner, type, adminLock] = await Promise.all([
       this.usersRepo.findOneByOrFail({ id: updated.userId }),
       this.typesRepo.findOneByOrFail({ id: updated.activityTypeId }),
+      this.lockService.getAdminLock(user.entity_id),
     ]);
 
-    const isLocked = await this.lockService.isDateLocked(owner.entity_id, updated.activityDate);
+    const isLocked = this.lockService.isDateLockedSync(updated.activityDate, adminLock);
 
     return ActivityResponseDto.fromEntity(updated, owner.username, (type as any).name, isLocked);
   }

--- a/backend/src/periods/lock.service.ts
+++ b/backend/src/periods/lock.service.ts
@@ -24,6 +24,20 @@ export class LockService {
     private readonly calculator: PeriodCalculator,
   ) {}
 
+  async getAdminLock(entityId: string): Promise<AdminLock | null> {
+    return this.adminLockRepo.findOne({ where: { entityId } });
+  }
+
+  isDateLockedSync(dateStr: string, adminLock: AdminLock | null): boolean {
+    if (this.calculator.isDateInPastPeriod(dateStr)) {
+      return true;
+    }
+    if (adminLock && dateStr <= adminLock.lockDate) {
+      return true;
+    }
+    return false;
+  }
+
   async isDateLocked(entityId: string, dateStr: string): Promise<boolean> {
     if (this.calculator.isDateInPastPeriod(dateStr)) {
       return true;

--- a/backend/src/periods/tests/lock-service.spec.ts
+++ b/backend/src/periods/tests/lock-service.spec.ts
@@ -45,6 +45,39 @@ describe('LockService', () => {
     jest.clearAllMocks();
   });
 
+  describe('getAdminLock', () => {
+    it('returns the admin lock for an entity', async () => {
+      const lock = { id: 'lock-1', entityId: 'entity-1', lockDate: '2026-03-15' };
+      adminLockRepo.findOne.mockResolvedValue(lock);
+      expect(await service.getAdminLock('entity-1')).toEqual(lock);
+    });
+
+    it('returns null when no admin lock exists', async () => {
+      adminLockRepo.findOne.mockResolvedValue(null);
+      expect(await service.getAdminLock('entity-1')).toBeNull();
+    });
+  });
+
+  describe('isDateLockedSync', () => {
+    it('returns true when date is in a past period', () => {
+      expect(service.isDateLockedSync('2026-03-10', null)).toBe(true);
+    });
+
+    it('returns true when date <= admin lock date', () => {
+      const lock = { lockDate: '2026-03-25' } as any;
+      expect(service.isDateLockedSync('2026-03-20', lock)).toBe(true);
+    });
+
+    it('returns false when date is current and no admin lock', () => {
+      expect(service.isDateLockedSync('2026-03-20', null)).toBe(false);
+    });
+
+    it('returns false when date is after admin lock date', () => {
+      const lock = { lockDate: '2026-03-18' } as any;
+      expect(service.isDateLockedSync('2026-03-20', lock)).toBe(false);
+    });
+  });
+
   describe('isDateLocked', () => {
     it('returns true when date is in a past period', async () => {
       adminLockRepo.findOne.mockResolvedValue(null);


### PR DESCRIPTION
## Summary

- Add `getAdminLock(entityId)` to fetch admin lock once per request
- Add `isDateLockedSync(dateStr, adminLock)` for pure synchronous computation using pre-fetched lock
- Refactor `findMine()`, `create()`, `getOne()`, `update()` in ActivitiesController to use single-fetch pattern instead of per-item DB queries
- 20 items no longer means 20 identical `adminLockRepo.findOne()` calls

## Test plan

- [x] `npm test -- --testPathPattern=lock-service` — 25 tests pass (6 new)
- [x] Full backend suite — 37 suites, 323 tests pass