### PR TITLE
fix(frontend): throw AuthException when access token retrieval fails

### DIFF
--- a/frontend/lib/core/api_client.dart
+++ b/frontend/lib/core/api_client.dart
@@ -167,6 +167,12 @@ class ApiClient {
         headers['Authorization'] = 'Bearer $token';
       }
     } catch (e) {
+      if (e is SocketException) {
+        throw NetworkException.noConnection();
+      }
+      if (e is TimeoutException) {
+        throw NetworkException.timeout();
+      }
       throw AuthException.tokenExpired();
     }
 

--- a/frontend/lib/core/api_client.dart
+++ b/frontend/lib/core/api_client.dart
@@ -167,8 +167,7 @@ class ApiClient {
         headers['Authorization'] = 'Bearer $token';
       }
     } catch (e) {
-      // If we can't get a token, continue without it
-      // The server will return 401 if auth is required
+      throw AuthException.tokenExpired();
     }
 
     if (additionalHeaders != null) {

--- a/frontend/test/core/api_client_test.dart
+++ b/frontend/test/core/api_client_test.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/core/api_client.dart';
+import 'package:logger/core/errors/app_exception.dart';
+
+void main() {
+  group('ApiClient._buildHeaders', () {
+    test('throws AuthException.tokenExpired when token retrieval fails', () {
+      final client = ApiClient(
+        baseUrl: 'http://localhost',
+        getAccessToken: () async => throw Exception('Auth0 SDK error'),
+      );
+
+      expect(
+        () => client.get('/test'),
+        throwsA(isA<AuthException>().having(
+          (e) => e.technicalMessage,
+          'technicalMessage',
+          'Token expired',
+        )),
+      );
+    });
+
+    test('throws NetworkException on SocketException during token retrieval',
+        () {
+      final client = ApiClient(
+        baseUrl: 'http://localhost',
+        getAccessToken: () async =>
+            throw const SocketException('Connection refused'),
+      );
+
+      expect(
+        () => client.get('/test'),
+        throwsA(isA<NetworkException>()),
+      );
+    });
+
+    test('throws NetworkException on TimeoutException during token retrieval',
+        () {
+      final client = ApiClient(
+        baseUrl: 'http://localhost',
+        getAccessToken: () async =>
+            throw TimeoutException('Token request timed out'),
+      );
+
+      expect(
+        () => client.get('/test'),
+        throwsA(isA<NetworkException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Replace silent catch in `_buildHeaders()` that swallowed token retrieval failures and sent unauthenticated requests
- Now throws `AuthException.tokenExpired()` so the error propagates to callers and triggers login redirect instead of a confusing 401 error

## Test plan

- [x] `flutter analyze lib/core/api_client.dart` — no issues
- [ ] Manual: simulate token provider failure, verify user sees login prompt instead of generic API error