### PR TITLE
refactor(activity-form): improve role and activity type selection logic for edit mode

### DIFF
--- a/frontend/lib/widgets/dialogs/activity_form_dialog.dart
+++ b/frontend/lib/widgets/dialogs/activity_form_dialog.dart
@@ -152,9 +152,8 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
         setState(() {
           _selectedRole = matchingRole;
           _selectedType = foundType;
-          _typesFuture = _typeService
-              .fetchByRole(matchingRole!.role.id)
-              .then((filtered) {
+          _typesFuture =
+              _typeService.fetchByRole(matchingRole!.role.id).then((filtered) {
             if (_selectedType != null) {
               ActivityType? matched;
               for (final t in filtered) {

--- a/frontend/lib/widgets/dialogs/activity_form_dialog.dart
+++ b/frontend/lib/widgets/dialogs/activity_form_dialog.dart
@@ -40,6 +40,7 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
   late final PeriodsService _periodsService;
   late Future<List<UserRoleAssignment>> _rolesFuture;
   late Future<List<ActivityType>> _typesFuture;
+  late Future<List<ActivityType>> _allTypesFuture;
 
   UserRoleAssignment? _selectedRole;
   ActivityType? _selectedType;
@@ -97,17 +98,98 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
     }
 
     _dateCtrl.text = DateFormat.yMMMMd('es').format(_selectedDate);
-    _typesFuture = _typeService.fetchAll().then((types) {
+
+    _allTypesFuture = _typeService.fetchAll();
+    _typesFuture = _allTypesFuture.then((types) {
       if (isEditMode && types.isNotEmpty) {
         final typeId = widget.existingActivity?['activityTypeId'] as String?;
-        if (typeId != null) {
-          final found = types.where((t) => t.id == typeId).firstOrNull;
+        if (typeId != null && typeId.isNotEmpty) {
+          ActivityType? found;
+          for (final t in types) {
+            if (t.id == typeId) {
+              found = t;
+              break;
+            }
+          }
           if (found != null) {
             setState(() => _selectedType = found);
           }
         }
       }
       return types;
+    });
+
+    _rolesFuture = _rolesFuture.then((roles) async {
+      if (!isEditMode) return roles;
+
+      final activeRoles = roles.where((r) => r.isActive).toList();
+      if (activeRoles.isEmpty) return roles;
+
+      final typeId = widget.existingActivity?['activityTypeId'] as String?;
+      if (typeId == null || typeId.isEmpty) return roles;
+
+      final types = await _allTypesFuture;
+      ActivityType? foundType;
+      for (final t in types) {
+        if (t.id == typeId) {
+          foundType = t;
+          break;
+        }
+      }
+      if (foundType == null) return roles;
+
+      UserRoleAssignment? matchingRole;
+      for (final role in activeRoles) {
+        final allowed = foundType.allowedRoles
+            .any((allowedRole) => allowedRole.id == role.role.id);
+        if (allowed) {
+          matchingRole = role;
+          break;
+        }
+      }
+
+      if (matchingRole != null) {
+        setState(() {
+          _selectedRole = matchingRole;
+          _selectedType = foundType;
+          _typesFuture = _typeService
+              .fetchByRole(matchingRole!.role.id)
+              .then((filtered) {
+            if (_selectedType != null) {
+              ActivityType? matched;
+              for (final t in filtered) {
+                if (t.id == _selectedType!.id) {
+                  matched = t;
+                  break;
+                }
+              }
+              _selectedType = matched;
+            }
+            return filtered;
+          });
+        });
+      } else if (activeRoles.length == 1) {
+        final fallbackRole = activeRoles.first;
+        setState(() {
+          _selectedRole = fallbackRole;
+          _typesFuture =
+              _typeService.fetchByRole(fallbackRole.role.id).then((filtered) {
+            if (_selectedType != null) {
+              ActivityType? matched;
+              for (final t in filtered) {
+                if (t.id == _selectedType!.id) {
+                  matched = t;
+                  break;
+                }
+              }
+              _selectedType = matched;
+            }
+            return filtered;
+          });
+        });
+      }
+
+      return roles;
     });
   }
 
@@ -412,8 +494,18 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
                               style: theme.textTheme.bodyMedium);
                         }
 
+                        ActivityType? selectedFromList;
+                        if (_selectedType != null) {
+                          for (final t in types) {
+                            if (t.id == _selectedType!.id) {
+                              selectedFromList = t;
+                              break;
+                            }
+                          }
+                        }
+
                         return DropdownButtonFormField<ActivityType>(
-                          initialValue: _selectedType,
+                          initialValue: selectedFromList,
                           isExpanded: true,
                           items: types
                               .map((t) => DropdownMenuItem<ActivityType>(

--- a/frontend/lib/widgets/dialogs/activity_form_dialog.dart
+++ b/frontend/lib/widgets/dialogs/activity_form_dialog.dart
@@ -111,7 +111,7 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
               break;
             }
           }
-          if (found != null) {
+          if (found != null && mounted) {
             setState(() => _selectedType = found);
           }
         }
@@ -149,6 +149,7 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
       }
 
       if (matchingRole != null) {
+        if (!mounted) return roles;
         setState(() {
           _selectedRole = matchingRole;
           _selectedType = foundType;
@@ -162,13 +163,16 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
                   break;
                 }
               }
-              _selectedType = matched;
+              if (mounted) {
+                setState(() => _selectedType = matched);
+              }
             }
             return filtered;
           });
         });
       } else if (activeRoles.length == 1) {
         final fallbackRole = activeRoles.first;
+        if (!mounted) return roles;
         setState(() {
           _selectedRole = fallbackRole;
           _typesFuture =
@@ -181,7 +185,9 @@ class _ActivityFormDialogState extends State<ActivityFormDialog> {
                   break;
                 }
               }
-              _selectedType = matched;
+              if (mounted) {
+                setState(() => _selectedType = matched);
+              }
             }
             return filtered;
           });


### PR DESCRIPTION
### Summary
Enhances the activity form dialog to intelligently handle role and activity type selection when editing existing activities. The form now automatically selects the appropriate role based on the activity type's allowed roles, improving the user experience and reducing errors.

### Changes

#### Activity Form Dialog

**Enhanced Edit Mode Logic:**
- **Intelligent role pre-selection**: When editing an activity, the form now:
  1. Identifies the activity type from the existing activity
  2. Finds a matching user role that's allowed for that activity type
  3. Automatically selects that role and filters activity types accordingly
  4. Falls back to the user's only role if they have just one assignment

### User Impact

**Before:**
- Users editing an activity had to manually reselect their role
- Incorrect role selection could make the activity type unavailable
- Confusing experience when activity type disappeared from dropdown

**After:**
- Editing an activity automatically selects the correct role
- Activity type remains visible and selected
- Seamless editing experience with pre-filled, consistent data
- Reduces user errors and confusion


### Technical Notes
- Uses explicit loops for better null safety and readability
- Maintains backward compatibility with create mode
- Properly chains async operations with `_allTypesFuture`
- Validates selected values exist in available options before display