### PR TITLE
feat(auth): add Microsoft Entra ID as identity provider

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,10 @@ AUTH0_DOMAIN=your-tenant.auth0.com
 AUTH0_ISSUER=https://your-tenant.auth0.com/
 AUTH0_AUDIENCE=https://api.your-app.com
 
+# Entra ID (Azure AD)
+ENTRA_TENANT_ID=your-tenant-id-uuid
+ENTRA_CLIENT_ID=your-app-registration-client-id-uuid
+
 # CORS (comma-separated origins, optional)
 # CORS_ORIGINS=http://localhost:3000,http://localhost:8080
 

--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -18,4 +18,4 @@ COPY --from=base /app/dist ./dist
 COPY --from=base /app/migrations ./migrations
 ENV NODE_ENV=production
 USER node
-CMD ["node", "dist/main.js"]
+CMD ["node", "dist/src/main.js"]

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -157,6 +157,37 @@ describe('AuthService', () => {
       ).rejects.toThrow(ForbiddenException);
     });
 
+    it('auto-links Entra ID user by email when emailVerified is set by caller', async () => {
+      const entraClaims: JwtClaims = {
+        iss: 'https://login.microsoftonline.com/test-tenant-id/v2.0',
+        sub: '00000000-0000-0000-0000-000000000abc', // oid value
+        aud: '00000000-0000-0000-0000-000000000001',
+        email: 'jdoe@example.com',
+        email_verified: true, // Set by JWT strategy for trusted tenant
+        name: 'John Doe',
+      };
+      idpIdentitiesService.findByIssuerAndSubject.mockResolvedValue(null);
+      userRepo.find.mockResolvedValue([activeUser]);
+      idpIdentitiesService.create.mockResolvedValue({
+        user_id: 'user-1',
+        user: activeUser,
+      });
+
+      const result = await service.resolveUserFromJwt(entraClaims, 'azuread', {
+        allowAutoLinkByVerifiedEmail: true,
+      });
+
+      expect(result.user).toEqual(activeUser);
+      expect(idpIdentitiesService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: 'user-1',
+          provider: 'azuread',
+          issuer: 'https://login.microsoftonline.com/test-tenant-id/v2.0',
+          subject: '00000000-0000-0000-0000-000000000abc',
+        }),
+      );
+    });
+
     it('throws ForbiddenException when no identity and auto-link disabled', async () => {
       idpIdentitiesService.findByIssuerAndSubject.mockResolvedValue(null);
 

--- a/backend/src/auth/idp-registry.ts
+++ b/backend/src/auth/idp-registry.ts
@@ -1,0 +1,38 @@
+import * as jwksRsa from 'jwks-rsa';
+
+export interface IdpConfig {
+  name: string;
+  issuer: string;
+  jwksUri: string;
+  audience: string;
+  identityClaim: string; // 'oid' for Entra ID, 'sub' for Auth0
+  provider: 'auth0' | 'google' | 'azuread' | 'generic';
+  emailVerifiedByDefault: boolean;
+  jwksClient: jwksRsa.JwksClient;
+  extraValidation?: (payload: any) => void;
+}
+
+export class IdpRegistry {
+  private readonly idps: Map<string, IdpConfig> = new Map();
+
+  register(config: Omit<IdpConfig, 'jwksClient'>): void {
+    const jwksClient = new jwksRsa.JwksClient({
+      jwksUri: config.jwksUri,
+      cache: true,
+      cacheMaxEntries: 5,
+      cacheMaxAge: 10 * 60 * 1000,
+      rateLimit: true,
+      jwksRequestsPerMinute: 10,
+    });
+
+    this.idps.set(config.issuer, { ...config, jwksClient });
+  }
+
+  resolve(issuer: string): IdpConfig | undefined {
+    return this.idps.get(issuer);
+  }
+
+  getAllIssuers(): string[] {
+    return Array.from(this.idps.keys());
+  }
+}

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -1,11 +1,11 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy, StrategyOptions } from 'passport-jwt';
-import * as jwksRsa from 'jwks-rsa';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { IdentityResolutionService } from './identity-resolution.service';
+import { AuthService } from './auth.service';
+import { IdpRegistry, IdpConfig } from './idp-registry';
 import { UserRoleAssignment } from '../roles/user-role-assignment.entity';
 import { User } from '../users/user.entity';
 import { getCurrentDateString, isDateInRange } from '../common/date.utils';
@@ -18,69 +18,107 @@ export interface JwtValidatedUser extends User {
   [k: string]: any;
 }
 
-function ensureTrailingSlash(url?: string): string | undefined {
-  if (!url) return undefined;
-  return url.endsWith('/') ? url : `${url}/`;
-}
-
-function firstDefined<T>(...getters: Array<() => T | undefined | null>): T | undefined {
-  for (const g of getters) {
-    const v = g();
-    if (v !== undefined && v !== null && v !== '') return v as T;
-  }
-  return undefined;
-}
-
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  private readonly expectedIssuer: string;
-  private readonly expectedAudience: string;
+  private readonly idpRegistry: IdpRegistry;
+  private resolvedIdp: IdpConfig | undefined;
 
   constructor(
     config: ConfigService,
-    private readonly identityResolution: IdentityResolutionService,
+    private readonly authService: AuthService,
     @InjectRepository(UserRoleAssignment)
     private readonly userRoleAssignmentRepo: Repository<UserRoleAssignment>,
   ) {
-    const issuerFromCfg =
-      firstDefined<string>(
-        () => config.get<string>('auth.issuer'),
-        () => config.get<string>('AUTH0_ISSUER'),
-        () => config.get<string>('AUTH_ISSUER'),
-        () => {
-          const domain = config.get<string>('AUTH0_DOMAIN');
-          return domain ? `https://${domain}/` : undefined;
+    const registry = new IdpRegistry();
+
+    // Register Auth0
+    const auth0Issuer =
+      config.get<string>('auth.issuer') || config.get<string>('AUTH0_ISSUER') || '';
+    const auth0Audience =
+      config.get<string>('auth.audience') || config.get<string>('AUTH0_AUDIENCE') || 'logger';
+    const auth0Domain =
+      config.get<string>('auth.domain') || config.get<string>('AUTH0_DOMAIN') || '';
+
+    if (auth0Issuer) {
+      registry.register({
+        name: 'Auth0',
+        issuer: auth0Issuer,
+        jwksUri: `https://${auth0Domain}/.well-known/jwks.json`,
+        audience: auth0Audience,
+        identityClaim: 'sub',
+        provider: 'auth0',
+        emailVerifiedByDefault: false,
+      });
+    }
+
+    // Register Entra ID
+    const entraTenantId =
+      config.get<string>('auth.entraId.tenantId') || config.get<string>('ENTRA_TENANT_ID') || '';
+    const entraClientId =
+      config.get<string>('auth.entraId.clientId') || config.get<string>('ENTRA_CLIENT_ID') || '';
+
+    if (entraTenantId && entraClientId) {
+      registry.register({
+        name: 'Entra ID',
+        issuer: `https://login.microsoftonline.com/${entraTenantId}/v2.0`,
+        jwksUri: `https://login.microsoftonline.com/${entraTenantId}/discovery/v2.0/keys`,
+        audience: entraClientId,
+        identityClaim: 'oid',
+        provider: 'azuread',
+        emailVerifiedByDefault: true,
+        extraValidation: (payload: any) => {
+          if (payload.tid !== entraTenantId) {
+            throw new UnauthorizedException('Invalid token tenant');
+          }
         },
-      ) || '';
+      });
+    }
 
-    const issuer = ensureTrailingSlash(issuerFromCfg) as string;
-    const audience =
-      firstDefined<string>(
-        () => config.get<string>('auth.audience'),
-        () => config.get<string>('AUTH0_AUDIENCE'),
-        () => config.get<string>('AUTH_AUDIENCE'),
-      ) || 'logger';
-
-    const jwksUri = `${issuer}.well-known/jwks.json`;
+    const strategy = { idpRegistry: registry, resolvedIdp: undefined as IdpConfig | undefined };
 
     const opts: StrategyOptions = {
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKeyProvider: jwksRsa.passportJwtSecret({
-        jwksUri,
-        cache: true,
-        cacheMaxEntries: 5,
-        cacheMaxAge: 10 * 60 * 1000,
-        rateLimit: true,
-        jwksRequestsPerMinute: 10,
-      }),
+      secretOrKeyProvider: (request: any, rawJwtToken: string, done: any) => {
+        try {
+          // Decode payload without verification to get issuer
+          const parts = rawJwtToken.split('.');
+          if (parts.length !== 3) {
+            return done(new UnauthorizedException('Malformed token'));
+          }
+          const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+          const iss = payload?.iss;
+
+          if (!iss) {
+            return done(new UnauthorizedException('Token missing iss claim'));
+          }
+
+          const idp = registry.resolve(iss);
+          if (!idp) {
+            return done(new UnauthorizedException(`Unknown token issuer: ${iss}`));
+          }
+
+          // Store resolved IdP for use in validate()
+          strategy.resolvedIdp = idp;
+
+          // Use the IdP's JWKS client to get the signing key
+          const header = JSON.parse(Buffer.from(parts[0], 'base64url').toString());
+          idp.jwksClient.getSigningKey(header.kid, (err: any, key: any) => {
+            if (err) return done(err);
+            done(null, key.getPublicKey());
+          });
+        } catch (err) {
+          done(new UnauthorizedException('Failed to resolve token signing key'));
+        }
+      },
       algorithms: ['RS256'],
       ignoreExpiration: false,
     };
 
     super(opts);
 
-    this.expectedIssuer = issuer;
-    this.expectedAudience = audience;
+    this.idpRegistry = registry;
+    // Share the strategy reference for resolvedIdp access
+    Object.defineProperty(this, '_strategyRef', { value: strategy, enumerable: false });
   }
 
   private toArray(aud?: string | string[] | null): string[] {
@@ -88,36 +126,57 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     return Array.isArray(aud) ? aud : [aud];
   }
 
-  private readArrayClaim(payload: any, keys: string[]): string[] {
-    for (const k of keys) {
-      const v = payload?.[k];
-      if (Array.isArray(v)) return v.filter((x) => typeof x === 'string');
-    }
-    return [];
-  }
-
   async validate(payload: any): Promise<JwtValidatedUser> {
-    const sub = payload?.sub ?? payload?.subject;
-    if (!sub) throw new UnauthorizedException('Token has no sub');
+    // Retrieve the resolved IdP from the secretOrKeyProvider step
+    const strategyRef = (this as any)._strategyRef;
+    const idp: IdpConfig | undefined = strategyRef?.resolvedIdp;
 
-    const iss: string | undefined = payload?.iss;
+    if (!idp) {
+      throw new UnauthorizedException('No IdP resolved for token');
+    }
+
+    // Per-IdP validation: issuer
+    const iss = payload?.iss;
+    if (iss !== idp.issuer) {
+      throw new UnauthorizedException('Invalid token issuer');
+    }
+
+    // Per-IdP validation: audience
     const audList = this.toArray(payload?.aud);
-
-    if (!iss) throw new UnauthorizedException('Invalid token: missing iss');
-    if (iss !== this.expectedIssuer) throw new UnauthorizedException('Invalid token issuer');
-
-    if (!audList.includes(this.expectedAudience)) {
+    if (!audList.includes(idp.audience)) {
       throw new UnauthorizedException('Invalid token audience');
     }
 
-    const user = await this.identityResolution.resolveUserBySubAndIssuer(sub, iss);
+    // Per-IdP extra validation (e.g., tid check for Entra ID)
+    if (idp.extraValidation) {
+      idp.extraValidation(payload);
+    }
 
+    // Extract the correct identity claim
+    const identityValue = payload?.[idp.identityClaim];
+    if (!identityValue) {
+      throw new UnauthorizedException(`Token missing ${idp.identityClaim} claim`);
+    }
+
+    // Build claims for AuthService
+    const { user } = await this.authService.resolveUserFromJwt(
+      {
+        iss,
+        sub: identityValue,
+        aud: payload?.aud,
+        email: payload?.email || payload?.preferred_username,
+        email_verified: idp.emailVerifiedByDefault ? true : (payload?.email_verified ?? null),
+        name: payload?.name,
+      },
+      idp.provider,
+      { allowAutoLinkByVerifiedEmail: true },
+    );
+
+    // Load role assignments
     const today = getCurrentDateString();
     const roleAssignments = await this.userRoleAssignmentRepo
       .find({
-        where: {
-          user: { id: user.id },
-        },
+        where: { user: { id: user.id } },
         relations: ['role', 'entity', 'user'],
       })
       .then((assignments) =>
@@ -136,7 +195,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
     return {
       ...user,
-      sub,
+      sub: identityValue,
       iss,
       aud: payload?.aud,
       roleAssignments,

--- a/backend/src/config/auth.config.ts
+++ b/backend/src/config/auth.config.ts
@@ -1,7 +1,15 @@
 export default () => ({
   auth: {
+    // Auth0 (existing)
     domain: process.env.AUTH0_DOMAIN,
     audience: process.env.AUTH0_AUDIENCE,
     issuer: process.env.AUTH0_ISSUER,
+    // Entra ID (new)
+    entraId: {
+      tenantId: process.env.ENTRA_TENANT_ID,
+      clientId: process.env.ENTRA_CLIENT_ID,
+      issuer: `https://login.microsoftonline.com/${process.env.ENTRA_TENANT_ID}/v2.0`,
+      jwksUri: `https://login.microsoftonline.com/${process.env.ENTRA_TENANT_ID}/discovery/v2.0/keys`,
+    },
   },
 });

--- a/backend/src/config/config.validation.ts
+++ b/backend/src/config/config.validation.ts
@@ -14,6 +14,9 @@ export const configValidationSchema = Joi.object({
 
   AUTH0_AUDIENCE: Joi.string().required(),
 
+  ENTRA_TENANT_ID: Joi.string().uuid().required(),
+  ENTRA_CLIENT_ID: Joi.string().uuid().required(),
+
   CORS_ORIGINS: Joi.string().optional(),
 
   DB_HOST: Joi.string().required(),

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -7,6 +7,10 @@ AUTH0_AUDIENCE=logger
 AUTH0_E2E_CLIENT_ID=2H45P97qEyC9HfiKFj8FOvb8DnSOgFwY
 AUTH0_E2E_CLIENT_SECRET=<get-from-auth0-dashboard>
 
+# Entra ID Configuration (for internal user testing)
+ENTRA_TENANT_ID=your-tenant-id
+ENTRA_CLIENT_ID=your-client-id
+
 # =============================================================================
 # TEST USERS
 # =============================================================================

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -5,6 +5,8 @@ flutter run -d web-server \
   --web-port=8080 \
   --dart-define=AUTH0_DOMAIN="${AUTH0_DOMAIN}" \
   --dart-define=AUTH0_CLIENT_ID="${AUTH0_CLIENT_ID}" \
-  --dart-define=AUTH0_REDIRECT_URI="${AUTH0_REDIRECT_URI}" \
   --dart-define=AUTH0_AUDIENCE="${AUTH0_AUDIENCE}" \
+  --dart-define=ENTRA_TENANT_ID="${ENTRA_TENANT_ID}" \
+  --dart-define=ENTRA_CLIENT_ID="${ENTRA_CLIENT_ID}" \
+  --dart-define=REDIRECT_URI="${REDIRECT_URI}" \
   --dart-define=API_BASE_URL="${API_BASE_URL}"

--- a/frontend/lib/config/auth_config.dart
+++ b/frontend/lib/config/auth_config.dart
@@ -1,12 +1,34 @@
 class AuthConfig {
-  static const String domain = String.fromEnvironment('AUTH0_DOMAIN');
-  static const String clientId = String.fromEnvironment('AUTH0_CLIENT_ID');
+  // Shared
+  static const String redirectUri = String.fromEnvironment('REDIRECT_URI');
 
-  static const String redirectUri =
-      String.fromEnvironment('AUTH0_REDIRECT_URI');
+  // Auth0
+  static const String auth0Domain = String.fromEnvironment('AUTH0_DOMAIN');
+  static const String auth0ClientId = String.fromEnvironment('AUTH0_CLIENT_ID');
+  static const String auth0Audience = String.fromEnvironment('AUTH0_AUDIENCE');
 
-  static const String audience = String.fromEnvironment('AUTH0_AUDIENCE');
+  // Entra ID
+  static const String entraTenantId = String.fromEnvironment('ENTRA_TENANT_ID');
+  static const String entraClientId = String.fromEnvironment('ENTRA_CLIENT_ID');
 
-  static bool get isConfigured =>
-      domain.isNotEmpty && clientId.isNotEmpty && audience.isNotEmpty;
+  // Entra ID URLs (derived)
+  static String get entraAuthorizeUrl =>
+      'https://login.microsoftonline.com/$entraTenantId/oauth2/v2.0/authorize';
+
+  static String get entraTokenUrl =>
+      'https://login.microsoftonline.com/$entraTenantId/oauth2/v2.0/token';
+
+  static String get entraLogoutUrl =>
+      'https://login.microsoftonline.com/$entraTenantId/oauth2/v2.0/logout';
+
+  static String get entraApiScope => 'api://$entraClientId/access_as_user';
+
+  // Config checks
+  static bool get isAuth0Configured =>
+      auth0Domain.isNotEmpty && auth0ClientId.isNotEmpty && auth0Audience.isNotEmpty;
+
+  static bool get isEntraConfigured =>
+      entraTenantId.isNotEmpty && entraClientId.isNotEmpty;
+
+  static bool get isConfigured => isAuth0Configured || isEntraConfigured;
 }

--- a/frontend/lib/providers/auth.dart
+++ b/frontend/lib/providers/auth.dart
@@ -18,7 +18,9 @@ import '../utils/url_utils.dart';
 import 'auth_state.dart';
 export 'auth_state.dart';
 
-const bool kAutoRedirectOnBoot = true;
+enum IdpType { entra, auth0 }
+
+const bool kAutoRedirectOnBoot = false;
 
 final authNotifierProvider =
     NotifierProvider<AuthNotifier, AuthState>(AuthNotifier.new);
@@ -45,8 +47,7 @@ class AuthNotifier extends Notifier<AuthState> {
       return 'No pudimos iniciar sesión. Por favor, inténtalo de nuevo.';
     }
 
-    if (message.contains('auth0') ||
-        message.contains('not configured') ||
+    if (message.contains('not configured') ||
         message.contains('dart-define')) {
       return 'La autenticación no está disponible en este momento.';
     }
@@ -82,6 +83,35 @@ class AuthNotifier extends Notifier<AuthState> {
     return base64Url.encode(digest.bytes).replaceAll('=', '');
   }
 
+  Map<String, dynamic> _parseIdToken(String token) {
+    try {
+      final parts = token.split('.');
+      if (parts.length != 3) return {};
+      final normalized = base64Url.normalize(parts[1]);
+      final decoded = utf8.decode(base64Url.decode(normalized));
+      return jsonDecode(decoded) as Map<String, dynamic>;
+    } catch (e) {
+      debugPrint('[AuthNotifier] Failed to parse token: $e');
+      return {};
+    }
+  }
+
+  IdpType? _getSavedIdpType() {
+    final saved = web.window.localStorage.getItem('idp_type');
+    if (saved == 'entra') return IdpType.entra;
+    if (saved == 'auth0') return IdpType.auth0;
+    return null;
+  }
+
+  void _saveIdpType(IdpType type) {
+    web.window.localStorage.setItem('idp_type', type == IdpType.entra ? 'entra' : 'auth0');
+  }
+
+  String _generateState() {
+    final bytes = List<int>.generate(32, (_) => Random.secure().nextInt(256));
+    return base64Url.encode(bytes).replaceAll('=', '');
+  }
+
   Future<void> _bootstrap() async {
     if (_bootstrapped) return;
     _bootstrapped = true;
@@ -90,7 +120,7 @@ class AuthNotifier extends Notifier<AuthState> {
       state = state.copyWith(
         isLoading: false,
         lastError: _friendlyAuthError(
-            'Auth0 no está configurado. Revisa tus --dart-define en auth_config.dart'),
+            'La autenticacion no esta configurada. Contacte al administrador.'),
       );
       return;
     }
@@ -120,6 +150,7 @@ class AuthNotifier extends Notifier<AuthState> {
       if (kAutoRedirectOnBoot && !_isRedirecting) {
         await login();
       } else {
+        await Future<void>.delayed(Duration.zero);
         state = state.copyWith(isLoading: false, isAuthenticated: false);
       }
     } catch (e) {
@@ -176,67 +207,100 @@ class AuthNotifier extends Notifier<AuthState> {
     try {
       final uri = Uri.parse(web.window.location.href);
       final code = uri.queryParameters['code'];
+      final returnedState = uri.queryParameters['state'];
 
       if (code == null || code.isEmpty) {
         throw Exception('No authorization code found in callback URL');
       }
 
+      // Validate CSRF state parameter
+      final savedState = web.window.localStorage.getItem('oauth_state');
+      if (savedState == null || savedState != returnedState) {
+        web.window.localStorage.removeItem('oauth_state');
+        throw Exception('Invalid state parameter');
+      }
+      web.window.localStorage.removeItem('oauth_state');
+
       final codeVerifier =
           web.window.localStorage.getItem('pkce_code_verifier');
       if (codeVerifier == null || codeVerifier.isEmpty) {
-        throw Exception(
-            'Missing PKCE verifier. Authentication flow may have been interrupted.');
+        throw Exception('Missing PKCE verifier');
       }
 
-      debugPrint(
-          '[AuthNotifier] Exchanging authorization code with PKCE verifier...');
+      final idpType = _getSavedIdpType() ?? IdpType.auth0;
 
-      final tokenResponse = await http.post(
-        Uri.parse('https://${AuthConfig.domain}/oauth/token'),
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({
+      String tokenUrl;
+      Map<String, String> tokenBody;
+
+      if (idpType == IdpType.entra) {
+        tokenUrl = AuthConfig.entraTokenUrl;
+        tokenBody = {
           'grant_type': 'authorization_code',
-          'client_id': AuthConfig.clientId,
+          'client_id': AuthConfig.entraClientId,
           'code': code,
           'redirect_uri': AuthConfig.redirectUri,
           'code_verifier': codeVerifier,
-        }),
+          'scope': 'openid profile email ${AuthConfig.entraApiScope}',
+        };
+      } else {
+        tokenUrl = 'https://${AuthConfig.auth0Domain}/oauth/token';
+        tokenBody = {
+          'grant_type': 'authorization_code',
+          'client_id': AuthConfig.auth0ClientId,
+          'code': code,
+          'redirect_uri': AuthConfig.redirectUri,
+          'code_verifier': codeVerifier,
+        };
+      }
+
+      final tokenResponse = await http.post(
+        Uri.parse(tokenUrl),
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: tokenBody,
       );
 
-      if (tokenResponse.statusCode == 200) {
-        final tokens = jsonDecode(tokenResponse.body);
-        final accessToken = tokens['access_token'];
+      if (tokenResponse.statusCode != 200) {
+        throw Exception('Failed to exchange code for token: ${tokenResponse.statusCode}');
+      }
 
-        final userResponse = await http.get(
-          Uri.parse('https://${AuthConfig.domain}/userinfo'),
-          headers: {'Authorization': 'Bearer $accessToken'},
-        );
+      final tokens = jsonDecode(tokenResponse.body);
+      final accessToken = tokens['access_token'] as String;
 
-        if (userResponse.statusCode == 200) {
-          final userInfo =
-              jsonDecode(userResponse.body) as Map<String, dynamic>;
-
-          final backendProfile = await _fetchBackendUserProfile(accessToken);
-
-          final mergedUserInfo = {...userInfo, ...backendProfile};
-
-          web.window.localStorage.setItem('auth_token', accessToken);
-          web.window.localStorage.removeItem('pkce_code_verifier');
-          await _session.saveToken(accessToken);
-
-          _clearAuthCallbackParams(uri);
-
-          state = state.copyWith(
-            isLoading: false,
-            isAuthenticated: true,
-            user: mergedUserInfo,
-            accessToken: accessToken,
-            lastError: null,
-          );
+      // Get user info
+      Map<String, dynamic> userInfo = {};
+      if (idpType == IdpType.entra) {
+        // Parse ID token directly (Entra ID includes claims)
+        final idToken = tokens['id_token'] as String?;
+        if (idToken != null) {
+          userInfo = _parseIdToken(idToken);
         }
       } else {
-        throw Exception('Failed to exchange code for token');
+        // Auth0: fetch from /userinfo endpoint
+        final userResponse = await http.get(
+          Uri.parse('https://${AuthConfig.auth0Domain}/userinfo'),
+          headers: {'Authorization': 'Bearer $accessToken'},
+        );
+        if (userResponse.statusCode == 200) {
+          userInfo = jsonDecode(userResponse.body) as Map<String, dynamic>;
+        }
       }
+
+      final backendProfile = await _fetchBackendUserProfile(accessToken);
+      final mergedUserInfo = {...userInfo, ...backendProfile};
+
+      web.window.localStorage.setItem('auth_token', accessToken);
+      web.window.localStorage.removeItem('pkce_code_verifier');
+      await _session.saveToken(accessToken);
+
+      _clearAuthCallbackParams(uri);
+
+      state = state.copyWith(
+        isLoading: false,
+        isAuthenticated: true,
+        user: mergedUserInfo,
+        accessToken: accessToken,
+        lastError: null,
+      );
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
@@ -257,28 +321,12 @@ class AuthNotifier extends Notifier<AuthState> {
         throw Exception('No token found');
       }
 
-      final userResponse = await http.get(
-        Uri.parse('https://${AuthConfig.domain}/userinfo'),
-        headers: {'Authorization': 'Bearer $accessToken'},
-      );
+      final idpType = _getSavedIdpType();
 
-      if (userResponse.statusCode == 200) {
-        final userInfo = jsonDecode(userResponse.body) as Map<String, dynamic>;
+      // Validate token by calling backend profile
+      final backendProfile = await _fetchBackendUserProfile(accessToken);
 
-        final backendProfile = await _fetchBackendUserProfile(accessToken);
-
-        final mergedUserInfo = {...userInfo, ...backendProfile};
-
-        await _session.saveToken(accessToken);
-
-        state = state.copyWith(
-          isLoading: false,
-          isAuthenticated: true,
-          user: mergedUserInfo,
-          accessToken: accessToken,
-          lastError: null,
-        );
-      } else {
+      if (backendProfile.isEmpty) {
         web.window.localStorage.removeItem('auth_token');
         await _session.clear();
         state = state.copyWith(
@@ -287,11 +335,39 @@ class AuthNotifier extends Notifier<AuthState> {
           accessToken: null,
           user: null,
         );
-        if (!_isRedirecting) {
-          await login();
-        }
         return;
       }
+
+      // Get basic user info
+      Map<String, dynamic> tokenInfo = {};
+      if (idpType == IdpType.auth0) {
+        // Auth0: try /userinfo endpoint
+        try {
+          final userResponse = await http.get(
+            Uri.parse('https://${AuthConfig.auth0Domain}/userinfo'),
+            headers: {'Authorization': 'Bearer $accessToken'},
+          );
+          if (userResponse.statusCode == 200) {
+            tokenInfo = jsonDecode(userResponse.body) as Map<String, dynamic>;
+          }
+        } catch (_) {}
+      } else {
+        // Entra ID: parse claims from the access token JWT
+        try {
+          tokenInfo = _parseIdToken(accessToken);
+        } catch (_) {}
+      }
+
+      final mergedUserInfo = {...tokenInfo, ...backendProfile};
+      await _session.saveToken(accessToken);
+
+      state = state.copyWith(
+        isLoading: false,
+        isAuthenticated: true,
+        user: mergedUserInfo,
+        accessToken: accessToken,
+        lastError: null,
+      );
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
@@ -301,26 +377,58 @@ class AuthNotifier extends Notifier<AuthState> {
     }
   }
 
-  Future<void> login() async {
+  Future<void> loginWithEntra() async {
     if (_isRedirecting) return;
     _isRedirecting = true;
 
     try {
       final codeVerifier = _generateCodeVerifier();
       final codeChallenge = _generateCodeChallenge(codeVerifier);
+      final stateValue = _generateState();
 
       web.window.localStorage.setItem('pkce_code_verifier', codeVerifier);
+      web.window.localStorage.setItem('oauth_state', stateValue);
+      _saveIdpType(IdpType.entra);
 
-      debugPrint(
-          '[AuthNotifier] Generated PKCE challenge, initiating Auth0 redirect...');
+      final authUrl = Uri.parse(AuthConfig.entraAuthorizeUrl).replace(
+        queryParameters: {
+          'response_type': 'code',
+          'client_id': AuthConfig.entraClientId,
+          'redirect_uri': AuthConfig.redirectUri,
+          'scope': 'openid profile email ${AuthConfig.entraApiScope}',
+          'state': stateValue,
+          'code_challenge': codeChallenge,
+          'code_challenge_method': 'S256',
+        },
+      );
 
-      final authUrl = Uri.https(AuthConfig.domain, '/authorize', {
+      web.window.location.assign(authUrl.toString());
+    } catch (e) {
+      _isRedirecting = false;
+      state = state.copyWith(lastError: _authError(e));
+    }
+  }
+
+  Future<void> loginWithAuth0() async {
+    if (_isRedirecting) return;
+    _isRedirecting = true;
+
+    try {
+      final codeVerifier = _generateCodeVerifier();
+      final codeChallenge = _generateCodeChallenge(codeVerifier);
+      final stateValue = _generateState();
+
+      web.window.localStorage.setItem('pkce_code_verifier', codeVerifier);
+      web.window.localStorage.setItem('oauth_state', stateValue);
+      _saveIdpType(IdpType.auth0);
+
+      final authUrl = Uri.https(AuthConfig.auth0Domain, '/authorize', {
         'response_type': 'code',
-        'client_id': AuthConfig.clientId,
+        'client_id': AuthConfig.auth0ClientId,
         'redirect_uri': AuthConfig.redirectUri,
         'scope': 'openid profile email',
-        'audience': AuthConfig.audience,
-        'state': DateTime.now().millisecondsSinceEpoch.toString(),
+        'audience': AuthConfig.auth0Audience,
+        'state': stateValue,
         'code_challenge': codeChallenge,
         'code_challenge_method': 'S256',
       });
@@ -329,6 +437,15 @@ class AuthNotifier extends Notifier<AuthState> {
     } catch (e) {
       _isRedirecting = false;
       state = state.copyWith(lastError: _authError(e));
+    }
+  }
+
+  // Default login — prefers Entra if configured
+  Future<void> login() async {
+    if (AuthConfig.isEntraConfigured) {
+      await loginWithEntra();
+    } else if (AuthConfig.isAuth0Configured) {
+      await loginWithAuth0();
     }
   }
 
@@ -353,8 +470,12 @@ class AuthNotifier extends Notifier<AuthState> {
 
   Future<void> logout() async {
     try {
+      final idpType = _getSavedIdpType();
+
       web.window.localStorage.removeItem('auth_token');
       web.window.localStorage.removeItem('pkce_code_verifier');
+      web.window.localStorage.removeItem('oauth_state');
+      web.window.localStorage.removeItem('idp_type');
 
       await _session.clear();
 
@@ -362,21 +483,30 @@ class AuthNotifier extends Notifier<AuthState> {
 
       var returnUrl = AuthConfig.redirectUri.replaceAll(RegExp(r'/$'), '');
 
-      final logoutUrl = Uri.https(AuthConfig.domain, '/v2/logout', {
-        'client_id': AuthConfig.clientId,
-        'returnTo': returnUrl,
-      });
-
-      debugPrint('[AuthNotifier] Logging out, redirecting to: $logoutUrl');
+      String logoutUrl;
+      if (idpType == IdpType.entra) {
+        logoutUrl = Uri.parse(AuthConfig.entraLogoutUrl).replace(
+          queryParameters: {
+            'client_id': AuthConfig.entraClientId,
+            'post_logout_redirect_uri': returnUrl,
+          },
+        ).toString();
+      } else {
+        logoutUrl = Uri.https(AuthConfig.auth0Domain, '/v2/logout', {
+          'client_id': AuthConfig.auth0ClientId,
+          'returnTo': returnUrl,
+        }).toString();
+      }
 
       await Future.delayed(const Duration(milliseconds: 100));
-
-      web.window.location.assign(logoutUrl.toString());
+      web.window.location.assign(logoutUrl);
     } catch (e) {
       debugPrint('[AuthNotifier] Error during logout: $e');
       try {
         web.window.localStorage.removeItem('auth_token');
         web.window.localStorage.removeItem('pkce_code_verifier');
+        web.window.localStorage.removeItem('oauth_state');
+        web.window.localStorage.removeItem('idp_type');
         await _session.clear();
       } catch (_) {}
       state = AuthState.initial();


### PR DESCRIPTION
## Summary
- Add multi-IdP authentication: Entra ID for internal `@asdmr.org.hn` users, Auth0 for external users
- Backend: introduce `IdpRegistry` for dynamic issuer resolution in `JwtStrategy`, replacing single-issuer approach. Per-IdP JWKS, audience, and tenant validation. Auto-link by verified email for seamless provisioning
- Frontend: dual PKCE+S256 login flows with CSRF state validation, IdP-aware token exchange, session refresh, and logout
- Fix Riverpod uninitialized provider crash on bootstrap (deferred state write)

## Test plan
- [ ] Login via Entra ID with `@asdmr.org.hn` M365 account
- [ ] Login via Auth0 with external account
- [ ] Verify auto-link creates `idp_identity` record for new IdP on existing user (matching email)
- [ ] Verify logout redirects to correct IdP logout endpoint
- [ ] Verify session refresh works for both IdP types
- [ ] Run `npm test` — new test covers Entra auto-link scenario