### PR TITLE
feat(reports): enable sorting for all columns in users report table

### DIFF
--- a/backend/src/reports/dto/users-report.dto.ts
+++ b/backend/src/reports/dto/users-report.dto.ts
@@ -10,6 +10,7 @@ export enum UsersSortField {
   ACTIVITIES = 'activities',
   EXPENSES = 'expenses',
   LAST_ACTIVITY = 'lastActivity',
+  TREND = 'trend',
 }
 
 export enum SortOrder {

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -47,6 +47,8 @@ import {
   UsersReportQueryDto,
   UsersReportResponse,
   UserReportItem,
+  UsersSortField,
+  SortOrder,
   EngagementFilter,
 } from './dto/users-report.dto';
 import { CsvExporter } from './export/csv-exporter';
@@ -1042,13 +1044,20 @@ export class ReportsService {
     // Get entity hierarchy
     const entityIds = await this.accessService.getEntityHierarchy(targetEntityId);
 
-    // Get users in hierarchy with pagination
-    const { users, total } = await this.accessService.getUsersInHierarchy(entityIds, {
-      page: query.page || 1,
-      limit: query.limit || 20,
+    // Determine if sorting by a computed field (requires in-memory sort)
+    const computedSortFields = ['activities', 'expenses', 'lastActivity', 'trend'];
+    const isComputedSort = computedSortFields.includes(query.sortBy);
+
+    // For computed sort fields, fetch all users (no pagination) so we can sort in-memory
+    // For DB-sortable fields, use efficient DB-level sort + pagination
+    const page = query.page || 1;
+    const limit = query.limit || 20;
+    const { users, total: dbTotal } = await this.accessService.getUsersInHierarchy(entityIds, {
+      page: isComputedSort ? 1 : page,
+      limit: isComputedSort ? Number.MAX_SAFE_INTEGER : limit,
       search: query.search,
-      sortBy: query.sortBy,
-      sortOrder: query.sortOrder,
+      sortBy: isComputedSort ? undefined : query.sortBy,
+      sortOrder: isComputedSort ? undefined : query.sortOrder,
     });
 
     // Determine time scope
@@ -1151,6 +1160,35 @@ export class ReportsService {
       userItems = userItems.filter((u) => u.activitiesCount === 0);
     }
 
+    // For computed sort fields, sort in-memory and paginate the result
+    let total = dbTotal;
+    if (isComputedSort) {
+      const sortOrder = query.sortOrder === SortOrder.DESC ? -1 : 1;
+      userItems.sort((a, b) => {
+        switch (query.sortBy) {
+          case UsersSortField.ACTIVITIES:
+            return (a.activitiesCount - b.activitiesCount) * sortOrder;
+          case UsersSortField.EXPENSES:
+            return (a.totalExpenses - b.totalExpenses) * sortOrder;
+          case UsersSortField.LAST_ACTIVITY: {
+            const dateA = a.lastActivityDate || '';
+            const dateB = b.lastActivityDate || '';
+            return dateA.localeCompare(dateB) * sortOrder;
+          }
+          case UsersSortField.TREND: {
+            const trendA = a.trend ?? -Infinity;
+            const trendB = b.trend ?? -Infinity;
+            return (trendA - trendB) * sortOrder;
+          }
+          default:
+            return 0;
+        }
+      });
+      total = userItems.length;
+      const offset = (page - 1) * limit;
+      userItems = userItems.slice(offset, offset + limit);
+    }
+
     // Calculate summary from all users (before pagination filtering)
     const allUsersMetrics = Array.from(userMetrics.values());
     const activeUsersCount = allUsersMetrics.filter((m) => m.count > 0).length;
@@ -1161,10 +1199,10 @@ export class ReportsService {
     return {
       users: userItems,
       pagination: {
-        page: query.page || 1,
-        limit: query.limit || 20,
+        page,
+        limit,
         total,
-        totalPages: Math.ceil(total / (query.limit || 20)),
+        totalPages: Math.ceil(total / limit),
       },
       summary: {
         totalUsers: total,

--- a/frontend/lib/widgets/reports/users_report_table.dart
+++ b/frontend/lib/widgets/reports/users_report_table.dart
@@ -232,20 +232,24 @@ class _UsersReportTableState extends State<UsersReportTable> {
             label: const Text('Rol'),
             onSort: (_, __) => _handleSort('role'),
           ),
-          const DataColumn(
-            label: Text('Actividades'),
+          DataColumn(
+            label: const Text('Actividades'),
             numeric: true,
+            onSort: (_, __) => _handleSort('activities'),
           ),
-          const DataColumn(
-            label: Text('Gastos'),
+          DataColumn(
+            label: const Text('Gastos'),
             numeric: true,
+            onSort: (_, __) => _handleSort('expenses'),
           ),
-          const DataColumn(
-            label: Text('Ultima Actividad'),
+          DataColumn(
+            label: const Text('Ultima Actividad'),
+            onSort: (_, __) => _handleSort('lastActivity'),
           ),
-          const DataColumn(
-            label: Text('Tendencia'),
+          DataColumn(
+            label: const Text('Tendencia'),
             numeric: true,
+            onSort: (_, __) => _handleSort('trend'),
           ),
         ],
         rows: widget.response.users.map((user) {
@@ -529,6 +533,14 @@ class _UsersReportTableState extends State<UsersReportTable> {
         return 2;
       case 'role':
         return 3;
+      case 'activities':
+        return 4;
+      case 'expenses':
+        return 5;
+      case 'lastActivity':
+        return 6;
+      case 'trend':
+        return 7;
       default:
         return null;
     }


### PR DESCRIPTION
## Summary

- Adds sorting support for the 4 remaining unsortable columns in the users report table: activities count, expenses, last activity date, and trend
- Computed fields can't use DB-level ORDER BY since they're derived from a separate activities query, so the service fetches all users unpaginated, sorts in memory, then slices for pagination when sorting by these fields
- The existing DB-sort path for name/email/entity/role remains unchanged

## Changes

- **backend/src/reports/dto/users-report.dto.ts** — Add `TREND` to `UsersSortField` enum
- **backend/src/reports/reports.service.ts** — Dual-path sort: DB-level for column-backed fields, in-memory for computed fields (activities, expenses, lastActivity, trend) with manual pagination
- **frontend/lib/widgets/reports/users_report_table.dart** — Add `onSort` handlers and sort column index mappings for the 4 new sortable columns

## Test plan

- [ ] Verify sorting by activities column orders users by activity count
- [ ] Verify sorting by expenses column orders users by total expenses
- [ ] Verify sorting by last activity column orders users by most recent activity date
- [ ] Verify sorting by trend column orders users by trend percentage
- [ ] Verify toggling sort direction (asc/desc) works for all new columns
- [ ] Verify existing sort columns (name, email, entity, role) still work
- [ ] Verify pagination remains correct when sorting by computed fields
- [ ] Flutter analyze: no issues
- [ ] Prettier: all files clean