### PR TITLE
feat(admin): allow admins to create activities for users

### DIFF
--- a/backend/src/activity/activities.service.spec.ts
+++ b/backend/src/activity/activities.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { In } from 'typeorm';
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 
 import { ActivitiesService } from './activities.service';
 import { Activity } from './activity.entity';
@@ -286,6 +286,138 @@ describe('ActivitiesService', () => {
       const result = await service.create(createActivityDto, userId);
 
       expect(result).toEqual(mockCreatedActivity);
+    });
+  });
+
+  describe('createForUserByAdmin', () => {
+    const dto = {
+      targetUserId: 'user-456',
+      activityTypeId: 'activity-type-456',
+      activityDate: '2027-01-15',
+      description: 'Admin created activity',
+      hasExpense: false,
+    };
+
+    beforeEach(() => {
+      mockUserRepo.findOne.mockImplementation(({ where }: any) => {
+        if (where?.id === 'user-456') {
+          return Promise.resolve({ id: 'user-456', entity_id: 'entity-2' });
+        }
+        return Promise.resolve({ id: 'user-123', entity_id: 'entity-1' });
+      });
+    });
+
+    it('creates an activity for the target user and records admin audit fields', async () => {
+      const mockActivityType = {
+        id: dto.activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: [],
+      };
+      const mockCreatedActivity = {
+        id: 'activity-admin-1',
+        ...dto,
+        userId: dto.targetUserId,
+        createdBy: 'admin-1',
+        updatedBy: 'admin-1',
+      };
+
+      mockActivityTypeRepo.findOne
+        .mockResolvedValueOnce(mockActivityType)
+        .mockResolvedValueOnce(mockActivityType);
+      mockActivityRepo.create.mockReturnValue(mockCreatedActivity);
+      mockActivityRepo.save.mockResolvedValue(mockCreatedActivity);
+
+      const result = await service.createForUserByAdmin(dto, 'admin-1');
+
+      expect(result).toEqual(mockCreatedActivity);
+      expect(mockActivityRepo.create).toHaveBeenCalledWith({
+        activityTypeId: dto.activityTypeId,
+        activityDate: dto.activityDate,
+        description: dto.description,
+        hasExpense: false,
+        expenseAmount: null,
+        userId: dto.targetUserId,
+        createdBy: 'admin-1',
+        updatedBy: 'admin-1',
+        status: 'active',
+      });
+      expect(mockLockService.isDateAvailableForUser).not.toHaveBeenCalled();
+    });
+
+    it('accepts future dates without running the user lock check', async () => {
+      const futureDto = { ...dto, activityDate: '2030-05-20' };
+      const mockActivityType = {
+        id: dto.activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: [],
+      };
+
+      mockActivityTypeRepo.findOne
+        .mockResolvedValueOnce(mockActivityType)
+        .mockResolvedValueOnce(mockActivityType);
+      mockActivityRepo.create.mockReturnValue({
+        id: 'activity-admin-2',
+        ...futureDto,
+        userId: dto.targetUserId,
+      });
+      mockActivityRepo.save.mockResolvedValue({
+        id: 'activity-admin-2',
+        ...futureDto,
+        userId: dto.targetUserId,
+      });
+
+      await expect(service.createForUserByAdmin(futureDto, 'admin-1')).resolves.toMatchObject({
+        activityDate: '2030-05-20',
+        userId: dto.targetUserId,
+      });
+      expect(mockLockService.isDateAvailableForUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the target user is not authorized for the activity type', async () => {
+      const mockActivityType = {
+        id: dto.activityTypeId,
+        name: 'Restricted Activity',
+        allowed_roles: [{ id: 'role-789', name: 'Pastor' }],
+      };
+
+      mockActivityTypeRepo.findOne
+        .mockResolvedValueOnce(mockActivityType)
+        .mockResolvedValueOnce(mockActivityType);
+      mockUserRoleAssignmentRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.createForUserByAdmin(dto, 'admin-1')).rejects.toThrow(
+        new ForbiddenException('Target user is not authorized to submit this activity type'),
+      );
+    });
+
+    it('requires expenseAmount when hasExpense is true', async () => {
+      const expenseDto = {
+        ...dto,
+        hasExpense: true,
+        expenseAmount: '',
+      };
+      const mockActivityType = {
+        id: dto.activityTypeId,
+        name: 'Test Activity',
+        allowed_roles: [],
+      };
+
+      mockActivityTypeRepo.findOne
+        .mockResolvedValueOnce(mockActivityType)
+        .mockResolvedValueOnce(mockActivityType);
+
+      await expect(service.createForUserByAdmin(expenseDto, 'admin-1')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects when target user does not exist', async () => {
+      mockActivityTypeRepo.findOne.mockResolvedValue({ id: dto.activityTypeId, allowed_roles: [] });
+      mockUserRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.createForUserByAdmin(dto, 'admin-1')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/backend/src/activity/activities.service.ts
+++ b/backend/src/activity/activities.service.ts
@@ -124,6 +124,44 @@ export class ActivitiesService {
     return this.repo.save(entity);
   }
 
+  async createForUserByAdmin(
+    dto: CreateActivityDto & { targetUserId: string },
+    adminUserId: string,
+  ): Promise<Activity> {
+    await this.ensureTypeOrThrow(dto.activityTypeId);
+
+    await this.getUserEntityId(dto.targetUserId);
+    const isAuthorizedForTarget = await this.canUserSubmitActivityType(
+      dto.targetUserId,
+      dto.activityTypeId,
+    );
+    if (!isAuthorizedForTarget) {
+      throw new ForbiddenException(
+        'Target user is not authorized to submit this activity type',
+      );
+    }
+
+    if (dto.hasExpense && (dto.expenseAmount == null || dto.expenseAmount === '')) {
+      throw new BadRequestException('expenseAmount is required when hasExpense is true.');
+    }
+
+    const activityDate = this.normalizeDateString(dto.activityDate);
+
+    const entity = this.repo.create({
+      activityTypeId: dto.activityTypeId,
+      activityDate,
+      description: dto.description ?? null,
+      hasExpense: dto.hasExpense,
+      expenseAmount: dto.hasExpense ? dto.expenseAmount : null,
+      userId: dto.targetUserId,
+      createdBy: adminUserId,
+      updatedBy: adminUserId,
+      status: ActivityStatus.ACTIVE,
+    });
+
+    return this.repo.save(entity);
+  }
+
   async findMine(
     userId: string,
     page = 1,

--- a/backend/src/admin/admin.controller.spec.ts
+++ b/backend/src/admin/admin.controller.spec.ts
@@ -1,0 +1,132 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AdminController } from './admin.controller';
+import { ActivitiesService } from '../activity/activities.service';
+import { User } from '../users/user.entity';
+import { ActivityType } from '../activities-type/activity-type.entity';
+import { LockService } from '../periods/lock.service';
+import { PermissionsService } from '../auth/permissions/permissions.service';
+import { RolesGuard } from '../auth/roles.guard';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  let activitiesService: jest.Mocked<ActivitiesService>;
+  let usersRepo: { findOneByOrFail: jest.Mock };
+  let typesRepo: { findOneByOrFail: jest.Mock };
+  let lockService: { getAdminLock: jest.Mock; isDateLockedSync: jest.Mock };
+
+  beforeEach(async () => {
+    usersRepo = {
+      findOneByOrFail: jest.fn(),
+    };
+    typesRepo = {
+      findOneByOrFail: jest.fn(),
+    };
+    lockService = {
+      getAdminLock: jest.fn(),
+      isDateLockedSync: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [
+        {
+          provide: ActivitiesService,
+          useValue: {
+            createForUserByAdmin: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: usersRepo,
+        },
+        {
+          provide: getRepositoryToken(ActivityType),
+          useValue: typesRepo,
+        },
+        {
+          provide: LockService,
+          useValue: lockService,
+        },
+        {
+          provide: PermissionsService,
+          useValue: {
+            userHasPermission: jest.fn().mockResolvedValue(true),
+          },
+        },
+        RolesGuard,
+      ],
+    }).compile();
+
+    controller = module.get<AdminController>(AdminController);
+    activitiesService = module.get(ActivitiesService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createActivityForUser', () => {
+    it('creates an activity for the target user and returns ActivityResponseDto shape', async () => {
+      const dto = {
+        targetUserId: 'user-2',
+        activityTypeId: 'type-1',
+        activityDate: '2027-01-15',
+        description: 'Admin scheduled activity',
+        hasExpense: false,
+      };
+      const createdAt = new Date('2026-05-07T10:00:00.000Z');
+      const updatedAt = new Date('2026-05-07T10:00:00.000Z');
+      const created = {
+        id: 'activity-1',
+        activityTypeId: dto.activityTypeId,
+        activityDate: dto.activityDate,
+        description: dto.description,
+        hasExpense: false,
+        expenseAmount: null,
+        status: 'active',
+        createdAt,
+        updatedAt,
+        userId: dto.targetUserId,
+      };
+
+      activitiesService.createForUserByAdmin.mockResolvedValue(created as any);
+      usersRepo.findOneByOrFail.mockResolvedValue({
+        id: dto.targetUserId,
+        username: 'target-user',
+        entity_id: 'entity-1',
+      });
+      typesRepo.findOneByOrFail.mockResolvedValue({
+        id: dto.activityTypeId,
+        name: 'Visita',
+      });
+      lockService.getAdminLock.mockResolvedValue({ lockDate: '2027-01-01' });
+      lockService.isDateLockedSync.mockReturnValue(false);
+
+      const result = await controller.createActivityForUser(
+        { user: { id: 'admin-1' } } as any,
+        dto as any,
+      );
+
+      expect(activitiesService.createForUserByAdmin).toHaveBeenCalledWith(dto, 'admin-1');
+      expect(usersRepo.findOneByOrFail).toHaveBeenCalledWith({ id: dto.targetUserId });
+      expect(typesRepo.findOneByOrFail).toHaveBeenCalledWith({ id: dto.activityTypeId });
+      expect(lockService.getAdminLock).toHaveBeenCalledWith('entity-1');
+      expect(result).toEqual({
+        id: 'activity-1',
+        activityTypeId: 'type-1',
+        activityTypeName: 'Visita',
+        activityDate: '2027-01-15',
+        description: 'Admin scheduled activity',
+        hasExpense: false,
+        expenseAmount: null,
+        status: 'active',
+        isLocked: false,
+        createdAt,
+        updatedAt,
+        ownerUserId: 'user-2',
+        ownerUsername: 'target-user',
+      });
+    });
+  });
+});

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,14 +1,30 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ActivitiesService } from '../activity/activities.service';
+import { CreateAdminActivityDto } from './dto/create-admin-activity.dto';
+import { ActivityResponseDto } from '../activity/dto/activity-response.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from '../users/user.entity';
+import { ActivityType } from '../activities-type/activity-type.entity';
+import { Repository } from 'typeorm';
+import { LockService } from '../periods/lock.service';
+import { Request } from 'express';
 
 @ApiTags('Admin')
 @ApiBearerAuth('JWT-auth')
 @Controller('admin')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class AdminController {
+  constructor(
+    private readonly activitiesService: ActivitiesService,
+    private readonly lockService: LockService,
+    @InjectRepository(User) private readonly usersRepo: Repository<User>,
+    @InjectRepository(ActivityType) private readonly typesRepo: Repository<ActivityType>,
+  ) {}
+
   @Get('dashboard')
   @Roles('read:admin_dashboard')
   @ApiOperation({ summary: 'Get admin dashboard' })
@@ -17,5 +33,34 @@ export class AdminController {
   @ApiResponse({ status: 403, description: 'Forbidden - requires admin permission' })
   getDashboard() {
     return { message: 'Welcome Admin' };
+  }
+
+  @Post('activities')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Create an activity for another user (Admin only)' })
+  @ApiResponse({
+    status: 201,
+    description: 'Activity created successfully for the target user',
+    type: ActivityResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin permission' })
+  async createActivityForUser(
+    @Req() req: Request,
+    @Body() dto: CreateAdminActivityDto,
+  ): Promise<ActivityResponseDto> {
+    const adminUserId = (req.user as any)?.id;
+    const created = await this.activitiesService.createForUserByAdmin(dto, adminUserId);
+
+    const [owner, type] = await Promise.all([
+      this.usersRepo.findOneByOrFail({ id: created.userId }),
+      this.typesRepo.findOneByOrFail({ id: created.activityTypeId }),
+    ]);
+
+    const adminLock = await this.lockService.getAdminLock(owner.entity_id);
+    const isLocked = this.lockService.isDateLockedSync(created.activityDate, adminLock);
+
+    return ActivityResponseDto.fromEntity(created, owner.username, (type as any).name, isLocked);
   }
 }

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,8 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AdminController } from './admin.controller';
 import { Reflector } from '@nestjs/core';
+import { ActivitiesModule } from '../activity/activities.module';
+import { PeriodsModule } from '../periods/periods.module';
+import { User } from '../users/user.entity';
+import { ActivityType } from '../activities-type/activity-type.entity';
 
 @Module({
+  imports: [ActivitiesModule, PeriodsModule, TypeOrmModule.forFeature([User, ActivityType])],
   controllers: [AdminController],
   providers: [Reflector],
 })

--- a/backend/src/admin/dto/create-admin-activity.dto.ts
+++ b/backend/src/admin/dto/create-admin-activity.dto.ts
@@ -1,0 +1,73 @@
+import {
+  IsBoolean,
+  IsDateString,
+  IsDefined,
+  IsNotEmpty,
+  IsNumberString,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
+import { Transform } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateAdminActivityDto {
+  @ApiProperty({
+    description: 'UUID of the target user who will own the activity',
+    example: '123e4567-e89b-12d3-a456-426614174001',
+  })
+  @Transform(({ obj }) => obj.targetUserId ?? obj.target_user_id)
+  @IsUUID()
+  @IsDefined()
+  targetUserId!: string;
+
+  @ApiProperty({
+    description: 'UUID of the activity type',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @Transform(({ obj }) => obj.activityTypeId ?? obj.activity_type_id)
+  @IsUUID()
+  @IsDefined()
+  activityTypeId!: string;
+
+  @ApiProperty({
+    description: 'Date of the activity in ISO 8601 format',
+    example: '2027-01-15',
+  })
+  @Transform(({ obj }) => obj.activityDate ?? obj.activity_date)
+  @IsDateString()
+  @IsDefined()
+  activityDate!: string;
+
+  @ApiPropertyOptional({
+    description: 'Optional description of the activity',
+    maxLength: 5000,
+    example: 'Scheduled visit on behalf of the regional office',
+  })
+  @Transform(({ obj }) => obj.description ?? null)
+  @IsOptional()
+  @IsString()
+  @MaxLength(5000)
+  description?: string | null;
+
+  @ApiProperty({
+    description: 'Whether the activity has an associated expense',
+    example: false,
+    default: false,
+  })
+  @Transform(({ obj }) => obj.hasExpense ?? obj.has_expense ?? false)
+  @IsBoolean()
+  hasExpense!: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Expense amount as a string (required when hasExpense is true)',
+    example: '150.00',
+  })
+  @Transform(({ obj }) => obj.expenseAmount ?? obj.expense_amount)
+  @ValidateIf((o) => o.hasExpense === true)
+  @IsNotEmpty()
+  @IsNumberString()
+  expenseAmount?: string;
+}


### PR DESCRIPTION
## Summary
- Add a dedicated POST /admin/activities endpoint for admins to create activities on behalf of other users
- Introduce an admin-specific activity creation DTO that accepts targetUserId and allows any activity date, including future or locked dates
- Add a dedicated service flow that creates the activity for the target user while preserving admin audit fields and leaving the standard user activity flow unchanged
- Wire the admin module to the activity service and add focused controller/service test coverage for the new admin flow

## Test plan
- [ ] npm test -- --runInBand src/activity/activities.service.spec.ts src/activity/dto/activity-date.validation.spec.ts src/admin/admin.controller.spec.ts
- [ ] npm run build
- [ ] Verify POST /activities still rejects future dates for regular users
- [ ] Verify POST /admin/activities allows admins to create activities for other users on future and locked dates
