### PR TITLE
refactor(infra): standardize resource naming and add identity module

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,6 @@ jobs:
       - name: Deploy to Container Apps
         uses: azure/container-apps-deploy-action@v2
         with:
-          resourceGroup: secretary-prod-rg
-          containerAppName: secretary-prod-api
+          resourceGroup: rg-logger-prod
+          containerAppName: ca-logger-prod-api
           imageToDeploy: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.build-and-push.outputs.version }}

--- a/infra/modules/container_apps/main.tf
+++ b/infra/modules/container_apps/main.tf
@@ -1,18 +1,26 @@
 resource "azurerm_container_app_environment" "main" {
-  name                       = "${var.project_name}-${var.env}-cae"
+  name                       = var.environment_name
   location                   = var.location
   resource_group_name        = var.rg_name
   log_analytics_workspace_id = var.log_analytics_workspace_id
   infrastructure_subnet_id   = var.container_apps_subnet_id
   tags                       = var.tags
+
+  lifecycle {
+    ignore_changes = [infrastructure_resource_group_name]
+  }
 }
 
 resource "azurerm_container_app" "api" {
-  name                         = "${var.project_name}-${var.env}-api"
+  name                         = var.app_name
   container_app_environment_id = azurerm_container_app_environment.main.id
   resource_group_name          = var.rg_name
   revision_mode                = "Single"
   tags                         = var.tags
+
+  lifecycle {
+    ignore_changes = [secret, template[0].container[0].image]
+  }
 
   registry {
     server               = "ghcr.io"
@@ -90,6 +98,14 @@ resource "azurerm_container_app" "api" {
       env {
         name  = "AUTH0_ISSUER"
         value = var.auth0_issuer
+      }
+      env {
+        name  = "ENTRA_TENANT_ID"
+        value = var.entra_tenant_id
+      }
+      env {
+        name  = "ENTRA_CLIENT_ID"
+        value = var.entra_client_id
       }
       env {
         name  = "CORS_ORIGINS"

--- a/infra/modules/container_apps/variables.tf
+++ b/infra/modules/container_apps/variables.tf
@@ -1,9 +1,11 @@
-variable "project_name" {
-  type = string
+variable "environment_name" {
+  type        = string
+  description = "Name for the Container App Environment."
 }
 
-variable "env" {
-  type = string
+variable "app_name" {
+  type        = string
+  description = "Name for the Container App."
 }
 
 variable "location" {
@@ -62,6 +64,16 @@ variable "auth0_audience" {
 
 variable "auth0_issuer" {
   type = string
+}
+
+variable "entra_tenant_id" {
+  type        = string
+  description = "Entra ID tenant ID."
+}
+
+variable "entra_client_id" {
+  type        = string
+  description = "Entra ID App Registration client ID."
 }
 
 variable "cors_origins" {

--- a/infra/modules/identity/main.tf
+++ b/infra/modules/identity/main.tf
@@ -1,0 +1,73 @@
+data "azuread_client_config" "current" {}
+
+resource "azuread_application" "logger" {
+  display_name     = "${var.project_name}-${var.env}"
+  sign_in_audience = "AzureADMyOrg"
+
+  api {
+    requested_access_token_version = 2
+
+    oauth2_permission_scope {
+      admin_consent_description  = "Allow the application to access the Logger API on behalf of the signed-in user."
+      admin_consent_display_name = "Access Logger API"
+      enabled                    = true
+      id                         = "00000000-0000-0000-0000-000000000001"
+      type                       = "User"
+      user_consent_description   = "Allow the application to access the Logger API on your behalf."
+      user_consent_display_name  = "Access Logger API"
+      value                      = "access_as_user"
+    }
+  }
+
+  single_page_application {
+    redirect_uris = var.redirect_uris
+  }
+
+  optional_claims {
+    id_token {
+      name = "email"
+    }
+    id_token {
+      name = "preferred_username"
+    }
+    access_token {
+      name = "email"
+    }
+  }
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # User.Read
+      type = "Scope"
+    }
+    resource_access {
+      id   = "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0" # email
+      type = "Scope"
+    }
+    resource_access {
+      id   = "14dad69e-099b-42c9-810b-d002981feec1" # profile
+      type = "Scope"
+    }
+    resource_access {
+      id   = "37f7f235-527c-4136-accd-4a02d197296e" # openid
+      type = "Scope"
+    }
+  }
+}
+
+resource "azuread_application_identifier_uri" "logger_api" {
+  application_id = azuread_application.logger.id
+  identifier_uri = "api://${azuread_application.logger.client_id}"
+}
+
+resource "azuread_service_principal" "logger" {
+  client_id = azuread_application.logger.client_id
+}
+
+resource "azuread_application_pre_authorized" "logger_spa" {
+  application_id       = azuread_application.logger.id
+  authorized_client_id = azuread_application.logger.client_id
+  permission_ids       = ["00000000-0000-0000-0000-000000000001"]
+}

--- a/infra/modules/identity/outputs.tf
+++ b/infra/modules/identity/outputs.tf
@@ -1,0 +1,14 @@
+output "client_id" {
+  value       = azuread_application.logger.client_id
+  description = "App Registration client ID."
+}
+
+output "tenant_id" {
+  value       = data.azuread_client_config.current.tenant_id
+  description = "Azure AD tenant ID."
+}
+
+output "api_scope" {
+  value       = "api://${azuread_application.logger.client_id}/access_as_user"
+  description = "Full custom API scope URI for frontend to request."
+}

--- a/infra/modules/identity/variables.tf
+++ b/infra/modules/identity/variables.tf
@@ -1,0 +1,14 @@
+variable "project_name" {
+  type        = string
+  description = "Project name for resource naming."
+}
+
+variable "env" {
+  type        = string
+  description = "Environment name (e.g., prod, dev)."
+}
+
+variable "redirect_uris" {
+  type        = list(string)
+  description = "SPA redirect URIs for the App Registration."
+}

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_log_analytics_workspace" "main" {
-  name                = "${var.project_name}-${var.env}-law"
+  name                = var.name
   location            = var.location
   resource_group_name = var.rg_name
   sku                 = "PerGB2018"

--- a/infra/modules/monitoring/variables.tf
+++ b/infra/modules/monitoring/variables.tf
@@ -1,9 +1,6 @@
-variable "project_name" {
-  type = string
-}
-
-variable "env" {
-  type = string
+variable "name" {
+  type        = string
+  description = "Name for the Log Analytics workspace."
 }
 
 variable "location" {

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_network" "main" {
-  name                = "${var.project_name}-${var.env}-vnet"
+  name                = var.vnet_name
   address_space       = [var.vnet_cidr]
   location            = var.location
   resource_group_name = var.rg_name
@@ -43,7 +43,7 @@ resource "azurerm_private_dns_zone" "postgres" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "postgres" {
-  name                  = "${var.project_name}-${var.env}-pg-dns-link"
+  name                  = "link-${var.vnet_name}-pg"
   resource_group_name   = var.rg_name
   private_dns_zone_name = azurerm_private_dns_zone.postgres.name
   virtual_network_id    = azurerm_virtual_network.main.id

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -1,9 +1,6 @@
-variable "project_name" {
-  type = string
-}
-
-variable "env" {
-  type = string
+variable "vnet_name" {
+  type        = string
+  description = "Name for the virtual network."
 }
 
 variable "location" {

--- a/infra/modules/postgres/main.tf
+++ b/infra/modules/postgres/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_postgresql_flexible_server" "main" {
-  name                          = "${var.project_name}-${var.env}-pg"
+  name                          = var.name
   resource_group_name           = var.rg_name
   location                      = var.location
   version                       = var.postgres_version
@@ -17,6 +17,12 @@ resource "azurerm_postgresql_flexible_server" "main" {
   lifecycle {
     ignore_changes = [zone]
   }
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "uuid-ossp,citext,pg_trgm"
 }
 
 resource "azurerm_postgresql_flexible_server_database" "main" {

--- a/infra/modules/postgres/variables.tf
+++ b/infra/modules/postgres/variables.tf
@@ -1,9 +1,6 @@
-variable "project_name" {
-  type = string
-}
-
-variable "env" {
-  type = string
+variable "name" {
+  type        = string
+  description = "Name for the PostgreSQL Flexible Server."
 }
 
 variable "location" {

--- a/infra/root/README.md
+++ b/infra/root/README.md
@@ -1,146 +1,112 @@
-# Secretary Infrastructure -- Operations Guide
+# Logger Infrastructure — Operations Guide
 
-Infrastructure for the Secretary backend API on Azure Container Apps.
+Infrastructure for the Logger backend API on Azure Container Apps.
 
-For architecture decisions and rationale, see
-[`docs/plans/2026-02-18-azure-container-apps-infrastructure-design.md`](../../docs/plans/2026-02-18-azure-container-apps-infrastructure-design.md).
+## Architecture
 
-## Architecture (brief)
+| Layer | Resource | Name |
+|-------|----------|------|
+| Compute | Container Apps (Consumption) | `cae-logger-prod` / `ca-logger-prod-api` |
+| Database | PostgreSQL Flexible Server (B1ms) | `psql-logger-prod` |
+| Networking | VNet + private DNS | `vnet-logger-prod` |
+| Monitoring | Log Analytics | `law-logger-prod` |
+| State | Shared storage account | `sharedtfstate01` in `rg-shared` |
+| Registry | GHCR | `ghcr.io/goargus/logger` |
 
-- **Compute**: Azure Container Apps (Consumption plan) running NestJS API
-- **Database**: PostgreSQL Flexible Server (Burstable B1ms) with private endpoint via VNet
-- **Networking**: VNet with separate subnets for Container Apps and data
-- **Monitoring**: Log Analytics workspace
-- **Frontend**: GitHub Pages (deployed separately, not managed here)
-- **Registry**: GHCR (GitHub Container Registry)
+All application resources live in `rg-logger-prod`. State storage lives in the
+shared resource group `rg-shared` (org-wide, not per-project).
+
+**Naming convention:** Azure CAF — `{type}-{workload}-{env}` (e.g. `rg-logger-prod`).
 
 ## Prerequisites
 
-- Azure CLI authenticated: `az login`
+- Azure CLI authenticated (`az login`)
 - Terraform >= 1.6.0
-- Docker (for local image builds)
 - GitHub PAT with `read:packages` scope (for GHCR pull)
 
-## State Backend Setup (one-time)
+## Bootstrap State Backend (one-time)
 
-Create the remote state storage before first `terraform init`:
+Run the bootstrap script to create the shared remote state storage:
 
 ```bash
-az group create --name secretary-tfstate-rg --location eastus2
-az storage account create --name secretarytfstate --resource-group secretary-tfstate-rg --sku Standard_LRS
-az storage container create --name tfstate --account-name secretarytfstate
+bash infra/scripts/bootstrap-state.sh
 ```
 
-Then update `backend.tf` with the real values:
-
-```hcl
-terraform {
-  backend "azurerm" {
-    resource_group_name  = "secretary-tfstate-rg"
-    storage_account_name = "secretarytfstate"
-    container_name       = "tfstate"
-    key                  = "secretary.prod.tfstate"
-  }
-}
-```
+This creates `rg-shared` with a `CanNotDelete` lock, storage account `sharedtfstate01`
+(blob versioning + 7-day soft delete), and a `tfstate` container.
 
 ## Variables
 
-Create `terraform.tfvars` in this directory. **Never commit this file.**
+Production values live in `prod.tfvars`. Pass sensitive values at the command line:
 
-```hcl
-postgres_admin_username = "pgadmin"
-postgres_admin_password = ""
-container_image         = "ghcr.io/goargus/logger:latest"
-ghcr_token              = ""
-auth0_domain            = "dev-ohuspam6fnmh4tgt.us.auth0.com"
-auth0_audience          = "logger"
-auth0_issuer            = "https://dev-ohuspam6fnmh4tgt.us.auth0.com/"
-admin_email             = ""
-admin_username          = ""
-admin_idp_issuer        = ""
-admin_idp_subject       = ""
+```bash
+terraform plan -var-file=prod.tfvars -var "ghcr_token=$(gh auth token)"
 ```
-
-All sensitive values (`postgres_admin_password`, `ghcr_token`) are marked sensitive in Terraform and will not appear in plan output.
 
 ## First Deploy
 
-1. Create the state backend (see above)
-2. Update `backend.tf` with real storage account values
-3. Push the first container image to GHCR:
+1. Bootstrap the state backend (see above)
+2. Initialize Terraform:
    ```bash
-   docker build -t ghcr.io/goargus/logger:latest ./backend
-   docker push ghcr.io/goargus/logger:latest
-   ```
-4. Fill in `terraform.tfvars`
-5. Deploy:
-   ```bash
+   cd infra/root
    terraform init
-   terraform plan
-   terraform apply
    ```
-6. Note the `api_url` output -- update Auth0 allowed callback/logout URLs to include it
-7. Update the frontend's `API_BASE_URL` to match the `api_url` output
-8. Verify the API is reachable: `curl https://<api_fqdn>/health`
+3. Plan and apply:
+   ```bash
+   terraform plan -var-file=prod.tfvars -var "ghcr_token=$(gh auth token)"
+   terraform apply -var-file=prod.tfvars -var "ghcr_token=$(gh auth token)"
+   ```
+4. Note the `api_url` output — update Auth0 allowed callback/logout URLs
+5. Verify: `curl https://<api_fqdn>/health`
 
 ## Deploying Updates
 
-**Automated (preferred):** Merging to `main` triggers GitHub Actions, which builds the image, pushes to GHCR, and deploys to Container Apps.
+**Automated (preferred):** Creating a GitHub release with a semver tag triggers the
+deploy workflow, which builds the image, pushes to GHCR, and deploys.
 
 **Manual:**
 
 ```bash
 az containerapp update \
-  --name secretary-prod-api \
-  --resource-group secretary-prod-rg \
-  --image ghcr.io/goargus/logger:<sha>
+  --name ca-logger-prod-api \
+  --resource-group rg-logger-prod \
+  --image ghcr.io/goargus/logger:<tag>
 ```
 
 ## Monitoring
 
-Stream live logs:
-
 ```bash
 az containerapp logs show \
-  --name secretary-prod-api \
-  --resource-group secretary-prod-rg \
+  --name ca-logger-prod-api \
+  --resource-group rg-logger-prod \
   --follow
 ```
 
-For historical queries, use **Azure Portal > Log Analytics workspace** linked to the Container Apps environment. Example KQL:
+Log Analytics KQL:
 
 ```kql
 ContainerAppConsoleLogs_CL
-| where ContainerAppName_s == "secretary-prod-api"
+| where ContainerAppName_s == "ca-logger-prod-api"
 | order by TimeGenerated desc
 | take 100
 ```
 
-## Cost Overview
+## Cost Estimate (~$17-22/month)
 
-Estimated ~$28/month at minimal usage:
-
-| Resource | Estimated Cost |
-|----------|---------------|
-| PostgreSQL Flexible Server (B1ms) | ~$13/mo |
-| Container Apps (Consumption) | ~$5/mo |
-| VNet + Private DNS | ~$4/mo |
-| Log Analytics | ~$4/mo |
-| Storage (tfstate) | < $1/mo |
-
-**Biggest levers:** PostgreSQL SKU (B1ms vs higher) and Container App scaling (min/max replicas).
+| Resource | SKU | Cost |
+|----------|-----|------|
+| PostgreSQL Flexible Server | B1ms (1 vCore, 2 GiB) | ~$12.41 |
+| PostgreSQL Storage | 32 GiB | ~$3.68 |
+| Container Apps | Consumption (free grant) | ~$0-5 |
+| Log Analytics | First 5 GB free | ~$0 |
+| VNet | Free | $0 |
+| Private DNS Zone | | ~$0.50 |
+| State Storage (rg-shared) | Standard_LRS | ~$0.10 |
 
 ## Destroy
 
-Tear down all managed resources:
-
 ```bash
-terraform destroy
+terraform destroy -var-file=prod.tfvars -var "ghcr_token=$(gh auth token)"
 ```
 
-This does **not** remove the tfstate storage account (managed separately). Delete it manually if no longer needed:
-
-```bash
-az group delete --name secretary-tfstate-rg --yes
-```
+This does **not** remove `rg-shared` (managed separately, protected by delete lock).

--- a/infra/root/backend.tf
+++ b/infra/root/backend.tf
@@ -1,9 +1,8 @@
-# Remote backend — will configure after initial deployment
-# terraform {
-#   backend "azurerm" {
-#     resource_group_name  = "REPLACE_ME_TFSTATE_RG"
-#     storage_account_name = "REPLACE_ME_TFSTATE_STORAGE"
-#     container_name       = "REPLACE_ME_TFSTATE_CONTAINER"
-#     key                  = "secretary.prod.tfstate"
-#   }
-# }
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "rg-shared"
+    storage_account_name = "sharedtfstate01"
+    container_name       = "tfstate"
+    key                  = "logger.prod.tfstate"
+  }
+}

--- a/infra/root/locals.tf
+++ b/infra/root/locals.tf
@@ -1,11 +1,20 @@
 locals {
-  env         = "prod"
-  name_prefix = "${var.project_name}-${local.env}"
+  env = "prod"
+
+  caf = {
+    rg   = "rg-${var.project_name}-${local.env}"
+    vnet = "vnet-${var.project_name}-${local.env}"
+    cae  = "cae-${var.project_name}-${local.env}"
+    ca   = "ca-${var.project_name}-${local.env}-api"
+    law  = "law-${var.project_name}-${local.env}"
+    psql = "psql-${var.project_name}-${local.env}"
+  }
 
   tags = merge(
     {
       environment = local.env
       project     = var.project_name
+      managed-by  = "terraform"
     },
     var.tags
   )

--- a/infra/root/main.tf
+++ b/infra/root/main.tf
@@ -10,6 +10,14 @@ resource "azurerm_resource_group" "main" {
   tags     = local.tags
 }
 
+module "identity" {
+  source = "../modules/identity"
+
+  project_name  = var.project_name
+  env           = local.env
+  redirect_uris = var.entra_redirect_uris
+}
+
 module "network" {
   source = "../modules/network"
 
@@ -60,6 +68,8 @@ module "container_apps" {
   auth0_domain               = var.auth0_domain
   auth0_audience             = var.auth0_audience
   auth0_issuer               = var.auth0_issuer
+  entra_tenant_id            = module.identity.tenant_id
+  entra_client_id            = module.identity.client_id
   cors_origins               = var.cors_origins
   admin_email                = var.admin_email
   admin_username             = var.admin_username

--- a/infra/root/outputs.tf
+++ b/infra/root/outputs.tf
@@ -26,3 +26,15 @@ output "api_custom_url" {
 output "frontend_custom_url" {
   value = "https://${module.cloudflare.frontend_fqdn}"
 }
+
+output "entra_client_id" {
+  value = module.identity.client_id
+}
+
+output "entra_tenant_id" {
+  value = module.identity.tenant_id
+}
+
+output "entra_api_scope" {
+  value = module.identity.api_scope
+}

--- a/infra/root/providers.tf
+++ b/infra/root/providers.tf
@@ -6,3 +6,5 @@ provider "cloudflare" {
   api_key = var.cloudflare_api_key
   email   = var.cloudflare_email
 }
+
+provider "azuread" {}

--- a/infra/root/variables.tf
+++ b/infra/root/variables.tf
@@ -73,6 +73,12 @@ variable "admin_idp_subject" {
   description = "Admin IDP subject identifier."
 }
 
+variable "entra_redirect_uris" {
+  type        = list(string)
+  description = "SPA redirect URIs for the Entra ID App Registration."
+  default     = ["https://logger.asdmr.org.hn/", "https://secretary-frontend.pages.dev/"]
+}
+
 variable "tags" {
   type        = map(string)
   description = "Tags to apply to all resources."

--- a/infra/root/versions.tf
+++ b/infra/root/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">= 3.90.0"
     }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 3.7.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = ">= 3.6.0"

--- a/infra/scripts/bootstrap-state.sh
+++ b/infra/scripts/bootstrap-state.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Bootstrap shared Terraform state backend in Azure.
+#
+# Creates:
+#   - Resource group:    rg-shared
+#   - Storage account:   sharedtfstate01  (versioning + 7-day soft delete)
+#   - Blob container:    tfstate
+#   - CanNotDelete lock on the resource group
+#
+# Safe to re-run — all commands use --only-show-errors and are idempotent.
+
+set -euo pipefail
+
+RG="rg-shared"
+LOCATION="southcentralus"
+SA="sharedtfstate01"
+CONTAINER="tfstate"
+
+echo "==> Creating resource group: ${RG}"
+az group create \
+  --name "$RG" \
+  --location "$LOCATION" \
+  --only-show-errors
+
+echo "==> Creating storage account: ${SA}"
+az storage account create \
+  --name "$SA" \
+  --resource-group "$RG" \
+  --location "$LOCATION" \
+  --sku Standard_LRS \
+  --min-tls-version TLS1_2 \
+  --allow-blob-public-access false \
+  --only-show-errors
+
+echo "==> Enabling blob versioning and 7-day soft delete"
+az storage account blob-service-properties update \
+  --account-name "$SA" \
+  --resource-group "$RG" \
+  --enable-versioning true \
+  --delete-retention-days 7 \
+  --enable-delete-retention true \
+  --only-show-errors
+
+echo "==> Creating blob container: ${CONTAINER}"
+az storage container create \
+  --name "$CONTAINER" \
+  --account-name "$SA" \
+  --auth-mode login \
+  --only-show-errors
+
+echo "==> Adding CanNotDelete lock on ${RG} (requires Owner/UAA role)"
+if az lock create \
+  --name "protect-shared-state" \
+  --resource-group "$RG" \
+  --lock-type CanNotDelete \
+  --notes "Protects Terraform remote state storage" \
+  --only-show-errors 2>/dev/null; then
+  echo "    Lock created."
+else
+  echo "    WARN: Could not create lock (missing Microsoft.Authorization/locks/write)."
+  echo "    Add it manually via the Azure portal with an Owner account."
+fi
+
+echo "==> Done. State backend ready at:"
+echo "    resource_group_name  = \"${RG}\""
+echo "    storage_account_name = \"${SA}\""
+echo "    container_name       = \"${CONTAINER}\""


### PR DESCRIPTION
## Summary
- Refactor Terraform modules to accept explicit resource names instead of composing them internally from `project_name`+`env`, giving the root module full naming control
- Add `identity` module for Entra ID App Registration (azuread provider): API permission scopes, SPA redirect URIs, service principal, pre-authorization
- Add `ENTRA_TENANT_ID` and `ENTRA_CLIENT_ID` env vars to container app module
- Add `bootstrap-state.sh` script for importing CLI-created Azure AD resources into Terraform state
- Update CI deploy action to reference new resource group and container app names
- Add PostgreSQL extensions configuration (`uuid-ossp`, `citext`, `pg_trgm`)

## Test plan
- [ ] `terraform plan` shows no unexpected changes against deployed state
- [ ] Verify identity module outputs correct `client_id`, `tenant_id`, and `api_scope`
- [ ] Verify container app receives Entra env vars