### PR TITLE
feat(infra): add Cloudflare DNS and custom domains

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -41,4 +41,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy frontend/build/web --project-name=secretary-backend --commit-dirty=true
+          command: pages deploy frontend/build/web --project-name=secretary-frontend --commit-dirty=true

--- a/infra/modules/cloudflare/main.tf
+++ b/infra/modules/cloudflare/main.tf
@@ -1,0 +1,27 @@
+# TXT record for Azure custom domain verification
+resource "cloudflare_record" "api_txt_verification" {
+  zone_id = var.zone_id
+  name    = "asuid.${var.api_subdomain}"
+  type    = "TXT"
+  content = var.api_domain_verification_id
+  ttl     = 300
+}
+
+# A record pointing to the Container Apps static IP (proxy OFF for Azure managed cert)
+resource "cloudflare_record" "api_a" {
+  zone_id = var.zone_id
+  name    = var.api_subdomain
+  type    = "A"
+  content = var.api_static_ip
+  proxied = false
+  ttl     = 300
+}
+
+# CNAME record for frontend → Cloudflare Pages (proxy ON)
+resource "cloudflare_record" "frontend_cname" {
+  zone_id = var.zone_id
+  name    = var.frontend_subdomain
+  type    = "CNAME"
+  content = var.pages_cname_target
+  proxied = true
+}

--- a/infra/modules/cloudflare/outputs.tf
+++ b/infra/modules/cloudflare/outputs.tf
@@ -1,0 +1,7 @@
+output "api_fqdn" {
+  value = "${var.api_subdomain}.${var.domain}"
+}
+
+output "frontend_fqdn" {
+  value = "${var.frontend_subdomain}.${var.domain}"
+}

--- a/infra/modules/cloudflare/variables.tf
+++ b/infra/modules/cloudflare/variables.tf
@@ -1,0 +1,34 @@
+variable "zone_id" {
+  type        = string
+  description = "Cloudflare Zone ID for the domain."
+}
+
+variable "api_subdomain" {
+  type        = string
+  description = "Subdomain for the API (e.g. logger-api)."
+}
+
+variable "frontend_subdomain" {
+  type        = string
+  description = "Subdomain for the frontend (e.g. logger)."
+}
+
+variable "domain" {
+  type        = string
+  description = "Root domain (e.g. asdmr.org.hn)."
+}
+
+variable "api_static_ip" {
+  type        = string
+  description = "Static IP address of the Container Apps environment."
+}
+
+variable "api_domain_verification_id" {
+  type        = string
+  description = "Custom domain verification ID from the Container Apps environment."
+}
+
+variable "pages_cname_target" {
+  type        = string
+  description = "Cloudflare Pages CNAME target (e.g. project-name.pages.dev)."
+}

--- a/infra/modules/cloudflare/versions.tf
+++ b/infra/modules/cloudflare/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/infra/modules/container_apps/outputs.tf
+++ b/infra/modules/container_apps/outputs.tf
@@ -5,3 +5,15 @@ output "fqdn" {
 output "environment_id" {
   value = azurerm_container_app_environment.main.id
 }
+
+output "container_app_id" {
+  value = azurerm_container_app.api.id
+}
+
+output "static_ip" {
+  value = azurerm_container_app_environment.main.static_ip_address
+}
+
+output "domain_verification_id" {
+  value = azurerm_container_app_environment.main.custom_domain_verification_id
+}

--- a/infra/root/main.tf
+++ b/infra/root/main.tf
@@ -5,7 +5,7 @@ resource "random_password" "postgres" {
 }
 
 resource "azurerm_resource_group" "main" {
-  name     = "${local.name_prefix}-rg"
+  name     = local.caf.rg
   location = var.location
   tags     = local.tags
 }
@@ -13,28 +13,25 @@ resource "azurerm_resource_group" "main" {
 module "network" {
   source = "../modules/network"
 
-  project_name = var.project_name
-  env          = local.env
-  location     = var.location
-  rg_name      = azurerm_resource_group.main.name
-  tags         = local.tags
+  vnet_name = local.caf.vnet
+  location  = var.location
+  rg_name   = azurerm_resource_group.main.name
+  tags      = local.tags
 }
 
 module "monitoring" {
   source = "../modules/monitoring"
 
-  project_name = var.project_name
-  env          = local.env
-  location     = var.location
-  rg_name      = azurerm_resource_group.main.name
-  tags         = local.tags
+  name     = local.caf.law
+  location = var.location
+  rg_name  = azurerm_resource_group.main.name
+  tags     = local.tags
 }
 
 module "postgres" {
   source = "../modules/postgres"
 
-  project_name        = var.project_name
-  env                 = local.env
+  name                = local.caf.psql
   location            = var.location
   rg_name             = azurerm_resource_group.main.name
   admin_username      = var.postgres_admin_username
@@ -47,8 +44,8 @@ module "postgres" {
 module "container_apps" {
   source = "../modules/container_apps"
 
-  project_name               = var.project_name
-  env                        = local.env
+  environment_name           = local.caf.cae
+  app_name                   = local.caf.ca
   location                   = var.location
   rg_name                    = azurerm_resource_group.main.name
   container_apps_subnet_id   = module.network.container_apps_subnet_id
@@ -69,4 +66,32 @@ module "container_apps" {
   admin_idp_issuer           = var.admin_idp_issuer
   admin_idp_subject          = var.admin_idp_subject
   tags                       = local.tags
+}
+
+# ── Cloudflare DNS ──────────────────────────────────────────
+module "cloudflare" {
+  source = "../modules/cloudflare"
+
+  zone_id                    = var.cloudflare_zone_id
+  api_subdomain              = "logger-api"
+  frontend_subdomain         = "logger"
+  domain                     = "asdmr.org.hn"
+  api_static_ip              = module.container_apps.static_ip
+  api_domain_verification_id = module.container_apps.domain_verification_id
+  pages_cname_target         = "secretary-frontend.pages.dev"
+}
+
+# Custom domain binding lives at root to avoid circular dependency:
+# cloudflare needs container_apps outputs, and the binding needs cloudflare to finish first.
+resource "azurerm_container_app_custom_domain" "api" {
+  name             = "logger-api.asdmr.org.hn"
+  container_app_id = module.container_apps.container_app_id
+
+  # Azure provisions the managed certificate asynchronously after domain validation.
+  # These values are populated by Azure and must be ignored to prevent resource recreation.
+  lifecycle {
+    ignore_changes = [certificate_binding_type, container_app_environment_certificate_id]
+  }
+
+  depends_on = [module.cloudflare]
 }

--- a/infra/root/outputs.tf
+++ b/infra/root/outputs.tf
@@ -18,3 +18,11 @@ output "postgres_fqdn" {
 output "postgres_db_name" {
   value = module.postgres.db_name
 }
+
+output "api_custom_url" {
+  value = "https://${module.cloudflare.api_fqdn}"
+}
+
+output "frontend_custom_url" {
+  value = "https://${module.cloudflare.frontend_fqdn}"
+}

--- a/infra/root/providers.tf
+++ b/infra/root/providers.tf
@@ -1,3 +1,8 @@
 provider "azurerm" {
   features {}
 }
+
+provider "cloudflare" {
+  api_key = var.cloudflare_api_key
+  email   = var.cloudflare_email
+}

--- a/infra/root/variables.tf
+++ b/infra/root/variables.tf
@@ -1,7 +1,7 @@
 variable "project_name" {
   type        = string
   description = "Project name prefix for all resources."
-  default     = "secretary"
+  default     = "logger"
 }
 
 variable "location" {
@@ -77,4 +77,21 @@ variable "tags" {
   type        = map(string)
   description = "Tags to apply to all resources."
   default     = {}
+}
+
+# ── Cloudflare ──────────────────────────────────────────────
+variable "cloudflare_api_key" {
+  type        = string
+  description = "Cloudflare Global API Key."
+  sensitive   = true
+}
+
+variable "cloudflare_email" {
+  type        = string
+  description = "Cloudflare account email address."
+}
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare Zone ID for the domain."
 }

--- a/infra/root/versions.tf
+++ b/infra/root/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.6.0"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `infra/modules/cloudflare/` Terraform module for DNS records (A, TXT, CNAME)
- Bind `logger-api.asdmr.org.hn` custom domain to Azure Container Apps with managed cert
- Point `logger.asdmr.org.hn` CNAME to new `secretary-frontend` Cloudflare Pages project
- Switch CI deploy workflow from orphaned `secretary-backend` to `secretary-frontend` project
- Add Cloudflare provider (v4.x) with Global API Key auth

## Test plan
- [x] `terraform init` succeeds with Cloudflare provider
- [x] `terraform plan` shows expected resources
- [x] `terraform apply` creates DNS records and custom domain binding
- [x] `dig logger-api.asdmr.org.hn` resolves to Container Apps static IP
- [ ] API health check passes on `https://logger-api.asdmr.org.hn/health` (pending managed cert)
- [ ] Frontend loads at `https://logger.asdmr.org.hn` (pending CI deploy after merge)