### PR TITLE
chore(ci): switch deploy trigger to semver releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,8 @@
 name: Deploy Backend
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - '.github/workflows/deploy.yml'
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:
@@ -20,7 +17,7 @@ jobs:
       packages: write
 
     outputs:
-      image_tag: ${{ steps.meta.outputs.tags }}
+      version: ${{ steps.meta.outputs.version }}
 
     steps:
       - name: Checkout code
@@ -39,7 +36,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
       - name: Build and push
@@ -72,4 +70,4 @@ jobs:
         with:
           resourceGroup: secretary-prod-rg
           containerAppName: secretary-prod-api
-          imageToDeploy: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          imageToDeploy: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.version }}


### PR DESCRIPTION
## Summary

- Replace push-to-main trigger with `release: published`
- Image tags use semantic versioning from release tags (v0.0.1 → 0.0.1, 0.0, latest)
- Deploy job references the semver version instead of git SHA

## Context

Preparing for first production release (v0.0.1). CI (push) handles lint/test/build-verify. Deploys are now release-driven.