### PR TITLE
chore(infra): prepare for initial production deployment

### DIFF
--- a/backend/.npmrc
+++ b/backend/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -1046,7 +1046,7 @@ export class ReportsService {
 
     // Determine if sorting by a computed field (requires in-memory sort)
     const computedSortFields = ['activities', 'expenses', 'lastActivity', 'trend'];
-    const isComputedSort = computedSortFields.includes(query.sortBy);
+    const isComputedSort = query.sortBy != null && computedSortFields.includes(query.sortBy);
 
     // For computed sort fields, fetch all users (no pagination) so we can sort in-memory
     // For DB-sortable fields, use efficient DB-level sort + pagination

--- a/infra/root/backend.tf
+++ b/infra/root/backend.tf
@@ -1,8 +1,9 @@
-terraform {
-  backend "azurerm" {
-    resource_group_name  = "REPLACE_ME_TFSTATE_RG"
-    storage_account_name = "REPLACE_ME_TFSTATE_STORAGE"
-    container_name       = "REPLACE_ME_TFSTATE_CONTAINER"
-    key                  = "secretary.prod.tfstate"
-  }
-}
+# Remote backend — will configure after initial deployment
+# terraform {
+#   backend "azurerm" {
+#     resource_group_name  = "REPLACE_ME_TFSTATE_RG"
+#     storage_account_name = "REPLACE_ME_TFSTATE_STORAGE"
+#     container_name       = "REPLACE_ME_TFSTATE_CONTAINER"
+#     key                  = "secretary.prod.tfstate"
+#   }
+# }

--- a/infra/root/main.tf
+++ b/infra/root/main.tf
@@ -1,3 +1,9 @@
+resource "random_password" "postgres" {
+  length           = 32
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
 resource "azurerm_resource_group" "main" {
   name     = "${local.name_prefix}-rg"
   location = var.location
@@ -32,7 +38,7 @@ module "postgres" {
   location            = var.location
   rg_name             = azurerm_resource_group.main.name
   admin_username      = var.postgres_admin_username
-  admin_password      = var.postgres_admin_password
+  admin_password      = random_password.postgres.result
   data_subnet_id      = module.network.data_subnet_id
   private_dns_zone_id = module.network.postgres_private_dns_zone_id
   tags                = local.tags
@@ -53,7 +59,7 @@ module "container_apps" {
   db_host                    = module.postgres.fqdn
   db_name                    = module.postgres.db_name
   db_username                = module.postgres.admin_username
-  db_password                = var.postgres_admin_password
+  db_password                = random_password.postgres.result
   auth0_domain               = var.auth0_domain
   auth0_audience             = var.auth0_audience
   auth0_issuer               = var.auth0_issuer

--- a/infra/root/variables.tf
+++ b/infra/root/variables.tf
@@ -15,12 +15,6 @@ variable "postgres_admin_username" {
   description = "Admin username for PostgreSQL Flexible Server."
 }
 
-variable "postgres_admin_password" {
-  type        = string
-  description = "Admin password for PostgreSQL Flexible Server."
-  sensitive   = true
-}
-
 variable "container_image" {
   type        = string
   description = "Full container image reference (e.g. ghcr.io/goargus/logger:latest)."

--- a/infra/root/versions.tf
+++ b/infra/root/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.90.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Fix TypeScript build error in reports service (`sortBy` undefined check)
- Add `.npmrc` with `legacy-peer-deps=true` to resolve peer dep conflict in Docker builds
- Switch Terraform to local state backend for initial apply
- Add `random_password` resource for PostgreSQL admin password (replaces manual variable)

## Context

Prepares the codebase for the first production deployment. The backend Docker build was failing due to a TS type error and npm peer dep conflict. Terraform infra was pointing at a non-existent remote backend.

## Test plan

- [ ] CI passes (lint, tests, Docker build verify)
- [ ] Deploy pipeline's `build-and-push` job succeeds (pushes image to GHCR)
- [ ] `terraform init && terraform plan -var-file=prod.tfvars` succeeds locally